### PR TITLE
[d3d8/9] Backport upstream fixes and optimizations

### DIFF
--- a/src/d3d8/d3d8_main.cpp
+++ b/src/d3d8/d3d8_main.cpp
@@ -8,7 +8,14 @@ namespace dxvk {
     if (!ppDirect3D8)
       return D3DERR_INVALIDCALL;
 
-    *ppDirect3D8 = ref(new D3D8Interface());
+    try {
+      *ppDirect3D8 = ref(new D3D8Interface());
+    } catch (const DxvkError& e) {
+      Logger::err(e.message());
+      *ppDirect3D8 = nullptr;
+      return D3DERR_NOTAVAILABLE;
+    }
+
     return D3D_OK;
   }
 

--- a/src/d3d8/d3d8_state_block.cpp
+++ b/src/d3d8/d3d8_state_block.cpp
@@ -5,37 +5,43 @@ namespace dxvk {
 
   D3D8StateBlock::D3D8StateBlock(
           D3D8Device*                       pDevice,
-          D3DSTATEBLOCKTYPE                 Type,
+          D3D8StateBlockType                Type,
           Com<d3d9::IDirect3DStateBlock9>&& pStateBlock)
     : m_device(pDevice)
-    , m_stateBlock(std::move(pStateBlock))
-    , m_type(Type)
-    , m_isSWVP(pDevice->GetD3D9()->GetSoftwareVertexProcessing()) {
-    if (Type == D3DSBT_VERTEXSTATE || Type == D3DSBT_ALL) {
+    , m_stateBlock(std::move(pStateBlock)) {
+    if (Type == D3D8StateBlockType::All) {
+      m_captures.flags.set(D3D8CapturedStateFlag::Indices);
+      m_captures.flags.set(D3D8CapturedStateFlag::SWVP);
+
+      m_captures.flags.set(D3D8CapturedStateFlag::VertexBuffers);
+      m_captures.streams.setAll();
+
+      m_captures.flags.set(D3D8CapturedStateFlag::Textures);
+      m_captures.textures.setAll();
+    }
+
+    if (Type == D3D8StateBlockType::VertexState || Type == D3D8StateBlockType::All) {
       // Lights, D3DTSS_TEXCOORDINDEX and D3DTSS_TEXTURETRANSFORMFLAGS,
       // vertex shader, VS constants, and various render states.
-      m_capture.vs = true;
+      m_captures.flags.set(D3D8CapturedStateFlag::VertexShader);
     }
 
-    if (Type == D3DSBT_PIXELSTATE || Type == D3DSBT_ALL) {
+    if (Type == D3D8StateBlockType::PixelState || Type == D3D8StateBlockType::All) {
       // Pixel shader, PS constants, and various RS/TSS states.
-      m_capture.ps = true;
+      m_captures.flags.set(D3D8CapturedStateFlag::PixelShader);
     }
 
-    if (Type == D3DSBT_ALL) {
-      m_capture.indices = true;
-      m_capture.swvp    = true;
-      m_capture.textures.setAll();
-      m_capture.streams.setAll();
-    }
+    m_state.textures.fill(nullptr);
+    m_state.streams.fill(D3D8VBOP());
 
-    m_textures.fill(nullptr);
-    m_streams.fill(D3D8VBOP());
+    // Automatically capture state on creation via D3D8Device::CreateStateBlock.
+    if (Type != D3D8StateBlockType::None)
+      Capture();
   }
 
   // Construct a state block without a D3D9 object
   D3D8StateBlock::D3D8StateBlock(D3D8Device* pDevice)
-    : D3D8StateBlock(pDevice, D3DSTATEBLOCKTYPE(0), nullptr) {
+    : D3D8StateBlock(pDevice, D3D8StateBlockType::None, nullptr) {
   }
 
   // Attach a D3D9 object to a state block that doesn't have one yet
@@ -51,31 +57,38 @@ namespace dxvk {
     if (unlikely(m_stateBlock == nullptr))
       return D3DERR_INVALIDCALL;
 
-    if (m_capture.vs) m_device->GetVertexShader(&m_vertexShader);
-    if (m_capture.ps) m_device->GetPixelShader(&m_pixelShader);
-
-    for (DWORD stage = 0; stage < m_textures.size(); stage++) {
-      if (m_capture.textures.get(stage))
-        m_textures[stage] = m_device->m_textures[stage].ptr();
+    if (m_captures.flags.test(D3D8CapturedStateFlag::Indices)) {
+      m_state.baseVertexIndex = m_device->m_baseVertexIndex;
+      m_state.indices = m_device->m_indices.ptr();
     }
 
-    for (DWORD stream = 0; stream < m_streams.size(); stream++) {
-      if (m_capture.streams.get(stream)) {
-        m_streams[stream].buffer = m_device->m_streams[stream].buffer.ptr();
-        m_streams[stream].stride = m_device->m_streams[stream].stride;
+    if (m_captures.flags.test(D3D8CapturedStateFlag::SWVP)) {
+      DWORD swvpState;
+      m_device->GetRenderState(D3DRS_SOFTWAREVERTEXPROCESSING, &swvpState);
+      m_state.isSWVP = static_cast<bool>(swvpState);
+    }
+
+    if (m_captures.flags.test(D3D8CapturedStateFlag::VertexBuffers)) {
+      for (DWORD stream = 0; stream < m_state.streams.size(); stream++) {
+        if (m_captures.streams.get(stream)) {
+          m_state.streams[stream].buffer = m_device->m_streams[stream].buffer.ptr();
+          m_state.streams[stream].stride = m_device->m_streams[stream].stride;
+        }
       }
     }
 
-    if (m_capture.indices) {
-      m_baseVertexIndex = m_device->m_baseVertexIndex;
-      m_indices = m_device->m_indices.ptr();
+    if (m_captures.flags.test(D3D8CapturedStateFlag::Textures)) {
+      for (DWORD stage = 0; stage < m_state.textures.size(); stage++) {
+        if (m_captures.textures.get(stage))
+          m_state.textures[stage] = m_device->m_textures[stage].ptr();
+      }
     }
 
-    if (m_capture.swvp) {
-      DWORD swvpState;
-      m_device->GetRenderState(D3DRS_SOFTWAREVERTEXPROCESSING, &swvpState);
-      m_isSWVP = static_cast<bool>(swvpState);
-    }
+    if (m_captures.flags.test(D3D8CapturedStateFlag::VertexShader))
+      m_device->GetVertexShader(&m_state.vertexShaderHandle);
+
+    if (m_captures.flags.test(D3D8CapturedStateFlag::PixelShader))
+      m_device->GetPixelShader(&m_state.pixelShaderHandle);
 
     return m_stateBlock->Capture();
   }
@@ -86,25 +99,32 @@ namespace dxvk {
 
     HRESULT res = m_stateBlock->Apply();
 
-    if (m_capture.vs) m_device->SetVertexShader(m_vertexShader);
-    if (m_capture.ps) m_device->SetPixelShader(m_pixelShader);
-
-    for (DWORD stage = 0; stage < m_textures.size(); stage++) {
-      if (m_capture.textures.get(stage))
-        m_device->SetTexture(stage, m_textures[stage]);
-    }
-
-    for (DWORD stream = 0; stream < m_streams.size(); stream++) {
-      if (m_capture.streams.get(stream))
-        m_device->SetStreamSource(stream, m_streams[stream].buffer, m_streams[stream].stride);
-    }
-
-    if (m_capture.indices)
-      m_device->SetIndices(m_indices, m_baseVertexIndex);
+    if (m_captures.flags.test(D3D8CapturedStateFlag::Indices))
+      m_device->SetIndices(m_state.indices, m_state.baseVertexIndex);
 
     // This was a very easy footgun for D3D8 applications.
-    if (m_capture.swvp)
-      m_device->SetRenderState(D3DRS_SOFTWAREVERTEXPROCESSING, static_cast<DWORD>(m_isSWVP));
+    if (m_captures.flags.test(D3D8CapturedStateFlag::SWVP))
+      m_device->SetRenderState(D3DRS_SOFTWAREVERTEXPROCESSING, static_cast<DWORD>(m_state.isSWVP));
+
+    if (m_captures.flags.test(D3D8CapturedStateFlag::VertexBuffers)) {
+      for (DWORD stream = 0; stream < m_state.streams.size(); stream++) {
+        if (m_captures.streams.get(stream))
+          m_device->SetStreamSource(stream, m_state.streams[stream].buffer, m_state.streams[stream].stride);
+      }
+    }
+
+    if (m_captures.flags.test(D3D8CapturedStateFlag::Textures)) {
+      for (DWORD stage = 0; stage < m_state.textures.size(); stage++) {
+        if (m_captures.textures.get(stage))
+          m_device->SetTexture(stage, m_state.textures[stage]);
+      }
+    }
+
+    if (m_captures.flags.test(D3D8CapturedStateFlag::VertexShader))
+      m_device->SetVertexShader(m_state.vertexShaderHandle);
+
+    if (m_captures.flags.test(D3D8CapturedStateFlag::PixelShader))
+      m_device->SetPixelShader(m_state.pixelShaderHandle);
 
     return res;
   }

--- a/src/d3d8/d3d8_state_block.h
+++ b/src/d3d8/d3d8_state_block.h
@@ -6,30 +6,69 @@
 #include "d3d8_device_child.h"
 
 #include "../util/util_bit.h"
+#include "../util/util_flags.h"
 
 #include <array>
 
 namespace dxvk {
 
-  struct D3D8StateCapture {
-    bool vs       : 1;
-    bool ps       : 1;
-    bool indices  : 1;
-    bool swvp     : 1;
+  enum class D3D8CapturedStateFlag : uint8_t {
+    Indices,
+    SWVP,
+    VertexBuffers,
+    Textures,
+    VertexShader,
+    PixelShader
+  };
 
-    bit::bitset<d8caps::MAX_TEXTURE_STAGES> textures;
+  using D3D8CapturedStateFlags = Flags<D3D8CapturedStateFlag>;
+
+  struct D3D8StateCaptures {
+    D3D8CapturedStateFlags flags;
+
     bit::bitset<d8caps::MAX_STREAMS>        streams;
+    bit::bitset<d8caps::MAX_TEXTURE_STAGES> textures;
 
-    D3D8StateCapture()
-      : vs(false)
-      , ps(false)
-      , indices(false)
-      , swvp(false) {
+    D3D8StateCaptures() {
       // Ensure all bits are initialized to false
-      textures.clearAll();
       streams.clearAll();
+      textures.clearAll();
     }
   };
+
+  struct D3D8VBOP {
+    IDirect3DVertexBuffer8* buffer = nullptr;
+    UINT                    stride = 0;
+  };
+
+  struct D3D8CapturableState {
+    std::array<D3D8VBOP, d8caps::MAX_STREAMS>                      streams;
+    std::array<IDirect3DBaseTexture8*, d8caps::MAX_TEXTURE_STAGES> textures;
+
+    IDirect3DIndexBuffer8* indices = nullptr;
+    UINT  baseVertexIndex    = 0;
+    DWORD vertexShaderHandle = 0;
+    DWORD pixelShaderHandle  = 0;
+
+    bool isSWVP = false; // D3DRS_SOFTWAREVERTEXPROCESSING
+  };
+
+  enum class D3D8StateBlockType : uint8_t {
+    None,
+    All,
+    PixelState,
+    VertexState,
+    Unknown
+  };
+
+  inline D3D8StateBlockType ConvertStateBlockType(D3DSTATEBLOCKTYPE type) {
+    switch (type) {
+      case D3DSBT_ALL:         return D3D8StateBlockType::All;
+      case D3DSBT_PIXELSTATE:  return D3D8StateBlockType::PixelState;
+      case D3DSBT_VERTEXSTATE: return D3D8StateBlockType::VertexState;
+      default:                 return D3D8StateBlockType::Unknown;
+    }
+  }
 
   // Wrapper class for D3D9 state blocks. Captures D3D8-specific state.
   class D3D8StateBlock  {
@@ -38,7 +77,7 @@ namespace dxvk {
 
     D3D8StateBlock(
             D3D8Device*                       pDevice,
-            D3DSTATEBLOCKTYPE                 Type,
+            D3D8StateBlockType                Type,
             Com<d3d9::IDirect3DStateBlock9>&& pStateBlock);
 
     D3D8StateBlock(D3D8Device* pDevice);
@@ -49,43 +88,45 @@ namespace dxvk {
 
     HRESULT Apply();
 
-    inline HRESULT SetVertexShader(DWORD Handle) {
-      m_vertexShader  = Handle;
-      m_capture.vs    = true;
-      return D3D_OK;
-    }
-
-    inline HRESULT SetPixelShader(DWORD Handle) {
-      m_pixelShader = Handle;
-      m_capture.ps  = true;
-      return D3D_OK;
-    }
-
-    inline HRESULT SetTexture(DWORD Stage, IDirect3DBaseTexture8* pTexture) {
-      m_textures[Stage] = pTexture;
-      m_capture.textures.set(Stage, true);
-      return D3D_OK;
-    }
-
-    inline HRESULT SetStreamSource(UINT StreamNumber, IDirect3DVertexBuffer8* pStreamData, UINT Stride) {
-      m_streams[StreamNumber].buffer = pStreamData;
-      // The previous stride is preserved if pStreamData is NULL
-      if (likely(pStreamData != nullptr))
-        m_streams[StreamNumber].stride = Stride;
-      m_capture.streams.set(StreamNumber, true);
-      return D3D_OK;
-    }
-
     inline HRESULT SetIndices(IDirect3DIndexBuffer8* pIndexData, UINT BaseVertexIndex) {
-      m_indices         = pIndexData;
-      m_baseVertexIndex = BaseVertexIndex;
-      m_capture.indices = true;
+      m_state.indices = pIndexData;
+      m_state.baseVertexIndex = BaseVertexIndex;
+      m_captures.flags.set(D3D8CapturedStateFlag::Indices);
       return D3D_OK;
     }
 
     inline HRESULT SetSoftwareVertexProcessing(bool value) {
-      m_isSWVP       = value;
-      m_capture.swvp = true;
+      m_state.isSWVP = value;
+      m_captures.flags.set(D3D8CapturedStateFlag::SWVP);
+      return D3D_OK;
+    }
+
+    inline HRESULT SetStreamSource(UINT StreamNumber, IDirect3DVertexBuffer8* pStreamData, UINT Stride) {
+      m_state.streams[StreamNumber].buffer = pStreamData;
+      // The previous stride is preserved if pStreamData is NULL
+      if (likely(pStreamData != nullptr))
+        m_state.streams[StreamNumber].stride = Stride;
+      m_captures.flags.set(D3D8CapturedStateFlag::VertexBuffers);
+      m_captures.streams.set(StreamNumber, true);
+      return D3D_OK;
+    }
+
+    inline HRESULT SetTexture(DWORD Stage, IDirect3DBaseTexture8* pTexture) {
+      m_state.textures[Stage] = pTexture;
+      m_captures.flags.set(D3D8CapturedStateFlag::Textures);
+      m_captures.textures.set(Stage, true);
+      return D3D_OK;
+    }
+
+    inline HRESULT SetVertexShader(DWORD Handle) {
+      m_state.vertexShaderHandle = Handle;
+      m_captures.flags.set(D3D8CapturedStateFlag::VertexShader);
+      return D3D_OK;
+    }
+
+    inline HRESULT SetPixelShader(DWORD Handle) {
+      m_state.pixelShaderHandle = Handle;
+      m_captures.flags.set(D3D8CapturedStateFlag::PixelShader);
       return D3D_OK;
     }
 
@@ -93,27 +134,9 @@ namespace dxvk {
 
     D3D8Device*                     m_device;
     Com<d3d9::IDirect3DStateBlock9> m_stateBlock;
-    D3DSTATEBLOCKTYPE               m_type;
 
-    struct D3D8VBOP {
-      IDirect3DVertexBuffer8*       buffer = nullptr;
-      UINT                          stride = 0;
-    };
-
-    // State Data //
-
-    D3D8StateCapture m_capture;
-
-    DWORD m_vertexShader = 0;
-    DWORD m_pixelShader  = 0;
-
-    std::array<IDirect3DBaseTexture8*, d8caps::MAX_TEXTURE_STAGES>  m_textures;
-    std::array<D3D8VBOP, d8caps::MAX_STREAMS>                       m_streams;
-
-    IDirect3DIndexBuffer8*  m_indices         = nullptr;
-    UINT                    m_baseVertexIndex = 0;
-
-    bool m_isSWVP;  // D3DRS_SOFTWAREVERTEXPROCESSING
+    D3D8CapturableState m_state;
+    D3D8StateCaptures   m_captures;
 
   };
 

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -1735,7 +1735,9 @@ namespace dxvk {
             reg = diffuse;
             break;
           case D3DTA_SPECULAR:
-            reg = specular;
+            // Specular highlights shouldn't be calculated at all if D3DRS_SPECULARENABLE
+            // is set to FALSE, so return vec4(0.0) to ensure correctness during texture blending.
+            reg = m_fsKey.Stages[0].Contents.GlobalSpecularEnable ? specular : m_module.constvec4f32(0.0f, 0.0f, 0.0f, 0.0f);
             break;
           case D3DTA_TEMP:
             reg = temp;

--- a/src/d3d9/d3d9_stateblock.cpp
+++ b/src/d3d9/d3d9_stateblock.cpp
@@ -39,6 +39,8 @@ namespace dxvk {
 
 
   HRESULT STDMETHODCALLTYPE D3D9StateBlock::Capture() {
+    D3D9DeviceLock lock = m_parent->LockDevice();
+
     if (m_captures.flags.test(D3D9CapturedStateFlag::VertexDecl))
       SetVertexDeclaration(m_deviceState->vertexDecl.ptr());
 
@@ -49,6 +51,8 @@ namespace dxvk {
 
 
   HRESULT STDMETHODCALLTYPE D3D9StateBlock::Apply() {
+    D3D9DeviceLock lock = m_parent->LockDevice();
+
     m_applying = true;
 
     if (m_captures.flags.test(D3D9CapturedStateFlag::VertexDecl) && m_state.vertexDecl != nullptr)

--- a/src/d3d9/d3d9_stateblock.h
+++ b/src/d3d9/d3d9_stateblock.h
@@ -63,19 +63,20 @@ namespace dxvk {
     } psConsts;
   };
 
-  enum class D3D9StateBlockType :uint32_t {
+  enum class D3D9StateBlockType : uint8_t {
     None,
+    All,
     VertexState,
     PixelState,
-    All
+    Unknown
   };
 
   inline D3D9StateBlockType ConvertStateBlockType(D3DSTATEBLOCKTYPE type) {
     switch (type) {
+      case D3DSBT_ALL:         return D3D9StateBlockType::All;
       case D3DSBT_PIXELSTATE:  return D3D9StateBlockType::PixelState;
       case D3DSBT_VERTEXSTATE: return D3D9StateBlockType::VertexState;
-      default:
-      case D3DSBT_ALL:         return D3D9StateBlockType::All;
+      default:                 return D3D9StateBlockType::Unknown;
     }
   }
 

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1094,6 +1094,23 @@ namespace dxvk {
       { "d3d9.customDeviceId",              "0330" },
       { "d3d9.customDeviceDesc",            "NVIDIA GeForce FX 5900 Ultra" },
     }} },
+    /* Psi-Ops: The Mindgate Conspiracy           *
+     * Broken input and physics above 60 fps      */
+    { R"(\\PsiOps\.exe$)", {{
+      { "d3d9.maxFrameRate",                  "60" },
+    }} },
+    /* Alone in the Dark (2008)                   *
+     * Crashes when selecting the graphics menu   *
+     * option without memory tracking in place    */
+    { R"(\\Alone\.exe$)", {{
+      { "d3d9.memoryTrackTest",             "True" },
+    }} },
+    /* Heroes of Annihilated Empires              *
+     * Cursor and other animations play back too  *
+     * fast without a frame cap in place.         */
+    { R"(\\Heroes of Annihilated Empires.*\\engine\.exe$)", {{
+      { "d3d9.maxFrameRate",                  "60" },
+    }} },
 
     /**********************************************/
     /* D3D8 GAMES                                 */
@@ -1229,11 +1246,17 @@ namespace dxvk {
     { R"(\\fifa2003(demo)?\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
-    /* Splinter Cell: Pandora Tomorrow            *
-     * Broken inputs and physics above 60 FPS     */
-    { R"(\\SplinterCell2\.exe$)", {{
+    /* Splinter Cell: Pandora Tomorrow (Retail)   *
+     * Missing shadows without dref scaling and   *
+     * broken inputs and physics above 60 FPS     */
+    { R"(\\offline\\system\\SplinterCell2\.exe$)", {{
       { "d3d9.maxFrameRate",                  "60" },
       { "d3d8.scaleDref",                     "24" },
+    }} },
+    /* Splinter Cell: Pandora Tomorrow (Steam)    *
+     * Broken inputs and physics above 60 FPS     */
+    { R"(\\Splinter Cell Pandora Tomorrow\\system\\SplinterCell2\.exe$)", {{
+      { "d3d9.maxFrameRate",                  "60" },
     }} },
     /* Chrome: Gold Edition                       *
      * Broken character model motion at high FPS  */
@@ -1253,26 +1276,8 @@ namespace dxvk {
      { R"(\\splintercell\.exe$)", {{
       { "d3d9.customVendorId",              "10de" },
       { "d3d9.maxFrameRate",                  "60" },
-      { "d3d9.deviceLossOnFocusLoss",       "True" },
       { "d3d8.scaleDref",                     "24" },
       { "d3d8.shadowPerspectiveDivide",     "True" },
-    }} },
-    /* Trainz v1.3 (2001)                         *
-     * Fixes black screen after alt-tab           */
-    { R"(\\bin\\trainz\.exe$)", {{
-      { "d3d9.deviceLossOnFocusLoss",       "True" },
-    }} },
-    /* A.I.M.: Artificial Intelligence Machine    *
-     * Fixes black screen after the options       *
-     * window is closed or on alt-tab             */
-    { R"(\\AIM\.exe$)", {{
-      { "d3d9.deviceLossOnFocusLoss",       "True" },
-    }} },
-    /* Star Trek: Starfleet Command III           *
-     * The GOG release ships with a D3D8 to D3D9  *
-     * wrapper that leaks several surfaces.       */
-    { R"(\\SFC3\.exe$)", {{
-      { "d3d9.countLosableResources",      "False" },
     }} },
     /* GTR - FIA GT Racing Game                   *
      * Vram complaint & restricted resolutions    *
@@ -1294,6 +1299,16 @@ namespace dxvk {
      * legacy DISCARD behavior                    */
     { R"(\\TopSpin\.exe$)", {{
       { "d3d8.forceLegacyDiscard",          "True" },
+    }} },
+    /* Lego Racers 2 - Hits an incredible amount  *
+     * of queue syncs with direct buffer mapping  */
+    { R"(\\LEGO Racers 2\.exe$)", {{
+      { "d3d9.allowDirectBufferMapping",   "False" },
+    }} },
+    /* Smash Up Derby - Poor performance on Intel *
+     * due to queue syncs on certain race tracks  */
+    { R"(\\Smash up Derby\\cars\.exe$)", {{
+      { "d3d9.allowDirectBufferMapping",   "False" },
     }} },
   }};
 


### PR DESCRIPTION
A collection of relevant d3d8/9 fixes and improvements from upstream dxvk. I've also taken the liberty to clean up some config options/app profiles that made no sense for dxvk-sarek (I guess they snuck in before when I copy-pasted in bulk).