### PR TITLE
[d3d11] Make transformFeedback optional, so old/low-end Adreno 6xx GPU can run DX10/11 on proprietary drivers

### DIFF
--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -816,8 +816,6 @@ namespace dxvk {
     InitReturnPtr(ppGeometryShader);
     D3D11CommonShader module;
 
-    if (!m_dxvkDevice->features().extTransformFeedback.transformFeedback)
-      return DXGI_ERROR_INVALID_CALL;
 
     // Zero-init some counterss so that we can increment
     // them while walking over the stream output entries
@@ -1997,7 +1995,7 @@ namespace dxvk {
       enabled.core.features.logicOp                               = supported.core.features.logicOp;
       enabled.core.features.shaderImageGatherExtended             = VK_TRUE;
       enabled.core.features.variableMultisampleRate               = supported.core.features.variableMultisampleRate;
-      enabled.extTransformFeedback.transformFeedback              = VK_TRUE;
+      enabled.extTransformFeedback.transformFeedback              = supported.extTransformFeedback.transformFeedback;
       enabled.extTransformFeedback.geometryStreams                = supported.extTransformFeedback.geometryStreams;
     }
     


### PR DESCRIPTION
![photo_2025-06-29_16-13-27](https://github.com/user-attachments/assets/e2ef7b52-d687-47ee-bca4-4b537c826c7f)
![photo_2025-06-29_16-13-45](https://github.com/user-attachments/assets/59999a70-81a6-4389-9c71-523c0e1531d5)
