### PR TITLE
[d3d8/9] Backport several d3d8 changes and SM0 support

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -305,6 +305,7 @@
 # capabilities that the applicatation queries.
 #
 # Supported values:
+# - 0: Fixed-function only
 # - 1: Shader Model 1
 # - 2: Shader Model 2
 # - 3: Shader Model 3
@@ -586,3 +587,83 @@
 # - True/False
 
 # dxvk.enableDebugUtils = False
+
+# Dref scaling for DXS0/FVF
+#
+# Some early D3D8 games expect Dref (depth texcoord Z) to be on the range of
+# [0..2^bitDepth - 1]. This option allows DXSO and fixed vertex function to
+# scale it back down to [0..1].
+#
+# Supported values: Any number representing bitDepth (typically 24).
+
+# d3d8.drefScaling = 0
+
+# Shadow perspective divide
+#
+# Older applications designed for Nvidia hardware (or ported from XBox)
+# expect shadow map texture coordinates to be perspective divided, even
+# though D3DTTFF_PROJECTED is never set for any texture coordinates.
+# Older Nvidia cards (GeForce 3, GeForce 4 series) performed this
+# projection directly in hardware.
+#
+# This option forces the D3DTTFF_PROJECTED flag for the necessary stages
+# when a depth texture is bound to slot 0, in order to emulate older
+# Nvidia hardware behavior.
+#
+# Supported values:
+# - True/False
+
+# d3d8.shadowPerspectiveDivide = False
+
+# Force vertex shader declaration
+#
+# Some games rely on undefined behavior by using undeclared vertex shader inputs.
+# The simplest way to fix them is to modify their vertex shader decl.
+#
+# This option takes a comma-separated list of colon-separated number pairs, where
+# the first number is a D3DVSDE_REGISTER value, the second is a D3DVSDT_TYPE value.
+#
+# Supported values:
+# - e.g. "0:2,3:2,7:1" for float3 position : v0, float3 normal : v3, float2 uv : v7.
+
+# d3d8.forceVsDecl = ""
+
+# Draw call batching
+#
+# Specialized drawcall batcher, typically for games that draw a lot of similar
+# geometry in separate drawcalls (sometimes even one triangle at a time).
+#
+# May hurt performance or introduce graphical artifacts outside of
+# specific games that are known to benefit from it.
+#
+# Supported values:
+# - True/False
+
+# d3d8.batching = False
+
+# P8 texture support workaround
+#
+# Early Nvidia GPUs, such as the GeForce 4 generation cards, included and exposed
+# P8 texture support. However, it was no longer advertised with cards in the FX series
+# and above. ATI/AMD drivers and hardware were most likely in a similar situation.
+#
+# This option will ensure all P8 textures are placed in D3DPOOL_SCRATCH, so that
+# their creation is guaranteed to succeed even if the format is unsupported.
+# Can help older titles that don't properly handle the lack of P8 support.
+#
+# Supported values:
+# - True/False
+
+# d3d8.placeP8InScratch = False
+
+# Legacy discard buffer behavior
+#
+# Older applications may rely on D3DLOCK_DISCARD being ignored for everything
+# except D3DUSAGE_DYNAMIC + D3DUSAGE_WRITEONLY buffers, however this approach
+# incurs a performance penalty.
+#
+# Supported values:
+# - True/False
+
+# d3d8.forceLegacyDiscard = False
+

--- a/src/d3d8/d3d8_batch.h
+++ b/src/d3d8/d3d8_batch.h
@@ -33,16 +33,16 @@ namespace dxvk {
             UINT   OffsetToLock,
             UINT   SizeToLock,
             BYTE** ppbData,
-            DWORD  Flags) {
+            DWORD  Flags) final {
       *ppbData = m_data.data() + OffsetToLock;
       return D3D_OK;
     }
 
-    HRESULT STDMETHODCALLTYPE Unlock() {
+    HRESULT STDMETHODCALLTYPE Unlock() final {
       return D3D_OK;
     }
 
-    HRESULT STDMETHODCALLTYPE GetDesc(D3DVERTEXBUFFER_DESC* pDesc) {
+    HRESULT STDMETHODCALLTYPE GetDesc(D3DVERTEXBUFFER_DESC* pDesc) final {
       if (unlikely(pDesc == nullptr))
         return D3DERR_INVALIDCALL;
 
@@ -56,7 +56,7 @@ namespace dxvk {
       return D3D_OK;
     }
 
-    void STDMETHODCALLTYPE PreLoad() {
+    void STDMETHODCALLTYPE PreLoad() final {
     }
 
     const void* GetPtr(UINT byteOffset = 0) const {

--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -47,7 +47,7 @@ namespace dxvk {
     , m_behaviorFlags(BehaviorFlags)
     , m_multithread(BehaviorFlags & D3DCREATE_MULTITHREADED) {
     // Get the bridge interface to D3D9.
-    if (FAILED(GetD3D9()->QueryInterface(__uuidof(IDxvkD3D8Bridge), (void**)&m_bridge))) {
+    if (FAILED(GetD3D9()->QueryInterface(__uuidof(IDxvkD3D8Bridge), reinterpret_cast<void**>(&m_bridge)))) {
       throw DxvkError("D3D8Device: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
     }
 
@@ -578,11 +578,11 @@ namespace dxvk {
     bool compressed = isDXT(srcDesc.Format);
 
     res = src->LockRect(&srcLocked, &srcRect, D3DLOCK_READONLY);
-    if (FAILED(res))
+    if (unlikely(FAILED(res)))
       return res;
 
     res = dst->LockRect(&dstLocked, &dstRect, 0);
-    if (FAILED(res)) {
+    if (unlikely(FAILED(res))) {
       src->UnlockRect();
       return res;
     }
@@ -629,8 +629,8 @@ namespace dxvk {
       size_t srcOffset = 0, dstOffset = 0;
       for (auto i = 0; i < rows; i++) {
         std::memcpy(
-          (uint8_t*)dstLocked.pBits + dstOffset,
-          (uint8_t*)srcLocked.pBits + srcOffset,
+          reinterpret_cast<uint8_t*>(dstLocked.pBits) + dstOffset,
+          reinterpret_cast<uint8_t*>(srcLocked.pBits) + srcOffset,
           amplitude);
         srcOffset += srcLocked.Pitch;
         dstOffset += dstLocked.Pitch;
@@ -638,7 +638,13 @@ namespace dxvk {
     }
 
     res = dst->UnlockRect();
+    if (unlikely(FAILED(res))) {
+      src->UnlockRect();
+      return res;
+    }
+
     res = src->UnlockRect();
+
     return res;
   }
 
@@ -1559,7 +1565,7 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::GetVertexShaderConstant(DWORD Register, void* pConstantData, DWORD ConstantCount) {
-    return GetD3D9()->GetVertexShaderConstantF(Register, (float*)pConstantData, ConstantCount);
+    return GetD3D9()->GetVertexShaderConstantF(Register, reinterpret_cast<float*>(pConstantData), ConstantCount);
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::SetStreamSource(
@@ -1657,7 +1663,7 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::GetPixelShaderConstant(DWORD Register, void* pConstantData, DWORD ConstantCount) {
-    return GetD3D9()->GetPixelShaderConstantF(Register, (float*)pConstantData, ConstantCount);
+    return GetD3D9()->GetPixelShaderConstantF(Register, reinterpret_cast<float*>(pConstantData), ConstantCount);
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::SetPixelShaderConstant(
@@ -1707,7 +1713,10 @@ namespace dxvk {
       // TODO: Implement D3DRS_LINEPATTERN - vkCmdSetLineRasterizationModeEXT
       // and advertise support with D3DPRASTERCAPS_PAT once that is done
       case D3DRS_LINEPATTERN:
-        Logger::warn("D3D8Device::SetRenderState: Unimplemented render state D3DRS_LINEPATTERN");
+        static bool s_linePatternErrorShown;
+
+        if (!std::exchange(s_linePatternErrorShown, true))
+          Logger::warn("D3D8Device::SetRenderState: Unimplemented render state D3DRS_LINEPATTERN");
         m_linePattern = bit::cast<D3DLINEPATTERN>(Value);
         return D3D_OK;
 
@@ -1739,7 +1748,10 @@ namespace dxvk {
 
       // TODO: Implement D3DRS_PATCHSEGMENTS
       case D3DRS_PATCHSEGMENTS:
-        Logger::warn("D3D8Device::SetRenderState: Unimplemented render state D3DRS_PATCHSEGMENTS");
+        static bool s_patchSegmentsErrorShown;
+
+        if (!std::exchange(s_patchSegmentsErrorShown, true))
+          Logger::warn("D3D8Device::SetRenderState: Unimplemented render state D3DRS_PATCHSEGMENTS");
         m_patchSegments = bit::cast<float>(Value);
         return D3D_OK;
     }
@@ -1815,45 +1827,42 @@ namespace dxvk {
     if (unlikely(pDeclaration == nullptr || pHandle == nullptr))
       return D3DERR_INVALIDCALL;
 
-    // Validate VS version for non-FF shaders
-    if (pFunction != nullptr) {
-      const uint32_t majorVersion = D3DSHADER_VERSION_MAJOR(pFunction[0]);
-      const uint32_t minorVersion = D3DSHADER_VERSION_MINOR(pFunction[0]);
-
-      if (unlikely(majorVersion != 1 || minorVersion > 1)) {
-        Logger::err(str::format("D3D8Device::CreateVertexShader: Unsupported VS version ", majorVersion, ".", minorVersion));
-        return D3DERR_INVALIDCALL;
-      }
-    }
-
-    D3D8VertexShaderInfo& info = m_vertexShaders.emplace_back();
-
-    // Store D3D8 bytecodes in the shader info
-    for (UINT i = 0; pDeclaration[i] != D3DVSD_END(); i++)
-      info.declaration.push_back(pDeclaration[i]);
-    info.declaration.push_back(D3DVSD_END());
-
-    if (pFunction != nullptr) {
-      for (UINT i = 0; pFunction[i] != D3DVS_END(); i++)
-        info.function.push_back(pFunction[i]);
-      info.function.push_back(D3DVS_END());
-    }
-
-    D3D9VertexShaderCode result = TranslateVertexShader8(pDeclaration, pFunction, m_d3d8Options);
-
-    // Create vertex declaration
-    HRESULT res = GetD3D9()->CreateVertexDeclaration(result.declaration, &(info.pVertexDecl));
+    D3D9VertexShaderCode translatedVS;
+    HRESULT res = TranslateVertexShader8(pDeclaration, pFunction, m_d3d8Options, translatedVS);
     if (unlikely(FAILED(res)))
       return res;
 
+    // Create vertex declaration
+    Com<d3d9::IDirect3DVertexDeclaration9> pVertexDecl;
+    res = GetD3D9()->CreateVertexDeclaration(translatedVS.declaration, &pVertexDecl);
+    if (unlikely(FAILED(res)))
+      return res;
+
+    Com<d3d9::IDirect3DVertexShader9> pVertexShader;
     if (pFunction != nullptr) {
-      res = GetD3D9()->CreateVertexShader(result.function.data(), &(info.pVertexShader));
+      res = GetD3D9()->CreateVertexShader(translatedVS.function.data(), &pVertexShader);
     } else {
       // pFunction is NULL: fixed function pipeline
-      info.pVertexShader = nullptr;
+      pVertexShader = nullptr;
     }
 
     if (likely(SUCCEEDED(res))) {
+      D3D8VertexShaderInfo& info = m_vertexShaders.emplace_back();
+
+      info.pVertexDecl = std::move(pVertexDecl);
+      info.pVertexShader = std::move(pVertexShader);
+
+      // Store D3D8 bytecodes in the shader info
+      for (UINT i = 0; pDeclaration[i] != D3DVSD_END(); i++)
+        info.declaration.push_back(pDeclaration[i]);
+      info.declaration.push_back(D3DVSD_END());
+
+      if (pFunction != nullptr) {
+        for (UINT i = 0; pFunction[i] != D3DVS_END(); i++)
+          info.function.push_back(pFunction[i]);
+        info.function.push_back(D3DVS_END());
+      }
+
       // Set bit to indicate this is not an FVF
       *pHandle = getShaderHandle(m_vertexShaders.size());
     }
@@ -1970,11 +1979,8 @@ namespace dxvk {
       if (!info)
         return D3DERR_INVALIDCALL;
 
-      if (info->pVertexDecl != nullptr)
-        info->pVertexDecl = nullptr;
-      if (info->pVertexShader != nullptr)
-        info->pVertexShader = nullptr;
-
+      info->pVertexDecl = nullptr;
+      info->pVertexShader = nullptr;
       info->declaration.clear();
       info->function.clear();
 
@@ -2056,20 +2062,11 @@ namespace dxvk {
     if (unlikely(pFunction == nullptr || pHandle == nullptr))
       return D3DERR_INVALIDCALL;
 
-    const uint32_t majorVersion = D3DSHADER_VERSION_MAJOR(pFunction[0]);
-    const uint32_t minorVersion = D3DSHADER_VERSION_MINOR(pFunction[0]);
-
-    if (unlikely(m_isFixedFunctionOnly || majorVersion != 1 || minorVersion > 4)) {
-      Logger::err(str::format("D3D8Device::CreatePixelShader: Unsupported PS version ", majorVersion, ".", minorVersion));
-      return D3DERR_INVALIDCALL;
-    }
-
-    d3d9::IDirect3DPixelShader9* pPixelShader;
-
+    Com<d3d9::IDirect3DPixelShader9> pPixelShader;
     HRESULT res = GetD3D9()->CreatePixelShader(pFunction, &pPixelShader);
 
     if (likely(SUCCEEDED(res))) {
-      m_pixelShaders.push_back(pPixelShader);
+      m_pixelShaders.push_back(std::move(pPixelShader));
       // Still set the shader bit, to prevent conflicts with NULL.
       *pHandle = getShaderHandle(m_pixelShaders.size());
     }

--- a/src/d3d8/d3d8_interface.cpp
+++ b/src/d3d8/d3d8_interface.cpp
@@ -7,15 +7,14 @@
 
 namespace dxvk {
 
-  D3D8Interface::D3D8Interface() {
-    m_d3d9 = d3d9::Direct3DCreate9(D3D_SDK_VERSION);
-
+  D3D8Interface::D3D8Interface()
+    : m_d3d9(d3d9::Direct3DCreate9(D3D_SDK_VERSION)) {
     // Get the bridge interface to D3D9.
-    if (FAILED(m_d3d9->QueryInterface(__uuidof(IDxvkD3D8InterfaceBridge), (void**)&m_bridge))) {
+    if (FAILED(m_d3d9->QueryInterface(__uuidof(IDxvkD3D8InterfaceBridge), reinterpret_cast<void**>(&m_bridge)))) {
       throw DxvkError("D3D8Interface: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
     }
 
-    m_bridge->SetD3D8CompatibilityMode(true);
+    m_bridge->EnableD3D8CompatibilityMode();
 
     m_d3d8Options = D3D8Options(*m_bridge->GetConfig());
 

--- a/src/d3d8/d3d8_options.h
+++ b/src/d3d8/d3d8_options.h
@@ -8,53 +8,29 @@ namespace dxvk {
 
   struct D3D8Options {
 
-    /// Some games rely on undefined behavior by using undeclared vertex shader inputs.
-    /// The simplest way to fix them is to simply modify their vertex shader decl.
-    ///
-    /// This option takes a comma-separated list of colon-separated number pairs, where
-    /// the first number is a D3DVSDE_REGISTER value, the second is a D3DVSDT_TYPE value.
-    ///   e.g. "0:2,3:2,7:1" for float3 position : v0, float3 normal : v3, float2 uv : v7
+    /// Override application vertex shader declarations.
     std::vector<std::pair<D3DVSDE_REGISTER, D3DVSDT_TYPE>> forceVsDecl;
 
-    /// Specialized drawcall batcher, typically for games that draw a lot of similar
-    /// geometry in separate drawcalls (sometimes even one triangle at a time).
-    ///
-    /// May hurt performance outside of specifc games that benefit from it.
-    bool batching = false;
+    /// Enable/disable the drawcall batcher.
+    bool batching;
 
-    /// The Lord of the Rings: The Fellowship of the Ring tries to create a P8 texture
-    /// in D3DPOOL_MANAGED on Nvidia and Intel, which fails, but has a separate code
-    /// path for ATI/AMD that creates it in D3DPOOL_SCRATCH instead, which works.
-    ///
-    /// The internal logic determining this path doesn't seem to be d3d-related, but
-    /// the game works universally if we mimic its own ATI/AMD workaround during P8
-    /// texture creation.
-    ///
-    /// Early Nvidia GPUs, such as the GeForce 4 generation cards, included and exposed
-    /// P8 texture support. However, it was no longer advertised with cards in the FX series
-    /// and above. Most likely ATI/AMD drivers never supported P8 in the first place.
-    bool placeP8InScratch = false;
+    /// Place all P8 textures in D3DPOOL_SCRATCH.
+    bool placeP8InScratch;
 
-    /// Rayman 3 relies on D3DLOCK_DISCARD being ignored for everything except D3DUSAGE_DYNAMIC +
-    /// D3DUSAGE_WRITEONLY buffers, however this approach incurs a performance penalty.
-    ///
-    /// Some titles might abuse this early D3D8 quirk, however at some point in its history
-    /// it was brought in line with standard D3D9 behavior.
-    bool forceLegacyDiscard = false;
+    /// Ignore D3DLOCK_DISCARD for everything except D3DUSAGE_DYNAMIC + D3DUSAGE_WRITEONLY buffers.
+    bool forceLegacyDiscard;
 
-    /// Splinter Cell expects shadow map texture coordinates to be perspective divided
-    /// even though D3DTTFF_PROJECTED is never set for any texture coordinates. This flag
-    /// forces that flag for the necessary stages when a depth texture is bound to slot 0
-    bool shadowPerspectiveDivide = false;
+    /// Force D3DTTFF_PROJECTED for the necessary stages when a depth texture is bound to slot 0.
+    bool shadowPerspectiveDivide;
 
     D3D8Options() {}
 
     D3D8Options(const Config& config) {
       auto forceVsDeclStr     = config.getOption<std::string>("d3d8.forceVsDecl",             "");
-      batching                = config.getOption<bool>       ("d3d8.batching",                batching);
-      placeP8InScratch        = config.getOption<bool>       ("d3d8.placeP8InScratch",        placeP8InScratch);
-      forceLegacyDiscard      = config.getOption<bool>       ("d3d8.forceLegacyDiscard",      forceLegacyDiscard);
-      shadowPerspectiveDivide = config.getOption<bool>       ("d3d8.shadowPerspectiveDivide", shadowPerspectiveDivide);
+      batching                = config.getOption<bool>       ("d3d8.batching",                false);
+      placeP8InScratch        = config.getOption<bool>       ("d3d8.placeP8InScratch",        false);
+      forceLegacyDiscard      = config.getOption<bool>       ("d3d8.forceLegacyDiscard",      false);
+      shadowPerspectiveDivide = config.getOption<bool>       ("d3d8.shadowPerspectiveDivide", false);
 
       parseVsDecl(forceVsDeclStr);
     }

--- a/src/d3d8/d3d8_resource.h
+++ b/src/d3d8/d3d8_resource.h
@@ -96,11 +96,11 @@ namespace dxvk {
 
     virtual IUnknown* GetInterface(REFIID riid) override try {
       return D3D8DeviceChild<D3D9, D3D8>::GetInterface(riid);
-    } catch (HRESULT err) {
+    } catch (const DxvkError& e) {
       if (riid == __uuidof(IDirect3DResource8))
         return this;
 
-      throw err;
+      throw e;
     }
 
   protected:

--- a/src/d3d8/d3d8_shader.h
+++ b/src/d3d8/d3d8_shader.h
@@ -10,9 +10,10 @@ namespace dxvk {
       std::vector<DWORD> function;
     };
 
-    D3D9VertexShaderCode TranslateVertexShader8(
-      const DWORD*        pDeclaration,
-      const DWORD*        pFunction,
-      const D3D8Options&  overrides);
+    HRESULT TranslateVertexShader8(
+      const DWORD*          pDeclaration,
+      const DWORD*          pFunction,
+      const D3D8Options&    overrides,
+      D3D9VertexShaderCode& pTranslatedVS);
 
 }

--- a/src/d3d8/d3d8_state_block.cpp
+++ b/src/d3d8/d3d8_state_block.cpp
@@ -71,8 +71,11 @@ namespace dxvk {
       m_indices = m_device->m_indices.ptr();
     }
 
-    if (m_capture.swvp)
-      m_device->GetRenderState(D3DRS_SOFTWAREVERTEXPROCESSING, (DWORD*)&m_isSWVP);
+    if (m_capture.swvp) {
+      DWORD swvpState;
+      m_device->GetRenderState(D3DRS_SOFTWAREVERTEXPROCESSING, &swvpState);
+      m_isSWVP = static_cast<bool>(swvpState);
+    }
 
     return m_stateBlock->Capture();
   }
@@ -101,7 +104,7 @@ namespace dxvk {
 
     // This was a very easy footgun for D3D8 applications.
     if (m_capture.swvp)
-      m_device->SetRenderState(D3DRS_SOFTWAREVERTEXPROCESSING, m_isSWVP);
+      m_device->SetRenderState(D3DRS_SOFTWAREVERTEXPROCESSING, static_cast<DWORD>(m_isSWVP));
 
     return res;
   }

--- a/src/d3d8/d3d8_surface.cpp
+++ b/src/d3d8/d3d8_surface.cpp
@@ -70,7 +70,7 @@ namespace dxvk {
       NULL);
 
     if (FAILED(res))
-      throw new DxvkError("D3D8: Failed to create blit image");
+      throw DxvkError("D3D8: Failed to create blit image");
 
     return image;
   }

--- a/src/d3d8/d3d8_wrapped_object.h
+++ b/src/d3d8/d3d8_wrapped_object.h
@@ -39,7 +39,7 @@ namespace dxvk {
       if (riid == __uuidof(D3D8))
         return this;
 
-      throw E_NOINTERFACE;
+      throw DxvkError("D3D8WrappedObject::QueryInterface: Unknown interface query");
     }
 
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject) final {
@@ -51,10 +51,10 @@ namespace dxvk {
       try {
         *ppvObject = ref(this->GetInterface(riid));
         return S_OK;
-      } catch (HRESULT err) {
-        Logger::warn("D3D8WrappedObject::QueryInterface: Unknown interface query");
+      } catch (const DxvkError& e) {
+        Logger::warn(e.message());
         Logger::warn(str::format(riid));
-        return err;
+        return E_NOINTERFACE;
       }
     }
 

--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -269,6 +269,8 @@ namespace dxvk {
 
     auto& options = m_parent->GetOptions();
 
+    const uint32_t maxShaderModel = m_parent->IsD3D8Compatible() ? std::min(1u, options.shaderModel) : options.shaderModel;
+
     // TODO: Actually care about what the adapter supports here.
     // ^ For Intel and older cards most likely here.
 
@@ -543,17 +545,22 @@ namespace dxvk {
     // Max Stream Stride
     pCaps->MaxStreamStride           = 508; // bytes
 
-    const uint32_t majorVersion = options.shaderModel;
-    const uint32_t minorVersion = options.shaderModel != 1 ? 0 : 4;
+    // Late fixed-function capable cards, such as the GeForce 4 MX series,
+    // expose support for VS 1.1, while not advertising any PS support
+    const uint32_t majorVersionVS = maxShaderModel == 0 ? 1 : maxShaderModel;
+    const uint32_t majorVersionPS = maxShaderModel;
+    // Max supported SM1 is VS 1.1 and PS 1.4
+    const uint32_t minorVersionVS = majorVersionVS != 1 ? 0 : 1;
+    const uint32_t minorVersionPS = majorVersionPS != 1 ? 0 : 4;
 
     // Shader Versions
-    pCaps->VertexShaderVersion = D3DVS_VERSION(majorVersion, minorVersion);
-    pCaps->PixelShaderVersion  = D3DPS_VERSION(majorVersion, minorVersion);
+    pCaps->VertexShaderVersion = D3DVS_VERSION(majorVersionVS, minorVersionVS);
+    pCaps->PixelShaderVersion  = D3DPS_VERSION(majorVersionPS, minorVersionPS);
 
     // Max Vertex Shader Const
     pCaps->MaxVertexShaderConst       = MaxFloatConstantsVS;
     // Max PS1 Value
-    pCaps->PixelShader1xMaxValue      = FLT_MAX;
+    pCaps->PixelShader1xMaxValue      = maxShaderModel > 0 ? FLT_MAX : 0.0f;
     // Dev Caps 2
     pCaps->DevCaps2                   = D3DDEVCAPS2_STREAMOFFSET
                                    /* | D3DDEVCAPS2_DMAPNPATCH */
@@ -600,27 +607,41 @@ namespace dxvk {
                                    /* | D3DPTFILTERCAPS_MAGFPYRAMIDALQUAD */
                                    /* | D3DPTFILTERCAPS_MAGFGAUSSIANQUAD */;
 
-    // Not too bothered about doing these longhand
-    // We should match whatever my AMD hardware reports here
-    // methinks for the best chance of stuff working.
-    pCaps->VS20Caps.Caps                     = 1;
-    pCaps->VS20Caps.DynamicFlowControlDepth  = 24;
-    pCaps->VS20Caps.NumTemps                 = 32;
-    pCaps->VS20Caps.StaticFlowControlDepth   = 4;
+    pCaps->VS20Caps.Caps                     = maxShaderModel >= 2 ? D3DVS20CAPS_PREDICATION : 0;
+    pCaps->VS20Caps.DynamicFlowControlDepth  = maxShaderModel >= 2 ? D3DVS20_MAX_DYNAMICFLOWCONTROLDEPTH : 0;
+    pCaps->VS20Caps.NumTemps                 = maxShaderModel >= 2 ? D3DVS20_MAX_NUMTEMPS : 0;
+    pCaps->VS20Caps.StaticFlowControlDepth   = maxShaderModel >= 2 ? D3DVS20_MAX_STATICFLOWCONTROLDEPTH : 0;
 
-    pCaps->PS20Caps.Caps                     = 31;
-    pCaps->PS20Caps.DynamicFlowControlDepth  = 24;
-    pCaps->PS20Caps.NumTemps                 = 32;
-    pCaps->PS20Caps.StaticFlowControlDepth   = 4;
+    pCaps->PS20Caps.Caps                     = maxShaderModel >= 2 ? D3DPS20CAPS_ARBITRARYSWIZZLE
+                                                                   | D3DPS20CAPS_GRADIENTINSTRUCTIONS
+                                                                   | D3DPS20CAPS_PREDICATION
+                                                                   | D3DPS20CAPS_NODEPENDENTREADLIMIT
+                                                                   | D3DPS20CAPS_NOTEXINSTRUCTIONLIMIT : 0;
+    pCaps->PS20Caps.DynamicFlowControlDepth  = maxShaderModel >= 2 ? D3DPS20_MAX_DYNAMICFLOWCONTROLDEPTH : 0;
+    pCaps->PS20Caps.NumTemps                 = maxShaderModel >= 2 ? D3DPS20_MAX_NUMTEMPS : 0;
+    pCaps->PS20Caps.StaticFlowControlDepth   = maxShaderModel >= 2 ? D3DPS20_MAX_STATICFLOWCONTROLDEPTH : 0;
+    pCaps->PS20Caps.NumInstructionSlots      = maxShaderModel >= 2 ? D3DPS20_MAX_NUMINSTRUCTIONSLOTS : 0;
 
-    pCaps->PS20Caps.NumInstructionSlots      = options.shaderModel >= 2 ? 512 : 256;
+    // Vertex texture samplers are only available as part of SM3, the caps are 0 otherwise.
+    pCaps->VertexTextureFilterCaps           = maxShaderModel == 3 ? D3DPTFILTERCAPS_MINFPOINT
+                                                                   | D3DPTFILTERCAPS_MINFLINEAR
+                                                                /* | D3DPTFILTERCAPS_MINFANISOTROPIC */
+                                                                /* | D3DPTFILTERCAPS_MINFPYRAMIDALQUAD */
+                                                                /* | D3DPTFILTERCAPS_MINFGAUSSIANQUAD */
+                                                                /* | D3DPTFILTERCAPS_MIPFPOINT */
+                                                                /* | D3DPTFILTERCAPS_MIPFLINEAR */
+                                                                /* | D3DPTFILTERCAPS_CONVOLUTIONMONO */
+                                                                   | D3DPTFILTERCAPS_MAGFPOINT
+                                                                   | D3DPTFILTERCAPS_MAGFLINEAR
+                                                                /* | D3DPTFILTERCAPS_MAGFANISOTROPIC */
+                                                                /* | D3DPTFILTERCAPS_MAGFPYRAMIDALQUAD */
+                                                                /* | D3DPTFILTERCAPS_MAGFGAUSSIANQUAD */ : 0;
 
-    pCaps->VertexTextureFilterCaps           = 50332416;
-    pCaps->MaxVShaderInstructionsExecuted    = 4294967295;
-    pCaps->MaxPShaderInstructionsExecuted    = 4294967295;
+    pCaps->MaxVShaderInstructionsExecuted    = maxShaderModel >= 2 ? 4294967295 : 0;
+    pCaps->MaxPShaderInstructionsExecuted    = maxShaderModel >= 2 ? 4294967295 : 0;
 
-    pCaps->MaxVertexShader30InstructionSlots = options.shaderModel == 3 ? 32768 : 0;
-    pCaps->MaxPixelShader30InstructionSlots  = options.shaderModel == 3 ? 32768 : 0;
+    pCaps->MaxVertexShader30InstructionSlots = maxShaderModel == 3 ? 32768 : 0;
+    pCaps->MaxPixelShader30InstructionSlots  = maxShaderModel == 3 ? 32768 : 0;
 
     return D3D_OK;
   }

--- a/src/d3d9/d3d9_bridge.cpp
+++ b/src/d3d9/d3d9_bridge.cpp
@@ -64,20 +64,15 @@ namespace dxvk {
     D3D9CommonTexture* srcTextureInfo = src->GetCommonTexture();
     D3D9CommonTexture* dstTextureInfo = dst->GetCommonTexture();
 
-    VkOffset3D srcOffset = { 0u, 0u, 0u };
-    VkOffset3D dstOffset = { 0u, 0u, 0u };
-    VkExtent3D texLevelExtent = srcTextureInfo->GetExtentMip(src->GetSubresource());
-    VkExtent3D extent = texLevelExtent;
+    VkOffset3D srcOffset = { pSrcRect->left,
+                             pSrcRect->top,
+                             0u };
 
-    srcOffset = { pSrcRect->left,
-                  pSrcRect->top,
-                  0u };
+    VkExtent3D extent = { uint32_t(pSrcRect->right - pSrcRect->left), uint32_t(pSrcRect->bottom - pSrcRect->top), 1 };
 
-    extent = { uint32_t(pSrcRect->right - pSrcRect->left), uint32_t(pSrcRect->bottom - pSrcRect->top), 1 };
-
-    dstOffset = { pDestPoint->x,
-                  pDestPoint->y,
-                  0u };
+    VkOffset3D dstOffset = { pDestPoint->x,
+                             pDestPoint->y,
+                             0u };
 
     m_device->UpdateTextureFromBuffer(
       srcTextureInfo, dstTextureInfo,
@@ -114,8 +109,8 @@ namespace dxvk {
     return m_interface->QueryInterface(riid, ppvObject);
   }
 
-  void DxvkD3D8InterfaceBridge::SetD3D8CompatibilityMode(const bool compatMode) {
-    m_interface->SetD3D8CompatibilityMode(compatMode);
+  void DxvkD3D8InterfaceBridge::EnableD3D8CompatibilityMode() {
+    m_interface->EnableD3D8CompatibilityMode();
   }
 
   const Config* DxvkD3D8InterfaceBridge::GetConfig() const {

--- a/src/d3d9/d3d9_bridge.h
+++ b/src/d3d9/d3d9_bridge.h
@@ -42,11 +42,9 @@ IDxvkD3D8Bridge : public IUnknown {
 MIDL_INTERFACE("D3D9D3D8-A407-773E-18E9-CAFEBEEF3000")
 IDxvkD3D8InterfaceBridge : public IUnknown {
   /**
-   * \brief Enables or disables D3D9-specific features and validations
-   *
-   * \param [in] compatMode Compatibility state
+   * \brief Enforces D3D8-specific features and validations
    */
-  virtual void SetD3D8CompatibilityMode(const bool compatMode) = 0;
+  virtual void EnableD3D8CompatibilityMode() = 0;
 
   /**
    * \brief Retrieves the DXVK configuration
@@ -106,7 +104,7 @@ namespace dxvk {
             REFIID  riid,
             void** ppvObject);
 
-    void SetD3D8CompatibilityMode(const bool compatMode);
+    void EnableD3D8CompatibilityMode();
 
     const Config* GetConfig() const;
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -2882,6 +2882,20 @@ namespace dxvk {
     if (unlikely(ppShader == nullptr))
       return D3DERR_INVALIDCALL;
 
+    const uint32_t majorVersion = D3DSHADER_VERSION_MAJOR(pFunction[0]);
+    const uint32_t minorVersion = D3DSHADER_VERSION_MINOR(pFunction[0]);
+
+    // Late fixed-function capable hardware exposed support for VS 1.1
+    const uint32_t shaderModelVS = m_isD3D8Compatible ? 1u : std::max(1u, m_d3d9Options.shaderModel);
+
+    if (unlikely(majorVersion > shaderModelVS
+              || (majorVersion == 1 && minorVersion > 1)
+              // Skip checking the SM2 minor version, as it has a 2_x mode apparently
+              || (majorVersion == 3 && minorVersion != 0))) {
+      Logger::err(str::format("D3D9DeviceEx::CreateVertexShader: Unsupported VS version ", majorVersion, ".", minorVersion));
+      return D3DERR_INVALIDCALL;
+    }
+
     DxsoModuleInfo moduleInfo;
     moduleInfo.options = m_dxsoOptions;
 
@@ -3213,6 +3227,19 @@ namespace dxvk {
 
     if (unlikely(ppShader == nullptr))
       return D3DERR_INVALIDCALL;
+
+    const uint32_t majorVersion = D3DSHADER_VERSION_MAJOR(pFunction[0]);
+    const uint32_t minorVersion = D3DSHADER_VERSION_MINOR(pFunction[0]);
+
+    const uint32_t shaderModelPS = m_isD3D8Compatible ? std::min(1u, m_d3d9Options.shaderModel) : m_d3d9Options.shaderModel;
+
+    if (unlikely(majorVersion > shaderModelPS
+              || (majorVersion == 1 && minorVersion > 4)
+              // Skip checking the SM2 minor version, as it has a 2_x mode apparently
+              || (majorVersion == 3 && minorVersion != 0))) {
+      Logger::err(str::format("D3D9DeviceEx::CreatePixelShader: Unsupported PS version ", majorVersion, ".", minorVersion));
+      return D3DERR_INVALIDCALL;
+    }
 
     DxsoModuleInfo moduleInfo;
     moduleInfo.options = m_dxsoOptions;

--- a/src/d3d9/d3d9_interface.cpp
+++ b/src/d3d9/d3d9_interface.cpp
@@ -58,6 +58,9 @@ namespace dxvk {
       Logger::info("Process set as DPI aware");
       SetProcessDPIAware();
     }
+
+    if (unlikely(m_d3d9Options.shaderModel == 0))
+      Logger::warn("D3D9InterfaceEx: WARNING! Fixed-function exclusive mode is enabled.");
   }
 
 

--- a/src/d3d9/d3d9_interface.h
+++ b/src/d3d9/d3d9_interface.h
@@ -132,11 +132,9 @@ namespace dxvk {
       return m_isD3D8Compatible;
     }
 
-    void SetD3D8CompatibilityMode(bool compatMode) {
-      if (compatMode)
-        Logger::info("The D3D9 interface is now operating in D3D8 compatibility mode.");
-
-      m_isD3D8Compatible = compatMode;
+    void EnableD3D8CompatibilityMode() {
+      m_isD3D8Compatible = true;
+      Logger::info("The D3D9 interface is now operating in D3D8 compatibility mode.");
     }
 
     Rc<DxvkInstance> GetInstance() { return m_instance; }

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -42,7 +42,7 @@ namespace dxvk {
     this->maxFrameLatency               = config.getOption<int32_t>     ("d3d9.maxFrameLatency",               0);
     this->maxFrameRate                  = config.getOption<int32_t>     ("d3d9.maxFrameRate",                  0);
     this->presentInterval               = config.getOption<int32_t>     ("d3d9.presentInterval",               -1);
-    this->shaderModel                   = config.getOption<int32_t>     ("d3d9.shaderModel",                   3);
+    this->shaderModel                   = config.getOption<int32_t>     ("d3d9.shaderModel",                   3u);
     this->evictManagedOnUnlock          = config.getOption<bool>        ("d3d9.evictManagedOnUnlock",          false);
     this->dpiAware                      = config.getOption<bool>        ("d3d9.dpiAware",                      true);
     this->strictConstantCopies          = config.getOption<bool>        ("d3d9.strictConstantCopies",          false);
@@ -78,6 +78,8 @@ namespace dxvk {
     // D3D8 options
     this->drefScaling                   = config.getOption<int32_t>     ("d3d8.scaleDref",                     0);
 
+    // Clamp the shader model value between 0 and 3
+    this->shaderModel    = dxvk::clamp(this->shaderModel, 0u, 3u);
     // If we are not Nvidia, enable general hazards.
     this->generalHazards = adapter != nullptr
                         && !adapter->matchesDriver(

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -34,7 +34,7 @@ namespace dxvk {
     int32_t maxFrameRate;
 
     /// Set the max shader model the device can support in the caps.
-    int32_t shaderModel;
+    uint32_t shaderModel;
 
     /// Whether or not managed resources should stay in memory until unlock, or until manually evicted.
     bool evictManagedOnUnlock;

--- a/src/d3d9/d3d9_shader.cpp
+++ b/src/d3d9/d3d9_shader.cpp
@@ -106,9 +106,6 @@ namespace dxvk {
 
     DxsoModule module(reader);
 
-    if (module.info().majorVersion() > pDxbcModuleInfo->options.shaderModel)
-      throw DxvkError("GetShaderModule: Out of range of supported shader model");
-
     if (module.info().shaderStage() != ShaderStage)
       throw DxvkError("GetShaderModule: Bytecode does not match shader stage");
 

--- a/src/dxso/dxso_options.cpp
+++ b/src/dxso/dxso_options.cpp
@@ -32,8 +32,6 @@ namespace dxvk {
     strictPow            = options.strictPow;
     d3d9FloatEmulation   = options.d3d9FloatEmulation;
 
-    shaderModel          = options.shaderModel;
-
     invariantPosition    = options.invariantPosition;
 
     forceSamplerTypeSpecConstants = options.forceSamplerTypeSpecConstants;

--- a/src/dxso/dxso_options.h
+++ b/src/dxso/dxso_options.h
@@ -32,9 +32,6 @@ namespace dxvk {
     /// Whether or not we should care about pow(0, 0) = 1
     bool strictPow;
 
-    /// Max version of shader to support
-    uint32_t shaderModel;
-
     /// Work around a NV driver quirk
     /// Fixes flickering/z-fighting in some games.
     bool invariantPosition;


### PR DESCRIPTION
Now that you've gotten a new stable release out and there's less risk for things to blow up :wink:, I've taken the liberty to backport several other retro-friendly changes and added features from dxvk, namely:

- d3d8 config options are now documented part of dxvk.conf
- several small d3d8 fixes and improvements
- proper support for a "Shader Model 0" mode, which essentially force exposes no programmable shader support. Note that some games will NOT like this one bit, however most games from the d3d8 era and some from the early d3d9 era will in fact provide a fallback path in which they will only use fixed function shaders (aka T&L, which is all that d3d7-capable cards supported at the time). This can be used for nostalgia reasons, to force games on simpler graphical paths that they would have used on limited capability hardware.

I've only tested the above SM0 mode briefly, but it seems to work just fine:
![SM0](https://github.com/user-attachments/assets/0ea09b9c-5860-4456-b1db-908f9854b9ff)

Don't worry, BloodRayne is one of those games that doesn't react well to a lack of PS 1.x support, so it looking like that only confirms the logic is working properly, and this is how it would have looked even back in the day on, say, a GeForce 4 MX card, if anyone had tried to play it. I've also confirmed it looks perfectly fine without the option.