### PR TITLE
[d3d9] Backport D3D9 software cursor support

### DIFF
--- a/src/d3d9/d3d9_cursor.cpp
+++ b/src/d3d9/d3d9_cursor.cpp
@@ -5,6 +5,32 @@
 
 namespace dxvk {
 
+  void D3D9Cursor::ResetCursor() {
+    ShowCursor(FALSE);
+
+    if (m_hCursor != nullptr) {
+      ResetHardwareCursor();
+    } else if (m_sCursor.Bitmap != nullptr) {
+      ResetSoftwareCursor();
+    }
+  }
+
+  
+  void D3D9Cursor::ResetHardwareCursor() {
+    ::DestroyCursor(m_hCursor);
+    m_hCursor = nullptr;
+  }
+
+
+  void D3D9Cursor::ResetSoftwareCursor() {
+      m_sCursor.Bitmap = nullptr;
+      m_sCursor.XHotSpot = 0;
+      m_sCursor.YHotSpot = 0;
+      m_sCursor.X = 0.0f;
+      m_sCursor.Y = 0.0f;
+  }
+
+
   void D3D9Cursor::UpdateCursor(int X, int Y) {
     POINT currentPos = { };
     if (::GetCursorPos(&currentPos) && currentPos == POINT{ X, Y })
@@ -14,21 +40,39 @@ namespace dxvk {
   }
 
 
+  void D3D9Cursor::RefreshSoftwareCursorPosition() {
+    POINT currentPos = { };
+    ::GetCursorPos(&currentPos);
+
+    m_sCursor.X = static_cast<float>(currentPos.x) - static_cast<float>(m_sCursor.XHotSpot);
+    m_sCursor.Y = static_cast<float>(currentPos.y) - static_cast<float>(m_sCursor.YHotSpot);
+  }
+
+
   BOOL D3D9Cursor::ShowCursor(BOOL bShow) {
-    ::SetCursor(bShow ? m_hCursor : nullptr);
+    // Cursor visibility remains unchanged (typically FALSE) if the cursor isn't set.
+    if (unlikely(m_hCursor == nullptr && m_sCursor.Bitmap == nullptr))
+      return m_visible;
+
+    if (m_hCursor != nullptr)
+      ::SetCursor(bShow ? m_hCursor : nullptr);
+
     return std::exchange(m_visible, bShow);
   }
 
 
   HRESULT D3D9Cursor::SetHardwareCursor(UINT XHotSpot, UINT YHotSpot, const CursorBitmap& bitmap) {
-    DWORD mask[32];
+    if (m_sCursor.Bitmap != nullptr)
+      ResetSoftwareCursor();
+
+    CursorMask mask;
     std::memset(mask, ~0, sizeof(mask));
 
     ICONINFO info;
     info.fIcon    = FALSE;
     info.xHotspot = XHotSpot;
     info.yHotspot = YHotSpot;
-    info.hbmMask  = ::CreateBitmap(HardwareCursorWidth, HardwareCursorHeight, 1, 1,  mask);
+    info.hbmMask  = ::CreateBitmap(HardwareCursorWidth, HardwareCursorHeight, 1, 1,  &mask[0]);
     info.hbmColor = ::CreateBitmap(HardwareCursorWidth, HardwareCursorHeight, 1, 32, &bitmap[0]);
 
     if (m_hCursor != nullptr)
@@ -38,6 +82,22 @@ namespace dxvk {
 
     ::DeleteObject(info.hbmMask);
     ::DeleteObject(info.hbmColor);
+
+    ShowCursor(m_visible);
+
+    return D3D_OK;
+  }
+
+  HRESULT D3D9Cursor::SetSoftwareCursor(UINT XHotSpot, UINT YHotSpot, Com<IDirect3DTexture9> pCursorBitmap) {
+    // Make sure to hide the win32 cursor
+    ::SetCursor(nullptr);
+
+    if (m_hCursor != nullptr)
+      ResetHardwareCursor();
+
+    m_sCursor.Bitmap    = pCursorBitmap;
+    m_sCursor.XHotSpot  = XHotSpot;
+    m_sCursor.YHotSpot  = YHotSpot;
 
     ShowCursor(m_visible);
 

--- a/src/d3d9/d3d9_cursor.h
+++ b/src/d3d9/d3d9_cursor.h
@@ -4,29 +4,62 @@
 
 namespace dxvk {
 
-  constexpr uint32_t HardwareCursorWidth     = 32u;
-  constexpr uint32_t HardwareCursorHeight    = 32u;
+  /**
+   * \brief D3D9 Software Cursor
+   */
+  struct D3D9_SOFTWARE_CURSOR {
+    Com<IDirect3DTexture9> Bitmap;
+    UINT XHotSpot = 0;
+    UINT YHotSpot = 0;
+    float X = 0.0f;
+    float Y = 0.0f;
+  };
+
+  constexpr uint32_t HardwareCursorWidth      = 32u;
+  constexpr uint32_t HardwareCursorHeight     = 32u;
   constexpr uint32_t HardwareCursorFormatSize = 4u;
   constexpr uint32_t HardwareCursorPitch      = HardwareCursorWidth * HardwareCursorFormatSize;
 
   // Format Size of 4 bytes (ARGB)
   using CursorBitmap = uint8_t[HardwareCursorHeight * HardwareCursorPitch];
+  // Monochrome mask (1 bit)
+  using CursorMask   = uint8_t[HardwareCursorHeight * HardwareCursorWidth / 8];
 
   class D3D9Cursor {
 
   public:
 
+    void ResetCursor();
+
+    void ResetHardwareCursor();
+
+    void ResetSoftwareCursor();
+
     void UpdateCursor(int X, int Y);
+
+    void RefreshSoftwareCursorPosition();
 
     BOOL ShowCursor(BOOL bShow);
 
     HRESULT SetHardwareCursor(UINT XHotSpot, UINT YHotSpot, const CursorBitmap& bitmap);
 
+    HRESULT SetSoftwareCursor(UINT XHotSpot, UINT YHotSpot, Com<IDirect3DTexture9> pCursorBitmap);
+
+    D3D9_SOFTWARE_CURSOR* GetSoftwareCursor() {
+      return &m_sCursor;
+    }
+
+    BOOL IsCursorVisible() const {
+      return m_visible;
+    }
+
   private:
 
-    BOOL    m_visible       = FALSE;
+    BOOL                  m_visible       = FALSE;
 
-    HCURSOR m_hCursor       = nullptr;
+    D3D9_SOFTWARE_CURSOR  m_sCursor;
+
+    HCURSOR               m_hCursor       = nullptr;
 
   };
 


### PR DESCRIPTION
A backport of my original D3D9 software cursor implementation, which used the D3D9 FVF pipeline to render a quad with a blended (cursor) texture. This is not what is currently in use in mainline dxvk, as we now rely on dxvk backend support for software cursor rendeding, but it should be good enough.

I still have to backport some fixes on top of it, so WIP, but it's also fully functional in its current state.

Affected d3d9 games are **Dungon Siege 2** and the **Act of War** series.