### PR TITLE
[d3d8] Backport latest upstream d3d8 fixes

### DIFF
--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -56,12 +56,6 @@ namespace dxvk {
 
     if (m_d3d8Options.batching)
       m_batcher = new D3D8Batcher(this, GetD3D9());
-
-    d3d9::D3DCAPS9 caps9;
-    HRESULT res = GetD3D9()->GetDeviceCaps(&caps9);
-
-    if (unlikely(SUCCEEDED(res) && caps9.PixelShaderVersion == D3DPS_VERSION(0, 0)))
-      m_isFixedFunctionOnly = true;
   }
 
   D3D8Device::~D3D8Device() {
@@ -162,6 +156,7 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     *ppD3D8 = m_parent.ref();
+
     return D3D_OK;
   }
 
@@ -229,29 +224,18 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D8Device::Reset(D3DPRESENT_PARAMETERS* pPresentationParameters) {
     D3D8DeviceLock lock = LockDevice();
 
+    HRESULT res = m_parent->ValidatePresentationParameters(pPresentationParameters);
+
+    if (unlikely(FAILED(res)))
+      return res;
+
     StateChange();
-
-    if (unlikely(pPresentationParameters == nullptr))
-      return D3DERR_INVALIDCALL;
-
-    // D3DSWAPEFFECT_COPY can not be used with more than one back buffer.
-    // This is also technically true for D3DSWAPEFFECT_COPY_VSYNC, however
-    // RC Cars depends on it not being rejected.
-    if (unlikely(pPresentationParameters->SwapEffect == D3DSWAPEFFECT_COPY
-              && pPresentationParameters->BackBufferCount > 1))
-      return D3DERR_INVALIDCALL;
-
-    // In D3D8 nothing except D3DPRESENT_INTERVAL_DEFAULT can be used
-    // as a flag for windowed presentation.
-    if (unlikely(pPresentationParameters->Windowed
-              && pPresentationParameters->FullScreen_PresentationInterval != D3DPRESENT_INTERVAL_DEFAULT))
-      return D3DERR_INVALIDCALL;
 
     m_presentParams = *pPresentationParameters;
     ResetState();
 
     d3d9::D3DPRESENT_PARAMETERS params = ConvertPresentParameters9(pPresentationParameters);
-    HRESULT res = GetD3D9()->Reset(&params);
+    res = GetD3D9()->Reset(&params);
 
     if (likely(SUCCEEDED(res)))
       RecreateBackBuffersAndAutoDepthStencil();
@@ -295,6 +279,7 @@ namespace dxvk {
     }
 
     *ppBackBuffer = m_backBuffers[iBackBuffer].ref();
+
     return D3D_OK;
   }
 
@@ -439,7 +424,7 @@ namespace dxvk {
     if (unlikely(ppVertexBuffer == nullptr))
       return D3DERR_INVALIDCALL;
 
-    if (ShouldBatch()) {
+    if (unlikely(ShouldBatch())) {
       *ppVertexBuffer = m_batcher->CreateVertexBuffer(Length, Usage, FVF, Pool);
       return D3D_OK;
     }
@@ -1248,7 +1233,7 @@ namespace dxvk {
       m_token++;
       auto stateBlockIterPair = m_stateBlocks.emplace(std::piecewise_construct,
                                                       std::forward_as_tuple(m_token),
-                                                      std::forward_as_tuple(this, Type, pStateBlock9.ref()));
+                                                      std::forward_as_tuple(this, Type, pStateBlock9.ptr()));
       *pToken = m_token;
 
       // D3D8 state blocks automatically capture state on creation.
@@ -1491,7 +1476,7 @@ namespace dxvk {
           UINT             PrimitiveCount) {
     D3D8DeviceLock lock = LockDevice();
 
-    if (ShouldBatch())
+    if (unlikely(ShouldBatch()))
       return m_batcher->DrawPrimitive(PrimitiveType, StartVertex, PrimitiveCount);
     return GetD3D9()->DrawPrimitive(d3d9::D3DPRIMITIVETYPE(PrimitiveType), StartVertex, PrimitiveCount);
   }
@@ -1603,7 +1588,7 @@ namespace dxvk {
     HRESULT res = GetD3D9()->SetStreamSource(StreamNumber, D3D8VertexBuffer::GetD3D9Nullable(buffer), 0, Stride);
 
     if (likely(SUCCEEDED(res))) {
-      if (ShouldBatch())
+      if (unlikely(ShouldBatch()))
         m_batcher->SetStream(StreamNumber, buffer, Stride);
 
       m_streams[StreamNumber].buffer = buffer;
@@ -1649,17 +1634,16 @@ namespace dxvk {
     if (unlikely(BaseVertexIndex > std::numeric_limits<int32_t>::max()))
       Logger::warn("D3D8Device::SetIndices: BaseVertexIndex exceeds INT_MAX");
 
-    // used by DrawIndexedPrimitive
-    m_baseVertexIndex = BaseVertexIndex;
-
     D3D8IndexBuffer* buffer = static_cast<D3D8IndexBuffer*>(pIndexData);
     HRESULT res = GetD3D9()->SetIndices(D3D8IndexBuffer::GetD3D9Nullable(buffer));
 
     if (likely(SUCCEEDED(res))) {
-      if (ShouldBatch())
-        m_batcher->SetIndices(buffer, m_baseVertexIndex);
+      if (unlikely(ShouldBatch()))
+        m_batcher->SetIndices(buffer, BaseVertexIndex);
 
       m_indices = buffer;
+      // used by DrawIndexedPrimitive
+      m_baseVertexIndex = BaseVertexIndex;
     }
 
     return res;
@@ -1735,6 +1719,7 @@ namespace dxvk {
 
         if (!std::exchange(s_linePatternErrorShown, true))
           Logger::warn("D3D8Device::SetRenderState: Unimplemented render state D3DRS_LINEPATTERN");
+
         m_linePattern = bit::cast<D3DLINEPATTERN>(Value);
         return D3D_OK;
 
@@ -1770,8 +1755,8 @@ namespace dxvk {
 
         if (!std::exchange(s_patchSegmentsErrorShown, true))
           Logger::warn("D3D8Device::SetRenderState: Unimplemented render state D3DRS_PATCHSEGMENTS");
-        m_patchSegments = bit::cast<float>(Value);
-        return D3D_OK;
+
+        return GetD3D9()->SetNPatchMode(bit::cast<float>(Value));
     }
 
     // Skip GetRenderState() calls for state
@@ -1827,7 +1812,8 @@ namespace dxvk {
         return D3D_OK;
 
       case D3DRS_PATCHSEGMENTS:
-        *pValue = bit::cast<DWORD>(m_patchSegments);
+        const float patchSegments = GetD3D9()->GetNPatchMode();
+        *pValue = bit::cast<DWORD>(patchSegments);
         return D3D_OK;
     }
 

--- a/src/d3d8/d3d8_device.h
+++ b/src/d3d8/d3d8_device.h
@@ -382,6 +382,10 @@ namespace dxvk {
       // Mirrors how D3D9 handles the BackBufferCount
       m_presentParams.BackBufferCount = std::max(m_presentParams.BackBufferCount, 1u);
 
+      // Reset D3D8 exclusive render states
+      m_linePattern = {};
+      m_zVisible    = 0;
+
       // Purge cached objects
       m_textures.fill(nullptr);
       m_streams.fill(D3D8VBO());
@@ -430,11 +434,6 @@ namespace dxvk {
     D3DLINEPATTERN        m_linePattern   = {};
     // Value of D3DRS_ZVISIBLE (although the RS is not supported, its value is stored)
     DWORD                 m_zVisible      = 0;
-    // Value of D3DRS_PATCHSEGMENTS
-    float                 m_patchSegments = 1.0f;
-
-    // Controls fixed-function exclusive mode (no PS support)
-    bool                  m_isFixedFunctionOnly = false;
 
     bool                  m_shadowPerspectiveDivide = false;
 

--- a/src/d3d8/d3d8_interface.h
+++ b/src/d3d8/d3d8_interface.h
@@ -170,6 +170,8 @@ namespace dxvk {
         D3DPRESENT_PARAMETERS* pPresentationParameters,
         IDirect3DDevice8** ppReturnedDeviceInterface);
 
+    HRESULT ValidatePresentationParameters(
+        const D3DPRESENT_PARAMETERS* pPresentationParameters);
 
     const D3D8Options& GetOptions() { return m_d3d8Options; }
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -2448,7 +2448,7 @@ namespace dxvk {
 
 
   HRESULT STDMETHODCALLTYPE D3D9DeviceEx::SetSoftwareVertexProcessing(BOOL bSoftware) {
-    auto lock = LockDevice();
+    D3D9DeviceLock lock = LockDevice();
 
     if (bSoftware && !CanSWVP())
       return D3DERR_INVALIDCALL;
@@ -2460,19 +2460,25 @@ namespace dxvk {
 
 
   BOOL    STDMETHODCALLTYPE D3D9DeviceEx::GetSoftwareVertexProcessing() {
-    auto lock = LockDevice();
+    D3D9DeviceLock lock = LockDevice();
 
     return m_isSWVP;
   }
 
 
   HRESULT STDMETHODCALLTYPE D3D9DeviceEx::SetNPatchMode(float nSegments) {
+    D3D9DeviceLock lock = LockDevice();
+
+    m_state.nPatchSegments = nSegments;
+
     return D3D_OK;
   }
 
 
   float   STDMETHODCALLTYPE D3D9DeviceEx::GetNPatchMode() {
-    return 0.0f;
+    D3D9DeviceLock lock = LockDevice();
+
+    return m_state.nPatchSegments;
   }
 
 
@@ -7528,6 +7534,11 @@ namespace dxvk {
     UpdateBoolSpecConstantVertex(0u);
     UpdateBoolSpecConstantPixel(0u);
     UpdateSamplerDepthModeSpecConstant(0u);
+
+    // In D3D8, this represents the value of D3DRS_PATCHSEGMENTS.
+    // It defaults to 1.0f and is reset as any other render state.
+    if (m_isD3D8Compatible)
+      m_state.nPatchSegments = 1.0f;
 
     return D3D_OK;
   }

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -227,6 +227,8 @@ namespace dxvk {
     std::vector<std::optional<D3DLIGHT9>>            lights;
     std::array<DWORD, caps::MaxEnabledLights>        enabledLightIndices;
 
+    float                                            nPatchSegments = 0.0f;
+
     bool IsLightEnabled(DWORD Index) {
       const auto& indices = enabledLightIndices;
       return std::find(indices.begin(), indices.end(), Index) != indices.end();

--- a/src/util/com/com_pointer.h
+++ b/src/util/com/com_pointer.h
@@ -68,9 +68,13 @@ namespace dxvk {
     }
     
     Com& operator = (T* object) {
-      this->decRef();
-      m_ptr = object;
-      this->incRef();
+      // prevents the destruction of private
+      // Com objects during self-assignment
+      if (likely(m_ptr != object)) {
+        this->decRef();
+        m_ptr = object;
+        this->incRef();
+      }
       return *this;
     }
     

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1153,7 +1153,7 @@ namespace dxvk {
     { R"(\\nfs4\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
       { "d3d9.memoryTrackTest",             "True" },
-      { "d3d9.maxAvailableMemory",           "256" },
+      { "d3d9.maxAvailableMemory",          "1024" },
       { "d3d8.batching",                    "True" },
     }} },
     /* Need for Speed: Hot Pursuit 2              */
@@ -1182,7 +1182,7 @@ namespace dxvk {
      * while loading the main menu otherwise      */
     { R"(\\Soldiers\.exe$)", {{
       { "d3d9.memoryTrackTest",             "True" },
-      { "d3d9.maxAvailableMemory",          "512"  },
+      { "d3d9.maxAvailableMemory",           "512" },
     }} },
     /* Cossacks II: Napoleonic Wars &             *
      * Battle for Europe                          */
@@ -1248,10 +1248,52 @@ namespace dxvk {
       { "d3d8.forceLegacyDiscard",          "True" },
     }} },
     /* Tom Clancy's Splinter Cell                 *
-     * Fixes shadow buffers and alt-tab           */
-    { R"(\\splintercell\.exe$)", {{
+     * Fixes shadow buffers, broken physics       *
+     * above 60 FPS and game freezing on alt-tab  */
+     { R"(\\splintercell\.exe$)", {{
+      { "d3d9.customVendorId",              "10de" },
+      { "d3d9.maxFrameRate",                  "60" },
+      { "d3d9.deviceLossOnFocusLoss",       "True" },
       { "d3d8.scaleDref",                     "24" },
       { "d3d8.shadowPerspectiveDivide",     "True" },
+    }} },
+    /* Trainz v1.3 (2001)                         *
+     * Fixes black screen after alt-tab           */
+    { R"(\\bin\\trainz\.exe$)", {{
+      { "d3d9.deviceLossOnFocusLoss",       "True" },
+    }} },
+    /* A.I.M.: Artificial Intelligence Machine    *
+     * Fixes black screen after the options       *
+     * window is closed or on alt-tab             */
+    { R"(\\AIM\.exe$)", {{
+      { "d3d9.deviceLossOnFocusLoss",       "True" },
+    }} },
+    /* Star Trek: Starfleet Command III           *
+     * The GOG release ships with a D3D8 to D3D9  *
+     * wrapper that leaks several surfaces.       */
+    { R"(\\SFC3\.exe$)", {{
+      { "d3d9.countLosableResources",      "False" },
+    }} },
+    /* GTR - FIA GT Racing Game                   *
+     * Vram complaint & restricted resolutions    *
+     * Performance                                */
+    { R"(\\GTR (- FIA GT Rac(e)?ing Game|Demo)\\(GTR(Demo)?|(3D)?Config)\.exe$)", {{
+      { "d3d9.maxAvailableMemory",          "1024" },
+      { "d3d9.memoryTrackTest",             "True" },
+      { "d3d9.cachedDynamicBuffers",        "True" },
+    }} },
+    /* Comanche 4 - Only enables the FSAA option  *
+     * if it detects a device ID of 0x025x.       */
+     { R"(\\c4(lan)?\.exe$)", {{
+      { "d3d9.customVendorId",              "10de" },
+      { "d3d9.customDeviceId",              "0250" },
+      { "d3d9.customDeviceDesc", "NVIDIA GeForce4 Ti 4600" },
+    }} },
+    /* Top Spin (2005)                            *
+     * Missing geometry and textures without      *
+     * legacy DISCARD behavior                    */
+    { R"(\\TopSpin\.exe$)", {{
+      { "d3d8.forceLegacyDiscard",          "True" },
     }} },
   }};
 


### PR DESCRIPTION
Includes the fixes for Top Spin, Sea Dogs 2: City of Abandoned Ships as well as other d3d8 built-in configs we've added recently.