### PR TITLE
[meta] Truncate action artifact names

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -30,6 +30,6 @@ jobs:
       id: upload-artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: dxvk-sarek-${{ env.VERSION_NAME }}
+        name: dxvk-${{ env.VERSION_NAME }}
         path: build/dxvk-${{ env.VERSION_NAME }}
         if-no-files-found: error

--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -77,5 +77,5 @@ jobs:
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: dxvk-sarek-${{ env.VERSION_NAME }}-msvc-output
+        name: dxvk-${{ env.VERSION_NAME }}-msvc-output
         path: artifacts\*


### PR DESCRIPTION
I noticed you've changed the repo branch names to be more explicit (which is good), thus the extra naming I added in the Action artifacts is a bit superfluous now (as it would generate files named dxvk-sarek-Sarek-[...] :) ), so got rid of that prefix. This also makes the action definitions more inline with upstream.

Keep in mind to always keep the "sarek" keyword in the branch names going forward, otherwise it might end up confusing people based on Actions artifact naming alone.

Another option would be to not drop the prefix (so not merge this PR), rather change the branch names simply to something like "main" and "async", which would make a bit more sense if you ask me, as branches aren't meant to contain the repo name. I'll leave it up to you to decide.