### PR TITLE
Fix color error on Windows

### DIFF
--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -1125,10 +1125,11 @@ namespace dxvk {
 
       case D3D9Format::A8R8G8B8:
       case D3D9Format::X8R8G8B8:
+        pDstFormats[n++] = { VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR };
+        break;
       case D3D9Format::A8B8G8R8:
       case D3D9Format::X8B8G8R8: {
         pDstFormats[n++] = { VK_FORMAT_R8G8B8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR };
-        pDstFormats[n++] = { VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR };
       } break;
 
       case D3D9Format::A2R10G10B10:


### PR DESCRIPTION
It’s prone to color display anomalies in the native Windows environment, and this commit fixes the issue.

在 Windows 原生环境下很容易出现颜色不对，这个提交修正了此情况。
没在 Linux+wine 的环境测试，估计这种情况不会出现？要不怎么都没人修呢？