### PR TITLE
[d3d9] Update software cursor position using SetCursorPosition

### DIFF
--- a/src/d3d9/d3d9_cursor.cpp
+++ b/src/d3d9/d3d9_cursor.cpp
@@ -26,26 +26,24 @@ namespace dxvk {
       m_sCursor.Bitmap = nullptr;
       m_sCursor.XHotSpot = 0;
       m_sCursor.YHotSpot = 0;
-      m_sCursor.X = 0.0f;
-      m_sCursor.Y = 0.0f;
   }
 
 
   void D3D9Cursor::UpdateCursor(int X, int Y) {
+    // SetCursorPosition is used to directly update the position of software cursors,
+    // but keep track of the cursor position even when using hardware cursors, in order
+    // to ensure a smooth transition/overlap from one type to the other.
+    m_sCursor.X = static_cast<float>(X);
+    m_sCursor.Y = static_cast<float>(Y);
+
+    if (unlikely(m_sCursor.Bitmap != nullptr))
+      return;
+
     POINT currentPos = { };
     if (::GetCursorPos(&currentPos) && currentPos == POINT{ X, Y })
         return;
 
     ::SetCursorPos(X, Y);
-  }
-
-
-  void D3D9Cursor::RefreshSoftwareCursorPosition() {
-    POINT currentPos = { };
-    ::GetCursorPos(&currentPos);
-
-    m_sCursor.X = static_cast<float>(currentPos.x) - static_cast<float>(m_sCursor.XHotSpot);
-    m_sCursor.Y = static_cast<float>(currentPos.y) - static_cast<float>(m_sCursor.YHotSpot);
   }
 
 

--- a/src/d3d9/d3d9_cursor.h
+++ b/src/d3d9/d3d9_cursor.h
@@ -37,8 +37,6 @@ namespace dxvk {
 
     void UpdateCursor(int X, int Y);
 
-    void RefreshSoftwareCursorPosition();
-
     BOOL ShowCursor(BOOL bShow);
 
     HRESULT SetHardwareCursor(UINT XHotSpot, UINT YHotSpot, const CursorBitmap& bitmap);

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -90,6 +90,11 @@ namespace dxvk {
     void*           mapPtr = nullptr;
   };
 
+  struct SWCursorVertex {
+    float x, y, z, rhw;
+    float u, v;
+  };
+
   class D3D9DeviceEx final : public ComObjectClamp<IDirect3DDevice9Ex> {
     constexpr static uint32_t DefaultFrameLatency = 3;
     constexpr static uint32_t MaxFrameLatency     = 20;


### PR DESCRIPTION
Backport of https://github.com/doitsujin/dxvk/pull/4670, with some other small embellishments. It fixes software cursor behavior on Windows, where apparently things can get more wonky. This is particularly needed by Dungeon Siege 2 & addons.