### PR TITLE
[d3d8] Backport dref scaling and other minor fixes

### DIFF
--- a/src/d3d8/d3d8_batch.h
+++ b/src/d3d8/d3d8_batch.h
@@ -6,7 +6,6 @@
 
 #include <vector>
 #include <cstdint>
-#include <climits>
 
 namespace dxvk {
 
@@ -83,7 +82,7 @@ namespace dxvk {
       D3DPRIMITIVETYPE PrimitiveType = D3DPT_INVALID;
       std::vector<uint16_t> Indices;
       UINT Offset = 0;
-      UINT MinVertex = UINT_MAX;
+      UINT MinVertex = std::numeric_limits<uint32_t>::max();
       UINT MaxVertex = 0;
       UINT PrimitiveCount = 0;
       UINT DrawCallCount = 0;
@@ -126,7 +125,7 @@ namespace dxvk {
 
         draw.PrimitiveType = D3DPRIMITIVETYPE(0);
         draw.Offset = 0;
-        draw.MinVertex = UINT_MAX;
+        draw.MinVertex = std::numeric_limits<uint32_t>::max();
         draw.MaxVertex = 0;
         draw.PrimitiveCount = 0;
         draw.DrawCallCount = 0;

--- a/src/d3d8/d3d8_buffer.h
+++ b/src/d3d8/d3d8_buffer.h
@@ -16,8 +16,7 @@ namespace dxvk {
             Com<D3D9>&&     pBuffer,
             D3DPOOL         Pool,
             DWORD           Usage)
-      : D3D8Resource<D3D9, D3D8> (pDevice, std::move(pBuffer))
-      , m_pool                   (Pool)
+      : D3D8Resource<D3D9, D3D8> (pDevice, Pool, std::move(pBuffer))
       , m_usage                  (Usage) {
       m_options = this->GetParent()->GetOptions();
     }
@@ -52,7 +51,6 @@ namespace dxvk {
   protected:
 
     const D3D8Options* m_options;
-    const D3DPOOL      m_pool;
     const DWORD        m_usage;
 
   };

--- a/src/d3d8/d3d8_d3d9_util.h
+++ b/src/d3d8/d3d8_d3d9_util.h
@@ -59,30 +59,30 @@ namespace dxvk {
     // Add D3D8-specific caps:
 
     // Removed in D3D9, since it can always render windowed
-    pCaps8->Caps2                     |= D3DCAPS2_CANRENDERWINDOWED;
+    pCaps8->Caps2                     |= D3DCAPS2_CANRENDERWINDOWED
     // A remnant from a bygone age of ddraw interop most likely
-    //                                 | D3DCAPS2_NO2DDURING3DSCENE;
+    /*                                 | D3DCAPS2_NO2DDURING3DSCENE*/;
 
     // Used in conjunction with D3DPRASTERCAPS_PAT, but generally unadvertised
-    //pCaps8->PrimitiveMiscCaps       |= D3DPMISCCAPS_LINEPATTERNREP;
+    /*pCaps8->PrimitiveMiscCaps       |= D3DPMISCCAPS_LINEPATTERNREP;*/
 
     // Replaced by D3DPRASTERCAPS_DEPTHBIAS in D3D9
-    pCaps8->RasterCaps                |= D3DPRASTERCAPS_ZBIAS;
+    pCaps8->RasterCaps                |= D3DPRASTERCAPS_ZBIAS
     // Advertised on Nvidia cards by modern drivers, but not on AMD or Intel
-    //                                 | D3DPRASTERCAPS_ANTIALIASEDGES
+    /*                                 | D3DPRASTERCAPS_ANTIALIASEDGES*/
     // Advertised on Nvidia cards, but not on AMD or Intel
-    //                                 | D3DPRASTERCAPS_STRETCHBLTMULTISAMPLE
+    /*                                 | D3DPRASTERCAPS_STRETCHBLTMULTISAMPLE*/
     // TODO: Implement D3DRS_LINEPATTERN - vkCmdSetLineRasterizationModeEXT
-    //                                 | D3DPRASTERCAPS_PAT;
+    /*                                 | D3DPRASTERCAPS_PAT*/;
 
     // MAG only filter caps, generally unsupported
-    //pCaps8->TextureFilterCaps       |= D3DPTFILTERCAPS_MAGFAFLATCUBIC
-    //                                 | D3DPTFILTERCAPS_MAGFGAUSSIANCUBIC;
-    //pCaps8->CubeTextureFilterCaps    = pCaps8->TextureFilterCaps;
-    //pCaps8->VolumeTextureFilterCaps  = pCaps8->TextureFilterCaps;
+    /*pCaps8->TextureFilterCaps       |= D3DPTFILTERCAPS_MAGFAFLATCUBIC*/
+    /*                                 | D3DPTFILTERCAPS_MAGFGAUSSIANCUBIC;*/
+    /*pCaps8->CubeTextureFilterCaps    = pCaps8->TextureFilterCaps;*/
+    /*pCaps8->VolumeTextureFilterCaps  = pCaps8->TextureFilterCaps;*/
 
     // Not advertised on any modern hardware
-    //pCaps8->VertexProcessingCaps    |= D3DVTXPCAPS_NO_VSDT_UBYTE4;
+    /*pCaps8->VertexProcessingCaps    |= D3DVTXPCAPS_NO_VSDT_UBYTE4;*/
   }
 
   // (9<-8) D3DD3DPRESENT_PARAMETERS: Returns D3D9's params given an input for D3D8

--- a/src/d3d8/d3d8_device.h
+++ b/src/d3d8/d3d8_device.h
@@ -393,20 +393,22 @@ namespace dxvk {
       m_backBuffers.resize(m_presentParams.BackBufferCount);
 
       m_autoDepthStencil = nullptr;
+
+      m_shadowPerspectiveDivide = false;
     }
 
     inline void RecreateBackBuffersAndAutoDepthStencil() {
       for (UINT i = 0; i < m_presentParams.BackBufferCount; i++) {
         Com<d3d9::IDirect3DSurface9> pSurface9;
         GetD3D9()->GetBackBuffer(0, i, d3d9::D3DBACKBUFFER_TYPE_MONO, &pSurface9);
-        m_backBuffers[i] = new D3D8Surface(this, std::move(pSurface9));
+        m_backBuffers[i] = new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pSurface9));
       }
 
       Com<d3d9::IDirect3DSurface9> pStencil9;
       // This call will fail if the D3D9 device is created without
       // the EnableAutoDepthStencil presentation parameter set to TRUE.
       HRESULT res = GetD3D9()->GetDepthStencilSurface(&pStencil9);
-      m_autoDepthStencil = FAILED(res) ? nullptr : new D3D8Surface(this, std::move(pStencil9));
+      m_autoDepthStencil = FAILED(res) ? nullptr : new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pStencil9));
 
       m_renderTarget = m_backBuffers[0];
       m_depthStencil = m_autoDepthStencil;
@@ -433,6 +435,8 @@ namespace dxvk {
 
     // Controls fixed-function exclusive mode (no PS support)
     bool                  m_isFixedFunctionOnly = false;
+
+    bool                  m_shadowPerspectiveDivide = false;
 
     D3D8StateBlock*                            m_recorder = nullptr;
     DWORD                                      m_recorderToken = 0;

--- a/src/d3d8/d3d8_include.h
+++ b/src/d3d8/d3d8_include.h
@@ -63,21 +63,21 @@ interface DECLSPEC_UUID("4B8AAAFA-140F-42BA-9131-597EAFAA2EAD") IDirect3DVolumeT
 #endif
 
 #ifdef __MINGW32__
-#define __CRT_UUID_DECL(type,l,w1,w2,b1,b2,b3,b4,b5,b6,b7,b8)         \
-}                                                                     \
+#define __CRT_UUID_DECL(type,l,w1,w2,b1,b2,b3,b4,b5,b6,b7,b8)                                                                               \
+}                                                                                                                                           \
   extern "C++" template<> struct __mingw_uuidof_s<d3d9::type> { static constexpr IID __uuid_inst = {l,w1,w2, {b1,b2,b3,b4,b5,b6,b7,b8}}; }; \
   extern "C++" template<> constexpr const GUID &__mingw_uuidof<d3d9::type>() { return __mingw_uuidof_s<d3d9::type>::__uuid_inst; }          \
   extern "C++" template<> constexpr const GUID &__mingw_uuidof<d3d9::type*>() { return __mingw_uuidof_s<d3d9::type>::__uuid_inst; }         \
 namespace d3d9 {
 
 #elif defined(__GNUC__)
-#define __CRT_UUID_DECL(type, a, b, c, d, e, f, g, h, i, j, k) \
-}                                                                                                                               \
-  extern "C++" { template <> constexpr GUID __uuidof_helper<d3d9::type>() { return GUID{a,b,c,{d,e,f,g,h,i,j,k}}; } }           \
-  extern "C++" { template <> constexpr GUID __uuidof_helper<d3d9::type*>() { return __uuidof_helper<d3d9::type>(); } }          \
-  extern "C++" { template <> constexpr GUID __uuidof_helper<const d3d9::type*>() { return __uuidof_helper<d3d9::type>(); } }    \
-  extern "C++" { template <> constexpr GUID __uuidof_helper<d3d9::type&>() { return __uuidof_helper<d3d9::type>(); } }          \
-  extern "C++" { template <> constexpr GUID __uuidof_helper<const d3d9::type&>() { return __uuidof_helper<d3d9::type>(); } }    \
+#define __CRT_UUID_DECL(type, a, b, c, d, e, f, g, h, i, j, k)                                                               \
+}                                                                                                                            \
+  extern "C++" { template <> constexpr GUID __uuidof_helper<d3d9::type>() { return GUID{a,b,c,{d,e,f,g,h,i,j,k}}; } }        \
+  extern "C++" { template <> constexpr GUID __uuidof_helper<d3d9::type*>() { return __uuidof_helper<d3d9::type>(); } }       \
+  extern "C++" { template <> constexpr GUID __uuidof_helper<const d3d9::type*>() { return __uuidof_helper<d3d9::type>(); } } \
+  extern "C++" { template <> constexpr GUID __uuidof_helper<d3d9::type&>() { return __uuidof_helper<d3d9::type>(); } }       \
+  extern "C++" { template <> constexpr GUID __uuidof_helper<const d3d9::type&>() { return __uuidof_helper<d3d9::type>(); } } \
 namespace d3d9 {
 #endif
 
@@ -126,27 +126,27 @@ namespace d3d9 {
 // Missed definitions in Wine/MinGW.
 
 #ifndef D3DPRESENT_BACK_BUFFERS_MAX_EX
-#define D3DPRESENT_BACK_BUFFERS_MAX_EX 30
+#define D3DPRESENT_BACK_BUFFERS_MAX_EX    30
 #endif
 
 #ifndef D3DSI_OPCODE_MASK
-#define D3DSI_OPCODE_MASK 0x0000FFFF
+#define D3DSI_OPCODE_MASK                 0x0000FFFF
 #endif
 
 #ifndef D3DSP_TEXTURETYPE_MASK
-#define D3DSP_TEXTURETYPE_MASK 0x78000000
+#define D3DSP_TEXTURETYPE_MASK            0x78000000
 #endif
 
 #ifndef D3DUSAGE_AUTOGENMIPMAP
-#define D3DUSAGE_AUTOGENMIPMAP 0x00000400L
+#define D3DUSAGE_AUTOGENMIPMAP            0x00000400L
 #endif
 
 #ifndef D3DSP_DCL_USAGE_MASK
-#define D3DSP_DCL_USAGE_MASK 0x0000000f
+#define D3DSP_DCL_USAGE_MASK              0x0000000f
 #endif
 
 #ifndef D3DSP_OPCODESPECIFICCONTROL_MASK
-#define D3DSP_OPCODESPECIFICCONTROL_MASK 0x00ff0000
+#define D3DSP_OPCODESPECIFICCONTROL_MASK  0x00ff0000
 #endif
 
 #ifndef D3DSP_OPCODESPECIFICCONTROL_SHIFT
@@ -154,31 +154,31 @@ namespace d3d9 {
 #endif
 
 #ifndef D3DCURSOR_IMMEDIATE_UPDATE
-#define D3DCURSOR_IMMEDIATE_UPDATE             0x00000001L
+#define D3DCURSOR_IMMEDIATE_UPDATE        0x00000001L
 #endif
 
 #ifndef D3DPRESENT_FORCEIMMEDIATE
-#define D3DPRESENT_FORCEIMMEDIATE              0x00000100L
+#define D3DPRESENT_FORCEIMMEDIATE         0x00000100L
 #endif
 
 // From d3dtypes.h
 
 #ifndef D3DDEVINFOID_TEXTUREMANAGER
-#define D3DDEVINFOID_TEXTUREMANAGER    1
+#define D3DDEVINFOID_TEXTUREMANAGER       1
 #endif
 
 #ifndef D3DDEVINFOID_D3DTEXTUREMANAGER
-#define D3DDEVINFOID_D3DTEXTUREMANAGER 2
+#define D3DDEVINFOID_D3DTEXTUREMANAGER    2
 #endif
 
 #ifndef D3DDEVINFOID_TEXTURING
-#define D3DDEVINFOID_TEXTURING         3
+#define D3DDEVINFOID_TEXTURING            3
 #endif
 
 // From d3dhal.h
 
 #ifndef D3DDEVINFOID_VCACHE
-#define D3DDEVINFOID_VCACHE            4
+#define D3DDEVINFOID_VCACHE               4
 #endif
 
 // MinGW headers are broken. Who'dve guessed?
@@ -186,21 +186,21 @@ namespace d3d9 {
 
 // Missing from d3d8types.h
 #ifndef D3DDEVINFOID_RESOURCEMANAGER
-#define D3DDEVINFOID_RESOURCEMANAGER    5
+#define D3DDEVINFOID_RESOURCEMANAGER      5
 #endif
 
 #ifndef D3DDEVINFOID_VERTEXSTATS
-#define D3DDEVINFOID_VERTEXSTATS        6   // Aka D3DDEVINFOID_D3DVERTEXSTATS
+#define D3DDEVINFOID_VERTEXSTATS          6 // Aka D3DDEVINFOID_D3DVERTEXSTATS
 #endif
 
 #ifndef D3DPRESENT_RATE_UNLIMITED
-#define D3DPRESENT_RATE_UNLIMITED       0x7FFFFFFF
+#define D3DPRESENT_RATE_UNLIMITED         0x7FFFFFFF
 #endif
 
 #else // _MSC_VER
 
 // These are enum typedefs in the MinGW headers, but not defined by Microsoft
-#define D3DVSDT_TYPE     DWORD
-#define D3DVSDE_REGISTER DWORD
+#define D3DVSDT_TYPE                      DWORD
+#define D3DVSDE_REGISTER                  DWORD
 
 #endif

--- a/src/d3d8/d3d8_main.cpp
+++ b/src/d3d8/d3d8_main.cpp
@@ -19,12 +19,15 @@ extern "C" {
   DLLEXPORT HRESULT __stdcall ValidatePixelShader(
       const DWORD*     pPixelShader,
       const D3DCAPS8*  pCaps,
-      BOOL             errorReturn,
+      BOOL             ErrorReturn,
       char**           pErrorString) {
+    HRESULT res = S_OK;
     std::string errorMessage = "";
 
+    // ValidatePixelShader returns immediately in case of a NULL pPixelShader
     if (unlikely(pPixelShader == nullptr)) {
-      errorMessage = "D3D8: ValidatePixelShader: Null pPixelShader";
+      dxvk::Logger::warn("D3D8: ValidatePixelShader: Null pPixelShader");
+      return E_FAIL;
     } else {
       const uint32_t majorVersion = D3DSHADER_VERSION_MAJOR(pPixelShader[0]);
       const uint32_t minorVersion = D3DSHADER_VERSION_MINOR(pPixelShader[0]);
@@ -32,16 +35,24 @@ extern "C" {
       if (unlikely(majorVersion != 1 || minorVersion > 4)) {
         errorMessage = dxvk::str::format("D3D8: ValidatePixelShader: Unsupported PS version ",
                                           majorVersion, ".", minorVersion);
+        res = E_FAIL;
       } else if (unlikely(pCaps && pPixelShader[0] > pCaps->PixelShaderVersion)) {
         errorMessage = dxvk::str::format("D3D8: ValidatePixelShader: Caps: Unsupported PS version ",
                                           majorVersion, ".", minorVersion);
+        res = E_FAIL;
       }
     }
 
-    const size_t errorMessageSize = errorMessage.size() + 1;
+    if (unlikely(res != S_OK)) {
+      dxvk::Logger::warn(errorMessage);
+
+      if (!ErrorReturn)
+        errorMessage = "";
+    }
 
 #ifdef _WIN32
-    if (pErrorString != nullptr && errorReturn) {
+    if (pErrorString != nullptr) {
+      const size_t errorMessageSize = errorMessage.size() + 1;
       // Wine tests call HeapFree() on the returned error string,
       // so the expectation is for it to be allocated on the heap.
       *pErrorString = (char*) HeapAlloc(GetProcessHeap(), 0, errorMessageSize);
@@ -50,24 +61,21 @@ extern "C" {
     }
 #endif
 
-    if (errorMessageSize > 1) {
-      dxvk::Logger::warn(errorMessage);
-      return E_FAIL;
-    }
-
-    return S_OK;
+    return res;
   }
 
   DLLEXPORT HRESULT __stdcall ValidateVertexShader(
       const DWORD*     pVertexShader,
       const DWORD*     pVertexDecl,
       const D3DCAPS8*  pCaps,
-      BOOL             errorReturn,
+      BOOL             ErrorReturn,
       char**           pErrorString) {
+    HRESULT res = S_OK;
     std::string errorMessage = "";
 
     if (unlikely(pVertexShader == nullptr)) {
       errorMessage = "D3D8: ValidateVertexShader: Null pVertexShader";
+      res = E_FAIL;
     } else {
       const uint32_t majorVersion = D3DSHADER_VERSION_MAJOR(pVertexShader[0]);
       const uint32_t minorVersion = D3DSHADER_VERSION_MINOR(pVertexShader[0]);
@@ -75,16 +83,24 @@ extern "C" {
       if (unlikely(majorVersion != 1 || minorVersion > 1)) {
         errorMessage = dxvk::str::format("D3D8: ValidateVertexShader: Unsupported VS version ",
                                           majorVersion, ".", minorVersion);
+        res = E_FAIL;
       } else if (unlikely(pCaps && pVertexShader[0] > pCaps->VertexShaderVersion)) {
         errorMessage = dxvk::str::format("D3D8: ValidateVertexShader: Caps: Unsupported VS version ",
                                           majorVersion, ".", minorVersion);
+        res = E_FAIL;
       }
     }
 
-    const size_t errorMessageSize = errorMessage.size() + 1;
+    if (unlikely(res != S_OK)) {
+      dxvk::Logger::warn(errorMessage);
+
+      if (!ErrorReturn)
+        errorMessage = "";
+    }
 
 #ifdef _WIN32
-    if (pErrorString != nullptr && errorReturn) {
+    if (pErrorString != nullptr) {
+      const size_t errorMessageSize = errorMessage.size() + 1;
       // Wine tests call HeapFree() on the returned error string,
       // so the expectation is for it to be allocated on the heap.
       *pErrorString = (char*) HeapAlloc(GetProcessHeap(), 0, errorMessageSize);
@@ -93,12 +109,7 @@ extern "C" {
     }
 #endif
 
-    if (errorMessageSize > 1) {
-      dxvk::Logger::warn(errorMessage);
-      return E_FAIL;
-    }
-
-    return S_OK;
+    return res;
   }
 
   DLLEXPORT void __stdcall DebugSetMute() {}

--- a/src/d3d8/d3d8_options.cpp
+++ b/src/d3d8/d3d8_options.cpp
@@ -9,7 +9,7 @@
 namespace dxvk {
 
   static inline uint32_t parseDword(std::string_view str) {
-    uint32_t value = UINT32_MAX;
+    uint32_t value = std::numeric_limits<uint32_t>::max();
     std::from_chars(str.data(), str.data() + str.size(), value);
     return value;
   }

--- a/src/d3d8/d3d8_options.h
+++ b/src/d3d8/d3d8_options.h
@@ -42,13 +42,19 @@ namespace dxvk {
     /// it was brought in line with standard D3D9 behavior.
     bool forceLegacyDiscard = false;
 
+    /// Splinter Cell expects shadow map texture coordinates to be perspective divided
+    /// even though D3DTTFF_PROJECTED is never set for any texture coordinates. This flag
+    /// forces that flag for the necessary stages when a depth texture is bound to slot 0
+    bool shadowPerspectiveDivide = false;
+
     D3D8Options() {}
 
     D3D8Options(const Config& config) {
-      auto forceVsDeclStr     = config.getOption<std::string>("d3d8.forceVsDecl",            "");
-      batching                = config.getOption<bool>       ("d3d8.batching",               batching);
-      placeP8InScratch        = config.getOption<bool>       ("d3d8.placeP8InScratch",       placeP8InScratch);
-      forceLegacyDiscard      = config.getOption<bool>       ("d3d8.forceLegacyDiscard",     forceLegacyDiscard);
+      auto forceVsDeclStr     = config.getOption<std::string>("d3d8.forceVsDecl",             "");
+      batching                = config.getOption<bool>       ("d3d8.batching",                batching);
+      placeP8InScratch        = config.getOption<bool>       ("d3d8.placeP8InScratch",        placeP8InScratch);
+      forceLegacyDiscard      = config.getOption<bool>       ("d3d8.forceLegacyDiscard",      forceLegacyDiscard);
+      shadowPerspectiveDivide = config.getOption<bool>       ("d3d8.shadowPerspectiveDivide", shadowPerspectiveDivide);
 
       parseVsDecl(forceVsDeclStr);
     }

--- a/src/d3d8/d3d8_resource.h
+++ b/src/d3d8/d3d8_resource.h
@@ -18,8 +18,9 @@ namespace dxvk {
 
   public:
 
-    D3D8Resource(D3D8Device* pDevice, Com<D3D9>&& Object)
+    D3D8Resource(D3D8Device* pDevice, D3DPOOL Pool, Com<D3D9>&& Object)
       : D3D8DeviceChild<D3D9, D3D8>(pDevice, std::move(Object))
+      , m_pool                     ( Pool )
       , m_priority                 ( 0 ) { }
 
     HRESULT STDMETHODCALLTYPE SetPrivateData(
@@ -79,9 +80,14 @@ namespace dxvk {
     }
 
     DWORD STDMETHODCALLTYPE SetPriority(DWORD PriorityNew) {
-      DWORD oldPriority = m_priority;
-      m_priority = PriorityNew;
-      return oldPriority;
+      // Priority can only be set for D3DPOOL_MANAGED resources
+      if (likely(m_pool == D3DPOOL_MANAGED)) {
+        DWORD oldPriority = m_priority;
+        m_priority = PriorityNew;
+        return oldPriority;
+      }
+
+      return m_priority;
     }
 
     DWORD STDMETHODCALLTYPE GetPriority() {
@@ -99,7 +105,8 @@ namespace dxvk {
 
   protected:
 
-    DWORD m_priority;
+    const D3DPOOL        m_pool;
+          DWORD          m_priority;
 
   private:
 

--- a/src/d3d8/d3d8_shader.cpp
+++ b/src/d3d8/d3d8_shader.cpp
@@ -1,4 +1,3 @@
-
 #include "d3d8_shader.h"
 
 #define VSD_SHIFT_MASK(token, field) ((token & field ## MASK) >> field ## SHIFT)

--- a/src/d3d8/d3d8_subresource.h
+++ b/src/d3d8/d3d8_subresource.h
@@ -16,9 +16,10 @@ namespace dxvk {
 
     D3D8Subresource(
             D3D8Device*             pDevice,
+      const D3DPOOL                 Pool,
             Com<D3D9>&&             Object,
             IDirect3DBaseTexture8*  pBaseTexture)
-    : Resource(pDevice, std::move(Object)),
+    : Resource(pDevice, Pool, std::move(Object)),
       m_container(pBaseTexture) {
     }
 

--- a/src/d3d8/d3d8_surface.cpp
+++ b/src/d3d8/d3d8_surface.cpp
@@ -1,4 +1,3 @@
-
 #include "d3d8_surface.h"
 #include "d3d8_device.h"
 
@@ -8,16 +7,18 @@ namespace dxvk {
 
   D3D8Surface::D3D8Surface(
           D3D8Device*                     pDevice,
+    const D3DPOOL                         Pool,
           IDirect3DBaseTexture8*          pTexture,
           Com<d3d9::IDirect3DSurface9>&&  pSurface)
-    : D3D8SurfaceBase (pDevice, std::move(pSurface), pTexture) {
+    : D3D8SurfaceBase (pDevice, Pool, std::move(pSurface), pTexture) {
   }
 
   // A surface does not need to be attached to a texture
   D3D8Surface::D3D8Surface(
           D3D8Device*                     pDevice,
+    const D3DPOOL                         Pool,
           Com<d3d9::IDirect3DSurface9>&&  pSurface)
-    : D3D8Surface (pDevice, nullptr, std::move(pSurface)) {
+    : D3D8Surface (pDevice, Pool, nullptr, std::move(pSurface)) {
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Surface::GetDesc(D3DSURFACE_DESC* pDesc) {

--- a/src/d3d8/d3d8_surface.h
+++ b/src/d3d8/d3d8_surface.h
@@ -15,11 +15,13 @@ namespace dxvk {
 
     D3D8Surface(
             D3D8Device*                     pDevice,
+      const D3DPOOL                         Pool,
             IDirect3DBaseTexture8*          pTexture,
             Com<d3d9::IDirect3DSurface9>&&  pSurface);
 
     D3D8Surface(
             D3D8Device*                     pDevice,
+      const D3DPOOL                         Pool,
             Com<d3d9::IDirect3DSurface9>&&  pSurface);
 
     HRESULT STDMETHODCALLTYPE GetDesc(D3DSURFACE_DESC* pDesc) final;

--- a/src/d3d8/d3d8_swapchain.cpp
+++ b/src/d3d8/d3d8_swapchain.cpp
@@ -27,7 +27,7 @@ namespace dxvk {
       HRESULT res = GetD3D9()->GetBackBuffer(BackBuffer, (d3d9::D3DBACKBUFFER_TYPE)Type, &pSurface9);
 
       if (likely(SUCCEEDED(res))) {
-        m_backBuffers[BackBuffer] = new D3D8Surface(GetParent(), std::move(pSurface9));
+        m_backBuffers[BackBuffer] = new D3D8Surface(GetParent(), D3DPOOL_DEFAULT, std::move(pSurface9));
         *ppBackBuffer = m_backBuffers[BackBuffer].ref();
       }
 

--- a/src/d3d8/d3d8_texture.cpp
+++ b/src/d3d8/d3d8_texture.cpp
@@ -8,8 +8,9 @@ namespace dxvk {
 
   D3D8Texture2D::D3D8Texture2D(
           D3D8Device*                    pDevice,
+    const D3DPOOL                        Pool,
           Com<d3d9::IDirect3DTexture9>&& pTexture)
-    : D3D8Texture2DBase(pDevice, std::move(pTexture), pTexture->GetLevelCount()) {
+    : D3D8Texture2DBase(pDevice, Pool, std::move(pTexture), pTexture->GetLevelCount()) {
   }
 
   D3DRESOURCETYPE STDMETHODCALLTYPE D3D8Texture2D::GetType() { return D3DRTYPE_TEXTURE; }
@@ -51,8 +52,9 @@ namespace dxvk {
 
   D3D8Texture3D::D3D8Texture3D(
           D3D8Device*                           pDevice,
+    const D3DPOOL                               Pool,
           Com<d3d9::IDirect3DVolumeTexture9>&&  pVolumeTexture)
-    : D3D8Texture3DBase(pDevice, std::move(pVolumeTexture), pVolumeTexture->GetLevelCount()) {}
+    : D3D8Texture3DBase(pDevice, Pool, std::move(pVolumeTexture), pVolumeTexture->GetLevelCount()) {}
 
   D3DRESOURCETYPE STDMETHODCALLTYPE D3D8Texture3D::GetType() { return D3DRTYPE_VOLUMETEXTURE; }
 
@@ -98,8 +100,9 @@ namespace dxvk {
 
   D3D8TextureCube::D3D8TextureCube(
           D3D8Device*                         pDevice,
+    const D3DPOOL                             Pool,
           Com<d3d9::IDirect3DCubeTexture9>&&  pTexture)
-    : D3D8TextureCubeBase(pDevice, std::move(pTexture), pTexture->GetLevelCount() * CUBE_FACES) {
+    : D3D8TextureCubeBase(pDevice, Pool, std::move(pTexture), pTexture->GetLevelCount() * CUBE_FACES) {
   }
 
   D3DRESOURCETYPE STDMETHODCALLTYPE D3D8TextureCube::GetType() { return D3DRTYPE_CUBETEXTURE; }

--- a/src/d3d8/d3d8_texture.h
+++ b/src/d3d8/d3d8_texture.h
@@ -21,9 +21,10 @@ namespace dxvk {
 
     D3D8BaseTexture(
             D3D8Device*                         pDevice,
+      const D3DPOOL                             Pool,
             Com<D3D9>&&                         pBaseTexture,
             UINT                                SubresourceCount)
-        : D3D8Resource<D3D9, D3D8> ( pDevice, std::move(pBaseTexture) ) {
+        : D3D8Resource<D3D9, D3D8> ( pDevice, Pool, std::move(pBaseTexture) ) {
       m_subresources.resize(SubresourceCount, nullptr);
     }
 
@@ -74,7 +75,7 @@ namespace dxvk {
           Com<SubresourceType9> subresource = LookupSubresource(Index);
 
           // Cache the subresource
-          m_subresources[Index] = new SubresourceType(this->m_parent, this, std::move(subresource));
+          m_subresources[Index] = new SubresourceType(this->m_parent, this->m_pool, this, std::move(subresource));
         } catch (HRESULT res) {
           return res;
         }
@@ -112,6 +113,7 @@ namespace dxvk {
 
     D3D8Texture2D(
             D3D8Device*                    pDevice,
+      const D3DPOOL                        Pool,
             Com<d3d9::IDirect3DTexture9>&& pTexture);
 
     D3DRESOURCETYPE STDMETHODCALLTYPE GetType() final;
@@ -139,6 +141,7 @@ namespace dxvk {
 
     D3D8Texture3D(
             D3D8Device*                           pDevice,
+      const D3DPOOL                               Pool,
             Com<d3d9::IDirect3DVolumeTexture9>&&  pVolumeTexture);
 
     D3DRESOURCETYPE STDMETHODCALLTYPE GetType() final;
@@ -166,6 +169,7 @@ namespace dxvk {
 
     D3D8TextureCube(
             D3D8Device*                         pDevice,
+      const D3DPOOL                             Pool,
             Com<d3d9::IDirect3DCubeTexture9>&&  pTexture);
 
     D3DRESOURCETYPE STDMETHODCALLTYPE GetType() final;

--- a/src/d3d8/d3d8_volume.cpp
+++ b/src/d3d8/d3d8_volume.cpp
@@ -6,9 +6,10 @@ namespace dxvk {
 
   D3D8Volume::D3D8Volume(
           D3D8Device*                   pDevice,
+    const D3DPOOL                       Pool,
           IDirect3DVolumeTexture8*      pTexture,
           Com<d3d9::IDirect3DVolume9>&& pVolume)
-    : D3D8VolumeBase(pDevice, std::move(pVolume), pTexture) {
+    : D3D8VolumeBase(pDevice, Pool, std::move(pVolume), pTexture) {
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Volume::GetDesc(D3DVOLUME_DESC* pDesc) {

--- a/src/d3d8/d3d8_volume.h
+++ b/src/d3d8/d3d8_volume.h
@@ -11,6 +11,7 @@ namespace dxvk {
 
     D3D8Volume(
             D3D8Device*                   pDevice,
+      const D3DPOOL                       Pool,
             IDirect3DVolumeTexture8*      pTexture,
             Com<d3d9::IDirect3DVolume9>&& pVolume);
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6989,6 +6989,8 @@ namespace dxvk {
 
         stage.Projected      = (ttff & D3DTTFF_PROJECTED) ? 1      : 0;
         stage.ProjectedCount = (ttff & D3DTTFF_PROJECTED) ? count  : 0;
+
+        stage.SampleDref = (m_depthTextures & (1 << idx)) != 0;
       }
 
       auto& stage0 = key.Stages[0].Contents;

--- a/src/d3d9/d3d9_device_child.h
+++ b/src/d3d9/d3d9_device_child.h
@@ -25,12 +25,28 @@ namespace dxvk {
     }
     
     ULONG STDMETHODCALLTYPE Release() {
-      uint32_t refCount = --this->m_refCount;
+      uint32_t oldRefCount, refCount;
+
+      do {
+        oldRefCount = this->m_refCount.load(std::memory_order_acquire);
+
+        // clamp value to 0 to prevent underruns
+        if (unlikely(!oldRefCount))
+          return 0;
+
+        refCount = oldRefCount - 1;
+
+      } while (!this->m_refCount.compare_exchange_weak(oldRefCount,
+                                                       refCount,
+                                                       std::memory_order_release,
+                                                       std::memory_order_acquire));
+
       if (unlikely(!refCount)) {
         auto* pDevice = GetDevice();
         this->ReleasePrivate();
         pDevice->Release();
       }
+
       return refCount;
     }
 

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -39,8 +39,13 @@ namespace dxvk {
   struct D3D9FixedFunctionOptions {
     D3D9FixedFunctionOptions(const D3D9Options* options);
 
-    bool invariantPosition;
+    bool    invariantPosition;
+    int32_t drefScaling;
   };
+
+  constexpr float GetDrefScaleFactor(int32_t bitDepth) {
+    return 1.0f / (float(1 << bitDepth) - 1.0f);
+  }
 
   // Returns new oFog if VS
   // Returns new oColor if PS
@@ -149,6 +154,7 @@ namespace dxvk {
         uint32_t     Projected    : 1;
 
         uint32_t     ProjectedCount : 3;
+        uint32_t     SampleDref     : 1;
 
         // Included in here, read from Stage 0 for packing reasons
         // Affects all stages.

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -75,6 +75,9 @@ namespace dxvk {
     this->allowDirectBufferMapping      = config.getOption<bool>        ("d3d9.allowDirectBufferMapping",      true);
     this->seamlessCubes                 = config.getOption<bool>        ("d3d9.seamlessCubes",                 false);
 
+    // D3D8 options
+    this->drefScaling                   = config.getOption<int32_t>     ("d3d8.scaleDref",                     0);
+
     // If we are not Nvidia, enable general hazards.
     this->generalHazards = adapter != nullptr
                         && !adapter->matchesDriver(

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -160,6 +160,9 @@ namespace dxvk {
 
     /// Don't use non seamless cube maps
     bool seamlessCubes;
+
+    /// Enable depth texcoord Z (Dref) scaling (D3D8 quirk)
+    int32_t drefScaling;
   };
 
 }

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -2970,9 +2970,16 @@ void DxsoCompiler::emitControlFlowGenericLoop(
       uint32_t reference = 0;
 
       if (depth) {
+        uint32_t fType = m_module.defFloatType(32);
         uint32_t component = sampler.dimensions;
         reference = m_module.opCompositeExtract(
-          m_module.defFloatType(32), texcoordVar.id, 1, &component);
+          fType, texcoordVar.id, 1, &component);
+
+        // [D3D8] Scale Dref from [0..(2^N - 1)] for D24S8 and D16 if Dref scaling is enabled
+        if (m_moduleInfo.options.drefScaling) {
+          uint32_t drefScale       = m_module.constf32(GetDrefScaleFactor(m_moduleInfo.options.drefScaling));
+          reference                = m_module.opFMul(fType, reference, drefScale);
+        }
       }
 
       if (projDivider != 0) {

--- a/src/dxso/dxso_options.cpp
+++ b/src/dxso/dxso_options.cpp
@@ -45,6 +45,8 @@ namespace dxvk {
     alphaTestWiggleRoom = options.alphaTestWiggleRoom;
 
     robustness2Supported = devFeatures.extRobustness2.robustBufferAccess2;
+
+    drefScaling         = options.drefScaling;
   }
 
 }

--- a/src/dxso/dxso_options.h
+++ b/src/dxso/dxso_options.h
@@ -57,6 +57,12 @@ namespace dxvk {
 
     /// Whether or not we can rely on robustness2 to handle oob constant access
     bool robustness2Supported;
+
+    /// Whether runtime to apply Dref scaling for depth textures of specified bit depth
+    /// (24: D24S8, 16: D16, 0: Disabled). This allows compatability with games
+    /// that expect a different depth test range, which was typically a D3D8 quirk on
+    /// early NVIDIA hardware.
+    int32_t drefScaling = 0;
   };
 
 }

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1180,6 +1180,7 @@ namespace dxvk {
      * Broken inputs and physics above 60 FPS     */
     { R"(\\SplinterCell2\.exe$)", {{
       { "d3d9.maxFrameRate",                  "60" },
+      { "d3d8.scaleDref",                     "24" },
     }} },
     /* Chrome: Gold Edition                       *
      * Broken character model motion at high FPS  */
@@ -1192,6 +1193,12 @@ namespace dxvk {
     { R"(\\Rayman3\.exe$)", {{
       { "d3d9.maxFrameRate",                  "60" },
       { "d3d8.forceLegacyDiscard",          "True" },
+    }} },
+    /* Tom Clancy's Splinter Cell                 *
+     * Fixes shadow buffers and alt-tab           */
+    { R"(\\splintercell\.exe$)", {{
+      { "d3d8.scaleDref",                     "24" },
+      { "d3d8.shadowPerspectiveDivide",     "True" },
     }} },
   }};
 


### PR DESCRIPTION
For this second part of the d3d8 backport, other than once again syncing everything from upstream d3d8, along with the shadowPerspectiveDivide quirk, I've also backported the dref scaling support which **AlpyneDreams** had added onto dxvk's d3d9 backend.

This fixes shadow rendering in Splinter Cell and Splinter Cell: Pandora Tomorrow, both titles now being playable.