### PR TITLE
[meta] Update GitHub Action workflows

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -3,19 +3,19 @@ name: Artifacts (Package)
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  build-artifacts:
-    runs-on: ubuntu-20.04
+  artifacts-mingw-w64:
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code
       id: checkout-code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: recursive
         fetch-depth: 0
 
     - name: Setup problem matcher
-      uses: Joshua-Ashton/gcc-problem-matcher@v1
+      uses: Joshua-Ashton/gcc-problem-matcher@v3
 
     - name: Build release
       id: build-release
@@ -28,8 +28,8 @@ jobs:
 
     - name: Upload artifacts
       id: upload-artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
-        name: dxvk-${{ env.VERSION_NAME }}
+        name: dxvk-sarek-${{ env.VERSION_NAME }}
         path: build/dxvk-${{ env.VERSION_NAME }}
         if-no-files-found: error

--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -4,21 +4,21 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build-set-windows:
-    runs-on: windows-2022
+    runs-on: windows-latest
 
     steps:
     - name: Checkout code
       id: checkout-code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: recursive
+        fetch-depth: 0
 
     - name: Setup glslangValidator
       shell: pwsh
       run: |
-        choco install vulkan-sdk -y
-        Write-Output "$([System.Environment]::GetEnvironmentVariable('VULKAN_SDK', 'Machine'))\Bin" `
-          | Out-File -FilePath "${Env:GITHUB_PATH}" -Append
+        Invoke-WebRequest -Uri "https://raw.githubusercontent.com/HansKristian-Work/vkd3d-proton-ci/main/glslangValidator.exe" -OutFile "glslangValidator.exe"
+        Write-Output "$pwd" | Out-File -FilePath "${Env:GITHUB_PATH}" -Append
 
     - name: Setup Meson
       shell: pwsh
@@ -32,6 +32,19 @@ jobs:
           | Select-Object -ExpandProperty InstallationPath
         Write-Output "VSDEVCMD=${installationPath}\Common7\Tools\VsDevCmd.bat" `
           | Out-File -FilePath "${Env:GITHUB_ENV}" -Append
+
+    - name: Download D3D8 SDK Headers
+      shell: pwsh
+      run: |
+        Invoke-WebRequest -URI https://raw.githubusercontent.com/NovaRain/DXSDK_Collection/master/DXSDK_Aug2007/Include/d3d8.h -OutFile include/d3d8.h
+        Invoke-WebRequest -URI https://raw.githubusercontent.com/NovaRain/DXSDK_Collection/master/DXSDK_Aug2007/Include/d3d8types.h -OutFile include/d3d8types.h
+        Invoke-WebRequest -URI https://raw.githubusercontent.com/NovaRain/DXSDK_Collection/master/DXSDK_Aug2007/Include/d3d8caps.h -OutFile include/d3d8caps.h
+
+    - name: Get version
+      id: get-version
+      shell: bash
+      run: |
+        echo "VERSION_NAME=${GITHUB_REF##*/}-${GITHUB_SHA##*/}" >> $GITHUB_ENV
 
     - name: Build MSVC x86
       shell: pwsh
@@ -50,3 +63,19 @@ jobs:
           | % { [System.Environment]::SetEnvironmentVariable($_[0], $_[1]) }
         meson --buildtype release --backend vs2022 build-msvc-x64
         msbuild -m build-msvc-x64/dxvk.sln
+
+    - name: Prepare artifacts
+      shell: pwsh
+      run: |
+        mkdir artifacts\x32
+        ls -Path build-msvc-x86\src -Include *.dll,*.pdb -Recurse
+          | cp -Destination (Join-Path -Path (pwd) -ChildPath artifacts\x32)
+        mkdir artifacts\x64
+        ls -Path build-msvc-x64\src -Include *.dll,*.pdb -Recurse
+          | cp -Destination (Join-Path -Path (pwd) -ChildPath artifacts\x64)
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: dxvk-sarek-${{ env.VERSION_NAME }}-msvc-output
+        path: artifacts\*

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,8 @@
-project('dxvk', ['c', 'cpp'], version : 'v1.10.9', meson_version : '>= 0.49', default_options : [ 'cpp_std=c++17' ])
+project('dxvk', ['c', 'cpp'], version : 'v1.10.9', meson_version : '>= 0.58', default_options : [ 'cpp_std=c++17', 'b_vscrt=static_from_buildtype' ])
 
 cpu_family = target_machine.cpu_family()
 platform   = target_machine.system()
+fs = import('fs')
 
 cpp = meson.get_compiler('cpp')
 cc = meson.get_compiler('c')
@@ -12,9 +13,17 @@ compiler_args = [
   '-msse2',
   '-mfpmath=sse',
   '-Wimplicit-fallthrough',
+  # gcc
+  '-Wno-missing-field-initializers',
+  '-Wno-unused-parameter',
+  '-Wno-misleading-indentation',
+  '-Wno-cast-function-type', # Needed for GetProcAddress.
   # clang
   '-Wno-unused-private-field',
   '-Wno-microsoft-exception-spec',
+  '-Wno-extern-c-compat',
+  '-Wno-unused-const-variable',
+  '-Wno-missing-braces',
 ]
 
 link_args = []
@@ -25,35 +34,62 @@ if get_option('build_id')
   ]
 endif
 
+dxvk_include_dirs = ['./include']
+if fs.is_dir('./include/vulkan/include')
+  dxvk_include_dirs += ['./include/vulkan/include']
+elif not cpp.check_header('vulkan/vulkan.h')
+  error('Missing Vulkan-Headers')
+endif
+if fs.is_dir('./include/spirv/include')
+  dxvk_include_dirs += ['./include/spirv/include']
+elif not cpp.check_header('spirv/unified1/spirv.hpp')
+  error('Missing SPIRV-Headers')
+endif
+
 if platform == 'windows'
   compiler_args += [
     '-DNOMINMAX',
     '-D_WIN32_WINNT=0xa00',
   ]
 
-  link_args += [
-    '-static',
-    '-static-libgcc',
-    '-static-libstdc++',
-    # We need to set the section alignment for debug symbols to
-    # work properly as well as avoiding a memcpy from the Wine loader.
-    '-Wl,--file-alignment=4096',
-  ]
-
-  # Wine's built-in back traces only work with dwarf2 symbols
-  if get_option('debug')
-    compiler_args += [
-      '-gstrict-dwarf',
-      '-gdwarf-2',
-    ]
-  endif
-
-  # Enable stdcall fixup on 32-bit
-  if cpu_family == 'x86'
+  if not dxvk_is_msvc
     link_args += [
-      '-Wl,--enable-stdcall-fixup',
-      '-Wl,--add-stdcall-alias',
-  ]
+      '-static',
+      '-static-libgcc',
+      '-static-libstdc++',
+      # We need to set the section alignment for debug symbols to
+      # work properly as well as avoiding a memcpy from the Wine loader.
+      '-Wl,--file-alignment=4096',
+    ]
+
+    # Wine's built-in back traces only work with dwarf4 symbols
+    if get_option('debug')
+      compiler_args += [
+        '-gdwarf-4',
+      ]
+    endif
+
+    if cpu_family == 'x86'
+      # Enable stdcall fixup on 32-bit
+      link_args += [
+        '-Wl,--enable-stdcall-fixup',
+        '-Wl,--kill-at',
+      ]
+      # Fix stack alignment issues with mingw on 32-bit
+      compiler_args += [
+        '-mpreferred-stack-boundary=2'
+      ]
+    endif
+  else
+    # setup file alignment + enable PDB output for MSVC builds
+    # PDBs are useful for Windows consumers of DXVK
+    compiler_args += [
+      '/Z7'
+    ]
+    link_args += [
+      '/FILEALIGN:4096',
+      '/DEBUG:FULL'
+    ]
   endif
 
   lib_d3d9    = cpp.find_library('d3d9')
@@ -80,23 +116,27 @@ if platform == 'windows'
   compiler_args += ['-DDXVK_WSI_WIN32']
 endif
 
+dxvk_include_path = include_directories(dxvk_include_dirs)
+
 add_project_arguments(cpp.get_supported_arguments(compiler_args), language: 'cpp')
 add_project_arguments(cc.get_supported_arguments(compiler_args), language: 'c')
 add_project_link_arguments(cpp.get_supported_link_arguments(link_args), language: 'cpp')
 add_project_link_arguments(cc.get_supported_link_arguments(link_args), language: 'c')
 
-dxvk_include_path = include_directories(['./include', './include/vulkan/include', './include/spirv/include'])
-
 exe_ext = ''
 dll_ext = ''
 def_spec_ext = '.def'
 
-glsl_compiler = find_program('glslangValidator')
-glsl_args = [ '-V', '--vn', '@BASENAME@', '@INPUT@', '-o', '@OUTPUT@' ]
-if run_command(glsl_compiler, [ '--quiet', '--version' ], check : false).returncode() == 0
-    glsl_args += [ '--quiet' ]
-endif
-glsl_generator = generator(glsl_compiler,
+glsl_compiler = find_program('glslang', 'glslangValidator')
+glsl_args = [
+  '-V',
+  '--quiet',
+  '--vn', '@BASENAME@',
+  '@INPUT@',
+  '-o', '@OUTPUT@',
+]
+glsl_generator = generator(
+  glsl_compiler,
   output    : [ '@BASENAME@.h' ],
   arguments : glsl_args,
 )

--- a/package-release.sh
+++ b/package-release.sh
@@ -62,6 +62,7 @@ function build_arch {
         $opt_strip                                          \
         --bindir "x$1"                                      \
         --libdir "x$1"                                      \
+        -Db_ndebug=if-release                               \
         -Dbuild_id=$opt_buildid                             \
         "$DXVK_BUILD_DIR/build.$1"
 
@@ -69,34 +70,16 @@ function build_arch {
   ninja install
 
   if [ $opt_devbuild -eq 0 ]; then
-    # Ensure DLLs are present before packaging
-    if ls "$DXVK_BUILD_DIR/x$1/"*.dll 1> /dev/null 2>&1; then
-      echo "DLLs found in x$1 directory."
-    else
-      echo "Warning: No DLLs found in x$1 directory!"
-    fi
-
-    # Remove unnecessary .a files
-    rm -f "$DXVK_BUILD_DIR/x$1/"*.!(dll)
-    rm -rf "$DXVK_BUILD_DIR/build.$1"
+    # get rid of some useless .a files
+    rm "$DXVK_BUILD_DIR/x$1/"*.!(dll)
+    rm -R "$DXVK_BUILD_DIR/build.$1"
   fi
 }
 
 function package {
-  cd "$(dirname "$DXVK_BUILD_DIR")"
-
-  # Ensure DLLs exist before packaging
-  if find "$DXVK_BUILD_DIR" -name "*.dll" | grep -q .; then
-    echo "Packaging DXVK build..."
-    tar -czf "$DXVK_ARCHIVE_PATH" "$(basename "$DXVK_BUILD_DIR")"
-    echo "Package created at: $DXVK_ARCHIVE_PATH"
-  else
-    echo "Error: No DLL files found! Packaging aborted."
-    exit 1
-  fi
-
-  # Clean up after packaging
-  rm -rf "$DXVK_BUILD_DIR"
+  cd "$DXVK_BUILD_DIR/.."
+  tar -czf "$DXVK_ARCHIVE_PATH" "dxvk-$DXVK_VERSION"
+  rm -R "dxvk-$DXVK_VERSION"
 }
 
 build_arch 64


### PR DESCRIPTION
Needs actions to be enabled on the repository as well to work properly, but that's fairly easy to do. @pythonlover02 It should look like this:

<img width="1704" height="597" alt="image" src="https://github.com/user-attachments/assets/38763e6d-c817-4b48-ab4b-dcba34e1e05a" />

I've kept things inline with upsteam, so that they'll be easy to maintain going forward, including MSVC builds, but removed native builds of course, since this branch pre-dates the dxvk-native merge. MSVC  builds have sometimes proven useful for Windows use, since they get around some compilation issues with mingw at times. That being said, I've backported a MSVC fix for the build scripts too.

You'll also need to port these commits to the async branch, of course, but once that is done the actions will be triggered on each push or pull request, so, for example, a commit on the `1.10.x-Proton-Sarek` branch will launch the actions and generate regular dxvk build artifacts, while one on `1.10.x-Proton-Sarek-Async` will launch the actions and generate async dxvk build artifacts. 

The artifacts will be accessible to users logged in to GitHub, as in the below screenshots:

<img width="1919" height="671" alt="image" src="https://github.com/user-attachments/assets/cf1a0770-7c5c-48ac-9b6e-16a04029236f" />

<img width="1919" height="770" alt="image" src="https://github.com/user-attachments/assets/3b125a48-8f38-4b5d-a72f-88dbaa86fbe8" />

Note that they will also typically expire after 90 days, so they're more useful for tests. Definitely don't rely on them as a build archive, because they're not intended for that purpose.