### PR TITLE
[d3d8] Backport fixes and W11V11U10 support

### DIFF
--- a/src/d3d8/d3d8_batch.h
+++ b/src/d3d8/d3d8_batch.h
@@ -152,31 +152,29 @@ namespace dxvk {
       Batch* batch = &m_batches[size_t(batchedPrimType)];
       batch->PrimitiveType = batchedPrimType;
 
-      //UINT vertices = GetVertexCount8(PrimitiveType, PrimitiveCount);
-
       switch (PrimitiveType) {
         case D3DPT_POINTLIST:
           batch->Indices.resize(batch->Offset + PrimitiveCount);
-          for (UINT i = 0; i < PrimitiveCount; i++)
+          for (uint32_t i = 0; i < PrimitiveCount; i++)
             batch->Indices[batch->Offset++] = (StartVertex + i);
           break;
         case D3DPT_LINELIST:
           batch->Indices.resize(batch->Offset + PrimitiveCount * 2);
-          for (UINT i = 0; i < PrimitiveCount; i++) {
+          for (uint32_t i = 0; i < PrimitiveCount; i++) {
             batch->Indices[batch->Offset++] = (StartVertex + i * 2 + 0);
             batch->Indices[batch->Offset++] = (StartVertex + i * 2 + 1);
           }
           break;
         case D3DPT_LINESTRIP:
           batch->Indices.resize(batch->Offset + PrimitiveCount * 2);
-          for (UINT i = 0; i < PrimitiveCount; i++) {
+          for (uint32_t i = 0; i < PrimitiveCount; i++) {
             batch->Indices[batch->Offset++] = (StartVertex + i + 0);
             batch->Indices[batch->Offset++] = (StartVertex + i + 1);
           }
           break;
         case D3DPT_TRIANGLELIST:
           batch->Indices.resize(batch->Offset + PrimitiveCount * 3);
-          for (UINT i = 0; i < PrimitiveCount; i++) {
+          for (uint32_t i = 0; i < PrimitiveCount; i++) {
             batch->Indices[batch->Offset++] = (StartVertex + i * 3 + 0);
             batch->Indices[batch->Offset++] = (StartVertex + i * 3 + 1);
             batch->Indices[batch->Offset++] = (StartVertex + i * 3 + 2);
@@ -190,14 +188,14 @@ namespace dxvk {
             batch->Indices[batch->Offset + 1] = batch->Indices[batch->Offset-2];
             batch->Indices[batch->Offset += 2] = StartVertex;
           }
-          for (UINT i = 0; i < PrimitiveCount; i++) {
+          for (uint32_t i = 0; i < PrimitiveCount; i++) {
             batch->Indices[batch->Offset++] = (StartVertex + i + 0);
           }
           break;
         // 1 2 3 4 5 6 7 -> 1 2 3, 1 3 4, 1 4 5, 1 5 6, 1 6 7
         case D3DPT_TRIANGLEFAN:
           batch->Indices.resize(batch->Offset + PrimitiveCount * 3);
-          for (UINT i = 0; i < PrimitiveCount; i++) {
+          for (uint32_t i = 0; i < PrimitiveCount; i++) {
             batch->Indices[batch->Offset++] = (StartVertex + 0);
             batch->Indices[batch->Offset++] = (StartVertex + i + 1);
             batch->Indices[batch->Offset++] = (StartVertex + i + 2);

--- a/src/d3d8/d3d8_device.h
+++ b/src/d3d8/d3d8_device.h
@@ -374,7 +374,7 @@ namespace dxvk {
      * called immediately before changing any D3D9 state.
      */
     inline void StateChange() {
-      if (ShouldBatch())
+      if (unlikely(ShouldBatch()))
         m_batcher->StateChange();
     }
 

--- a/src/d3d8/d3d8_format.h
+++ b/src/d3d8/d3d8_format.h
@@ -4,7 +4,7 @@
 
 namespace dxvk {
 
-  constexpr bool isDXT(D3DFORMAT fmt) {
+  inline bool isDXTFormat(D3DFORMAT fmt) {
     return fmt == D3DFMT_DXT1
         || fmt == D3DFMT_DXT2
         || fmt == D3DFMT_DXT3
@@ -12,33 +12,7 @@ namespace dxvk {
         || fmt == D3DFMT_DXT5;
   }
 
-  constexpr bool isDXT(d3d9::D3DFORMAT fmt) {
-    return isDXT(D3DFORMAT(fmt));
-  }
-
-  constexpr bool isUnsupportedSurfaceFormat(D3DFORMAT fmt) {
-    // mirror what dxvk doesn't support in terms of d3d9 surface formats
-    return fmt == D3DFMT_R8G8B8
-        || fmt == D3DFMT_R3G3B2
-        || fmt == D3DFMT_A8R3G3B2
-        || fmt == D3DFMT_A8P8
-        || fmt == D3DFMT_P8;
-        // not included in the d3d8 spec
-        //|| fmt == D3DFMT_CXV8U8;
-  }
-
-  constexpr bool isSupportedDepthStencilFormat(D3DFORMAT fmt) {
-    // native d3d8 doesn't support D3DFMT_D32, D3DFMT_D15S1 or D3DFMT_D24X4S4
-    return fmt == D3DFMT_D16_LOCKABLE
-        || fmt == D3DFMT_D16
-        //|| fmt == D3DFMT_D32
-        //|| fmt == D3DFMT_D15S1
-        //|| fmt == D3DFMT_D24X4S4
-        || fmt == D3DFMT_D24S8
-        || fmt == D3DFMT_D24X8;
-  }
-
-  constexpr bool isDepthStencilFormat(D3DFORMAT fmt) {
+  inline bool isDepthStencilFormat(D3DFORMAT fmt) {
     return fmt == D3DFMT_D16_LOCKABLE
         || fmt == D3DFMT_D16
         || fmt == D3DFMT_D32
@@ -48,8 +22,50 @@ namespace dxvk {
         || fmt == D3DFMT_D24X8;
   }
 
+  // The d3d8 documentation states: Render target formats are restricted to
+  // D3DFMT_X1R5G5B5, D3DFMT_R5G6B5, D3DFMT_X8R8G8B8, and D3DFMT_A8R8G8B8.
+  // This limited RT format support is confirmed by age-accurate drivers.
+  inline bool isRenderTargetFormat(D3DFORMAT fmt) {
+    return fmt == D3DFMT_X1R5G5B5
+        || fmt == D3DFMT_R5G6B5
+        || fmt == D3DFMT_X8R8G8B8
+        || fmt == D3DFMT_A8R8G8B8
+        // NULL format support was later added to d3d9 with
+        // GeForce 6 series cards, and also advertised in d3d8.
+        || fmt == (D3DFORMAT) MAKEFOURCC('N', 'U', 'L', 'L');
+  }
+
+  // Some games will exhaustively query all formats in the 0-100 range,
+  // so filter out some known formats which are exclusive to d3d9
+  inline bool isD3D9ExclusiveFormat(D3DFORMAT fmt) {
+    const d3d9::D3DFORMAT d3d9Fmt = d3d9::D3DFORMAT(fmt);
+
+    return d3d9Fmt == d3d9::D3DFMT_A8B8G8R8            //32
+        || d3d9Fmt == d3d9::D3DFMT_X8B8G8R8            //33
+        || d3d9Fmt == d3d9::D3DFMT_A2R10G10B10         //35
+        || d3d9Fmt == d3d9::D3DFMT_A16B16G16R16        //36
+        || d3d9Fmt == d3d9::D3DFMT_L16                 //81
+        || d3d9Fmt == d3d9::D3DFMT_D32F_LOCKABLE       //82
+        || d3d9Fmt == d3d9::D3DFMT_D24FS8              //83
+        || d3d9Fmt == d3d9::D3DFMT_D32_LOCKABLE        //84
+        || d3d9Fmt == d3d9::D3DFMT_S8_LOCKABLE         //85
+        || d3d9Fmt == d3d9::D3DFMT_Q16W16V16U16        //110
+        || d3d9Fmt == d3d9::D3DFMT_R16F                //111
+        || d3d9Fmt == d3d9::D3DFMT_G16R16F             //112
+        || d3d9Fmt == d3d9::D3DFMT_A16B16G16R16F       //113
+        || d3d9Fmt == d3d9::D3DFMT_R32F                //114
+        || d3d9Fmt == d3d9::D3DFMT_G32R32F             //115
+        || d3d9Fmt == d3d9::D3DFMT_A32B32G32R32F       //116
+        || d3d9Fmt == d3d9::D3DFMT_CxV8U8              //117
+        || d3d9Fmt == d3d9::D3DFMT_A1                  //118
+        || d3d9Fmt == d3d9::D3DFMT_A2B10G10R10_XR_BIAS //119
+        || d3d9Fmt == (d3d9::D3DFORMAT) MAKEFOURCC('D', 'F', '1', '6')
+        || d3d9Fmt == (d3d9::D3DFORMAT) MAKEFOURCC('D', 'F', '2', '4')
+        || d3d9Fmt == (d3d9::D3DFORMAT) MAKEFOURCC('I', 'N', 'T', 'Z');
+  }
+
   // Get bytes per pixel (or 4x4 block for DXT)
-  constexpr UINT getFormatStride(D3DFORMAT fmt) {
+  inline UINT getFormatStride(D3DFORMAT fmt) {
     switch (fmt) {
       default:
       case D3DFMT_UNKNOWN:
@@ -81,8 +97,6 @@ namespace dxvk {
       case D3DFMT_A8R8G8B8:
       case D3DFMT_X8R8G8B8:
       case D3DFMT_A2B10G10R10:
-      //case D3DFMT_A8B8G8R8:
-      //case D3DFMT_X8B8G8R8:
       case D3DFMT_G16R16:
       case D3DFMT_X8L8V8U8:
       case D3DFMT_Q8W8V8U8:
@@ -104,113 +118,8 @@ namespace dxvk {
     }
   }
 
-  constexpr uint32_t GetVertexCount8(D3DPRIMITIVETYPE type, UINT count) {
-    switch (type) {
-      default:
-      case D3DPT_TRIANGLELIST:  return count * 3;
-      case D3DPT_POINTLIST:     return count;
-      case D3DPT_LINELIST:      return count * 2;
-      case D3DPT_LINESTRIP:     return count + 1;
-      case D3DPT_TRIANGLESTRIP: return count + 2;
-      case D3DPT_TRIANGLEFAN:   return count + 2;
-    }
-  }
-
-  // Essentially the same logic as D3D9VertexDecl::SetFVF
-  constexpr UINT GetFVFStride(DWORD FVF) {
-    uint32_t texCount = 0;
-
-    uint32_t betas = 0;
-    uint8_t betaIdx = 0xFF;
-
-    UINT size = 0;
-
-    switch (FVF & D3DFVF_POSITION_MASK) {
-      case D3DFVF_XYZ:
-      case D3DFVF_XYZB1:
-      case D3DFVF_XYZB2:
-      case D3DFVF_XYZB3:
-      case D3DFVF_XYZB4:
-      case D3DFVF_XYZB5:
-        size += sizeof(float) * 3;
-
-        if ((FVF & D3DFVF_POSITION_MASK) == D3DFVF_XYZ)
-          break;
-
-        betas = (((FVF & D3DFVF_XYZB5) - D3DFVF_XYZB1) >> 1) + 1;
-        if (FVF & D3DFVF_LASTBETA_D3DCOLOR)
-          betaIdx = sizeof(D3DCOLOR);
-        else if (FVF & D3DFVF_LASTBETA_UBYTE4)
-          betaIdx = sizeof(BYTE) * 4;
-        else if ((FVF & D3DFVF_XYZB5) == D3DFVF_XYZB5)
-          betaIdx = sizeof(float);
-
-        if (betaIdx != 0xFF)
-          betas--;
-
-        if (betas > 0) {
-          if (betas <= 4)
-            size += sizeof(float) * betas;
-        }
-
-        if (betaIdx != 0xFF) {
-          size += betaIdx;
-        }
-        break;
-
-      case D3DFVF_XYZW:
-      case D3DFVF_XYZRHW:
-        size += sizeof(float) * 4;
-        break;
-
-      default:
-        break;
-    }
-
-    if (FVF & D3DFVF_NORMAL) {
-      size += sizeof(float) * 3;
-    }
-    if (FVF & D3DFVF_PSIZE) {
-      size += sizeof(float);
-    }
-    if (FVF & D3DFVF_DIFFUSE) {
-      size += sizeof(D3DCOLOR);
-    }
-    if (FVF & D3DFVF_SPECULAR) {
-      size += sizeof(D3DCOLOR);
-    }
-
-    texCount = (FVF & D3DFVF_TEXCOUNT_MASK) >> D3DFVF_TEXCOUNT_SHIFT;
-    texCount = std::min(texCount, 8u);
-
-    for (uint32_t i = 0; i < texCount; i++) {
-      switch ((FVF >> (16 + i * 2)) & 0x3) {
-        case D3DFVF_TEXTUREFORMAT1:
-          size += sizeof(float);
-          break;
-
-        case D3DFVF_TEXTUREFORMAT2:
-          size += sizeof(float) * 2;
-          break;
-
-        case D3DFVF_TEXTUREFORMAT3:
-          size += sizeof(float) * 3;
-          break;
-
-        case D3DFVF_TEXTUREFORMAT4:
-          size += sizeof(float) * 4;
-          break;
-
-        default:
-          break;
-      }
-    }
-
-    return size;
-  }
-
-  constexpr UINT getSurfaceSize(D3DFORMAT Format, UINT Width, UINT Height) {
-    if (isDXT(Format)) {
+  inline UINT getSurfaceSize(D3DFORMAT Format, UINT Width, UINT Height) {
+    if (isDXTFormat(Format)) {
       Width = ((Width + 3) >> 2);
       Height = ((Height + 3) >> 2);
     }

--- a/src/d3d8/d3d8_shader.cpp
+++ b/src/d3d8/d3d8_shader.cpp
@@ -11,7 +11,7 @@
 
 namespace dxvk {
 
-  static constexpr int D3D8_NUM_VERTEX_INPUT_REGISTERS = 17;
+  static constexpr uint32_t D3D8_NUM_VERTEX_INPUT_REGISTERS = 17;
 
   /**
    * Standard mapping of vertex input registers v0-v16 to D3D9 usages and usage indices
@@ -131,10 +131,10 @@ namespace dxvk {
     DWORD shaderInputRegisters = 0;
 
     d3d9::D3DVERTEXELEMENT9* vertexElements = pTranslatedVS.declaration;
-    unsigned int elementIdx = 0;
+    uint32_t elementIdx = 0;
 
     // These are used for pDeclaration and pFunction
-    int i = 0;
+    uint32_t i = 0;
     DWORD token;
 
     std::stringstream dbg;
@@ -236,10 +236,10 @@ namespace dxvk {
           dbg << "count=" << count << ", addr=" << addr << ", rs=" << rs;
 
           // Add a DEF instruction for each constant
-          for (DWORD j = 0; j < regCount; j += 4) {
+          for (uint32_t j = 0; j < regCount; j += 4) {
             defs.push_back(encodeInstruction(d3d9::D3DSIO_DEF));
             defs.push_back(encodeDestRegister(d3d9::D3DSPR_CONST2, addr));
-            defs.push_back(pDeclaration[i+j+0]);
+            defs.push_back(pDeclaration[i+j]);
             defs.push_back(pDeclaration[i+j+1]);
             defs.push_back(pDeclaration[i+j+2]);
             defs.push_back(pDeclaration[i+j+3]);
@@ -287,7 +287,7 @@ namespace dxvk {
       Logger::debug(str::format("VS version: ", vsMajor, ".", vsMinor));
 
       // Insert dcl instructions
-      for (int vn = 0; vn < D3D8_NUM_VERTEX_INPUT_REGISTERS; vn++) {
+      for (UINT vn = 0; vn < D3D8_NUM_VERTEX_INPUT_REGISTERS; vn++) {
 
         // If bit N is set then we need to dcl register vN
         if ((shaderInputRegisters & (1 << vn)) != 0) {

--- a/src/d3d9/d3d9_bridge.cpp
+++ b/src/d3d9/d3d9_bridge.cpp
@@ -4,6 +4,7 @@
 #include "d3d9_bridge.h"
 #include "d3d9_swapchain.h"
 #include "d3d9_surface.h"
+#include "d3d9_format.h"
 
 namespace dxvk {
 
@@ -86,6 +87,11 @@ namespace dxvk {
       m_device->MarkTextureMipsDirty(dstTextureInfo);
 
     return D3D_OK;
+  }
+
+  bool DxvkD3D8Bridge::IsSupportedSurfaceFormat(D3DFORMAT Format) {
+    auto mapping = m_device->LookupFormat(EnumerateFormat(Format));
+    return mapping.IsValid();
   }
 
   DxvkD3D8InterfaceBridge::DxvkD3D8InterfaceBridge(D3D9InterfaceEx* pObject)

--- a/src/d3d9/d3d9_bridge.h
+++ b/src/d3d9/d3d9_bridge.h
@@ -19,6 +19,7 @@ IDxvkD3D8Bridge : public IUnknown {
   // D3D8 keeps D3D9 objects contained in a namespace.
   #ifdef DXVK_D3D9_NAMESPACE
     using IDirect3DSurface9 = d3d9::IDirect3DSurface9;
+    using D3DFORMAT = d3d9::D3DFORMAT;
   #endif
 
   /**
@@ -34,6 +35,13 @@ IDxvkD3D8Bridge : public IUnknown {
       IDirect3DSurface9*        pSrcSurface,
       const RECT*               pSrcRect,
       const POINT*              pDestPoint) = 0;
+
+  /**
+   * \brief Checks if a particular surface format is supported by D3D9
+   *
+   * \param [in] Format D3DFORMAT value to be checked
+   */
+  virtual bool IsSupportedSurfaceFormat(D3DFORMAT Format) = 0;
 };
 
 /**
@@ -83,6 +91,8 @@ namespace dxvk {
         IDirect3DSurface9*        pSrcSurface,
         const RECT*               pSrcRect,
         const POINT*              pDestPoint);
+
+    bool IsSupportedSurfaceFormat(D3DFORMAT Format);
 
   private:
 

--- a/src/d3d9/d3d9_format.cpp
+++ b/src/d3d9/d3d9_format.cpp
@@ -1,4 +1,5 @@
 #include "d3d9_format.h"
+#include "d3d9_names.h"
 
 namespace dxvk {
 
@@ -168,6 +169,16 @@ namespace dxvk {
         // Convert -> float (this is a mixed snorm and unorm type)
           VK_FORMAT_R16G16B16A16_SFLOAT } };
 
+      case D3D9Format::W11V11U10: return {
+        VK_FORMAT_B10G11R11_UFLOAT_PACK32,
+        VK_FORMAT_UNDEFINED,
+        VK_IMAGE_ASPECT_COLOR_BIT,
+        { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G,
+          VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_ONE },
+        { D3D9ConversionFormat_W11V11U10,
+        // can't use B10G11R11 because this is a snorm type
+          VK_FORMAT_R16G16B16A16_SNORM } };
+
       case D3D9Format::UYVY: return {
         VK_FORMAT_B8G8R8A8_UNORM,
         VK_FORMAT_UNDEFINED,
@@ -257,15 +268,9 @@ namespace dxvk {
         VK_FORMAT_UNDEFINED,
         VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT };
 
-      case D3D9Format::D32_LOCKABLE: return {
-        VK_FORMAT_D32_SFLOAT,
-        VK_FORMAT_UNDEFINED,
-        VK_IMAGE_ASPECT_DEPTH_BIT };
+      case D3D9Format::D32_LOCKABLE: return {}; // Unsupported (everywhere)
 
-      case D3D9Format::S8_LOCKABLE: return {
-        VK_FORMAT_S8_UINT,
-        VK_FORMAT_UNDEFINED,
-        VK_IMAGE_ASPECT_STENCIL_BIT };
+      case D3D9Format::S8_LOCKABLE: return {}; // Unsupported (everywhere)
 
       case D3D9Format::L16: return {
         VK_FORMAT_R16_UNORM,
@@ -338,10 +343,7 @@ namespace dxvk {
 
       case D3D9Format::A1: return {}; // Unsupported
 
-      case D3D9Format::A2B10G10R10_XR_BIAS: return {
-        VK_FORMAT_A2B10G10R10_SNORM_PACK32,
-        VK_FORMAT_UNDEFINED,
-        VK_IMAGE_ASPECT_COLOR_BIT };
+      case D3D9Format::A2B10G10R10_XR_BIAS: return {}; // Unsupported (everywhere)
 
       case D3D9Format::BINARYBUFFER: return {
         VK_FORMAT_R8_UINT,
@@ -392,6 +394,8 @@ namespace dxvk {
 
       case D3D9Format::ATOC: return {}; // Driver hack, handled elsewhere
 
+      case D3D9Format::SSAA: return {}; // Driver hack, handled elsewhere
+
       case D3D9Format::INTZ: return {
         VK_FORMAT_D24_UNORM_S8_UINT,
         VK_FORMAT_UNDEFINED,
@@ -418,6 +422,29 @@ namespace dxvk {
       };
 
       case D3D9Format::RAWZ: return {}; // Unsupported
+
+      // EXT1, FXT1, GXT1 and HXT1 are checked for support
+      // by D3D9 SAGE engine games (e.g. Command & Conquer 3)
+
+      case D3D9Format::EXT1: return {}; // Unsupported (everywhere)
+
+      case D3D9Format::FXT1: return {}; // Unsupported (everywhere)
+
+      case D3D9Format::GXT1: return {}; // Unsupported (everywhere)
+
+      case D3D9Format::HXT1: return {}; // Unsupported (everywhere)
+
+      // AL16 and R16 FOURCCs are often checked for support by
+      // various D3D8 and early D3D9 games. AR16 and L16 (FOURCC)
+      // are also checked for support, but to a lesser extent.
+
+      case D3D9Format::AL16: return {}; // Unsupported (everywhere)
+
+      case D3D9Format::AR16: return {}; // Unsupported (everywhere)
+
+      case D3D9Format::R16:  return {}; // Unsupported (everywhere)
+
+      case D3D9Format::L16_FOURCC:  return {}; // Unsupported (everywhere)
 
       default:
         Logger::warn(str::format("ConvertFormat: Unknown format encountered: ", Format));

--- a/src/d3d9/d3d9_format.h
+++ b/src/d3d9/d3d9_format.h
@@ -40,6 +40,7 @@ namespace dxvk {
     X8L8V8U8 = 62,
     Q8W8V8U8 = 63,
     V16U16 = 64,
+    W11V11U10 = 65,
     A2W10V10U10 = 67,
     UYVY = MAKEFOURCC('U', 'Y', 'V', 'Y'),
     R8G8_B8G8 = MAKEFOURCC('R', 'G', 'B', 'G'),
@@ -109,16 +110,21 @@ namespace dxvk {
     // Not supported but exist
     AI44 = MAKEFOURCC('A', 'I', '4', '4'),
     IA44 = MAKEFOURCC('I', 'A', '4', '4'),
+    CENT = MAKEFOURCC('C', 'E', 'N', 'T'),
     R2VB = MAKEFOURCC('R', '2', 'V', 'B'),
     COPM = MAKEFOURCC('C', 'O', 'P', 'M'),
     SSAA = MAKEFOURCC('S', 'S', 'A', 'A'),
-    AL16 = MAKEFOURCC('A', 'L', '1', '6'),
-    R16  = MAKEFOURCC(' ', 'R', '1', '6'),
+    NVHS = MAKEFOURCC('N', 'V', 'H', 'S'),
+    NVHU = MAKEFOURCC('N', 'V', 'H', 'U'),
 
     EXT1 = MAKEFOURCC('E', 'X', 'T', '1'),
     FXT1 = MAKEFOURCC('F', 'X', 'T', '1'),
     GXT1 = MAKEFOURCC('G', 'X', 'T', '1'),
     HXT1 = MAKEFOURCC('H', 'X', 'T', '1'),
+    AL16 = MAKEFOURCC('A', 'L', '1', '6'),
+    AR16 = MAKEFOURCC('A', 'R', '1', '6'),
+    R16  = MAKEFOURCC(' ', 'R', '1', '6'),
+    L16_FOURCC = MAKEFOURCC(' ', 'L', '1', '6'),
   };
 
   inline D3D9Format EnumerateFormat(D3DFORMAT format) {
@@ -134,6 +140,7 @@ namespace dxvk {
     D3D9ConversionFormat_L6V5U5,
     D3D9ConversionFormat_X8L8V8U8,
     D3D9ConversionFormat_A2W10V10U10,
+    D3D9ConversionFormat_W11V11U10,
     D3D9ConversionFormat_NV12,
     D3D9ConversionFormat_YV12,
     D3D9ConversionFormat_Count

--- a/src/d3d9/d3d9_format_helpers.cpp
+++ b/src/d3d9/d3d9_format_helpers.cpp
@@ -4,6 +4,7 @@
 #include <d3d9_convert_l6v5u5.h>
 #include <d3d9_convert_x8l8v8u8.h>
 #include <d3d9_convert_a2w10v10u10.h>
+#include <d3d9_convert_w11v11u10.h>
 #include <d3d9_convert_nv12.h>
 #include <d3d9_convert_yv12.h>
 
@@ -54,6 +55,10 @@ namespace dxvk {
         break;
 
       case D3D9ConversionFormat_A2W10V10U10:
+        ConvertGenericFormat(conversionFormat, dstImage, dstSubresource, srcSlice, VK_FORMAT_R32_UINT, 0, { 1u, 1u });
+        break;
+
+      case D3D9ConversionFormat_W11V11U10:
         ConvertGenericFormat(conversionFormat, dstImage, dstSubresource, srcSlice, VK_FORMAT_R32_UINT, 0, { 1u, 1u });
         break;
 
@@ -119,6 +124,7 @@ namespace dxvk {
     m_shaders[D3D9ConversionFormat_L6V5U5] = InitShader(d3d9_convert_l6v5u5);
     m_shaders[D3D9ConversionFormat_X8L8V8U8] = InitShader(d3d9_convert_x8l8v8u8);
     m_shaders[D3D9ConversionFormat_A2W10V10U10] = InitShader(d3d9_convert_a2w10v10u10);
+    m_shaders[D3D9ConversionFormat_W11V11U10] = InitShader(d3d9_convert_w11v11u10);
     m_shaders[D3D9ConversionFormat_NV12] = InitShader(d3d9_convert_nv12);
     m_shaders[D3D9ConversionFormat_YV12] = InitShader(d3d9_convert_yv12);
   }

--- a/src/d3d9/d3d9_names.cpp
+++ b/src/d3d9/d3d9_names.cpp
@@ -33,6 +33,7 @@ namespace dxvk {
       ENUM_NAME(D3D9Format::X8L8V8U8);
       ENUM_NAME(D3D9Format::Q8W8V8U8);
       ENUM_NAME(D3D9Format::V16U16);
+      ENUM_NAME(D3D9Format::W11V11U10);
       ENUM_NAME(D3D9Format::A2W10V10U10);
       ENUM_NAME(D3D9Format::UYVY);
       ENUM_NAME(D3D9Format::R8G8_B8G8);
@@ -99,18 +100,24 @@ namespace dxvk {
       ENUM_NAME(D3D9Format::YV12);
       ENUM_NAME(D3D9Format::OPAQUE_420);
 
+      // Not supported but exist
       ENUM_NAME(D3D9Format::AI44);
       ENUM_NAME(D3D9Format::IA44);
+      ENUM_NAME(D3D9Format::CENT);
       ENUM_NAME(D3D9Format::R2VB);
       ENUM_NAME(D3D9Format::COPM);
       ENUM_NAME(D3D9Format::SSAA);
-      ENUM_NAME(D3D9Format::AL16);
-      ENUM_NAME(D3D9Format::R16);
+      ENUM_NAME(D3D9Format::NVHS);
+      ENUM_NAME(D3D9Format::NVHU);
 
       ENUM_NAME(D3D9Format::EXT1);
       ENUM_NAME(D3D9Format::FXT1);
       ENUM_NAME(D3D9Format::GXT1);
       ENUM_NAME(D3D9Format::HXT1);
+      ENUM_NAME(D3D9Format::AL16);
+      ENUM_NAME(D3D9Format::AR16);
+      ENUM_NAME(D3D9Format::R16);
+      ENUM_NAME(D3D9Format::L16_FOURCC);
 
       ENUM_DEFAULT(e);
     }

--- a/src/d3d9/d3d9_names.h
+++ b/src/d3d9/d3d9_names.h
@@ -2,6 +2,8 @@
 
 namespace dxvk {
 
+  std::ostream& operator << (std::ostream& os, D3D9Format e);
+
   std::ostream& operator << (std::ostream& os, D3DRENDERSTATETYPE e);
 
 }

--- a/src/d3d9/meson.build
+++ b/src/d3d9/meson.build
@@ -5,6 +5,7 @@ d3d9_shaders = files([
   'shaders/d3d9_convert_l6v5u5.comp',
   'shaders/d3d9_convert_x8l8v8u8.comp',
   'shaders/d3d9_convert_a2w10v10u10.comp',
+  'shaders/d3d9_convert_w11v11u10.comp',
   'shaders/d3d9_convert_nv12.comp',
   'shaders/d3d9_convert_yv12.comp'
 ])

--- a/src/d3d9/shaders/d3d9_convert_w11v11u10.comp
+++ b/src/d3d9/shaders/d3d9_convert_w11v11u10.comp
@@ -1,0 +1,43 @@
+#version 450
+#extension GL_GOOGLE_include_directive : enable
+
+#include "d3d9_convert_common.h"
+
+layout(
+  local_size_x = 8,
+  local_size_y = 8,
+  local_size_z = 1) in;
+
+layout(binding = 0)
+writeonly uniform image2D dst;
+
+layout(binding = 1) uniform usamplerBuffer src;
+
+layout(push_constant)
+uniform u_info_t {
+  uvec2 extent;
+} u_info;
+
+void main() {
+  ivec3 thread_id = ivec3(gl_GlobalInvocationID);
+
+  if (all(lessThan(thread_id.xy, u_info.extent))) {
+    uint offset = thread_id.x
+                + thread_id.y * u_info.extent.x;
+
+    uint value = texelFetch(src, int(offset)).r;
+
+    // Sign-extend magic!
+    int  u10 = bitfieldExtract(int (value), 0,  10);
+    int  v11 = bitfieldExtract(int (value), 10, 11);
+    int  w11 = bitfieldExtract(int (value), 21, 11);
+
+    vec4 color = vec4(
+      snormalize(u10, 10),
+      snormalize(v11, 10),
+      snormalize(w11, 10),
+      1.0);
+
+    imageStore(dst, thread_id.xy, color);
+  }
+}


### PR DESCRIPTION
A collection of mostly minor d3d8 fixes and optimization backports, along with a backport of support for the W11V11U10 d3d8 format.