### PR TITLE
[build] Fix d3d10 and ddraw dependencies

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,7 @@ fs = import('fs')
 
 cpp = meson.get_compiler('cpp')
 cc = meson.get_compiler('c')
-dxvk_is_msvc = cpp.get_id() == 'msvc'
+dxvk_is_msvc = cpp.get_argument_syntax() == 'msvc'
 
 compiler_args = [
   '-msse',
@@ -112,7 +112,6 @@ if platform == 'windows'
     )
   endif
 
-  dxvk_wsi = 'win32'
   compiler_args += ['-DDXVK_WSI_WIN32']
 endif
 

--- a/package-release.sh
+++ b/package-release.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+
 shopt -s extglob
 
 if [ -z "$1" ] || [ -z "$2" ]; then
@@ -9,9 +10,10 @@ if [ -z "$1" ] || [ -z "$2" ]; then
 fi
 
 DXVK_VERSION="$1"
-DXVK_SRC_DIR="$(dirname "$(readlink -f "$0")")"
-DXVK_BUILD_DIR="$(realpath "$2")/dxvk-$DXVK_VERSION"
-DXVK_ARCHIVE_PATH="$(realpath "$2")/dxvk-$DXVK_VERSION.tar.gz"
+DXVK_SRC_DIR=$(readlink -f "$0")
+DXVK_SRC_DIR=$(dirname "$DXVK_SRC_DIR")
+DXVK_BUILD_DIR=$(realpath "$2")"/dxvk-$DXVK_VERSION"
+DXVK_ARCHIVE_PATH=$(realpath "$2")"/dxvk-$DXVK_VERSION.tar.gz"
 
 if [ -e "$DXVK_BUILD_DIR" ]; then
   echo "Build directory $DXVK_BUILD_DIR already exists"
@@ -23,6 +25,8 @@ shift 2
 opt_nopackage=0
 opt_devbuild=0
 opt_buildid=false
+opt_64_only=0
+opt_32_only=0
 
 crossfile="build-win"
 
@@ -38,6 +42,12 @@ while [ $# -gt 0 ]; do
   "--build-id")
     opt_buildid=true
     ;;
+  "--64-only")
+    opt_64_only=1
+    ;;
+  "--32-only")
+    opt_32_only=1
+    ;;
   *)
     echo "Unrecognized option: $1" >&2
     exit 1
@@ -48,7 +58,7 @@ done
 function build_arch {
   export WINEARCH="win$1"
   export WINEPREFIX="$DXVK_BUILD_DIR/wine.$1"
-
+  
   cd "$DXVK_SRC_DIR"
 
   opt_strip=
@@ -82,8 +92,12 @@ function package {
   rm -R "dxvk-$DXVK_VERSION"
 }
 
-build_arch 64
-build_arch 32
+if [ $opt_32_only -eq 0 ]; then
+  build_arch 64
+fi
+if [ $opt_64_only -eq 0 ]; then
+  build_arch 32
+fi
 
 if [ $opt_nopackage -eq 0 ]; then
   package

--- a/src/d3d10/d3d10_core.cpp
+++ b/src/d3d10/d3d10_core.cpp
@@ -9,10 +9,14 @@ extern "C" {
   HRESULT __stdcall D3D11CoreCreateDevice(
           IDXGIFactory*       pFactory,
           IDXGIAdapter*       pAdapter,
+          D3D_DRIVER_TYPE     DriverType,
+          HMODULE             Software,
           UINT                Flags,
     const D3D_FEATURE_LEVEL*  pFeatureLevels,
           UINT                FeatureLevels,
-          ID3D11Device**      ppDevice);
+          UINT                SDKVersion,
+          ID3D11Device**      ppDevice,
+          D3D_FEATURE_LEVEL*  pFeatureLevel);
 
 
   DLLEXPORT HRESULT __stdcall D3D10CoreCreateDevice(
@@ -31,8 +35,8 @@ extern "C" {
     if (FAILED(hr))
       return hr;
 
-    hr = D3D11CoreCreateDevice(pFactory, pAdapter,
-      Flags, &FeatureLevel, 1, &d3d11Device);
+    hr = D3D11CoreCreateDevice(pFactory, pAdapter, D3D_DRIVER_TYPE_UNKNOWN,
+      nullptr, Flags, &FeatureLevel, 1, D3D11_SDK_VERSION, &d3d11Device, nullptr);
 
     if (FAILED(hr))
       return hr;

--- a/src/d3d10/meson.build
+++ b/src/d3d10/meson.build
@@ -6,7 +6,7 @@ d3d10_core_src = [
 
 d3d10_core_dll = shared_library('d3d10core'+dll_ext, d3d10_core_src, d3d10_core_res,
   name_prefix         : '',
-  dependencies        : [ d3d11_dep ],
+  dependencies        : [ lib_d3d11 ],
   include_directories : dxvk_include_path,
   install             : true,
   vs_module_defs      : 'd3d10core'+def_spec_ext,

--- a/src/ddraw/meson.build
+++ b/src/ddraw/meson.build
@@ -49,14 +49,13 @@ ddraw_src = [
 
 ddraw_dll = shared_library('ddraw'+dll_ext, ddraw_src, ddraw_res,
   name_prefix         : '',
-  dependencies        : [ util_dep, dxso_dep, dxvk_dep ],
+  dependencies        : [ lib_d3d9, util_dep, dxso_dep, dxvk_dep ],
   include_directories : dxvk_include_path,
   install             : true,
   vs_module_defs      : 'ddraw'+def_spec_ext,
-  link_with           : [ d3d9_dll ],
 )
 
 ddraw_dep = declare_dependency(
-  link_with           : [ ddraw_dll, d3d9_dll ],
+  link_with           : [ ddraw_dll ],
   include_directories : [ dxvk_include_path ],
 )

--- a/src/dxvk/meson.build
+++ b/src/dxvk/meson.build
@@ -58,7 +58,7 @@ dxvk_shaders = files([
   'hud/shaders/hud_text_vert.vert',
 ])
 
-dxvk_src = files([
+dxvk_src = [
   'dxvk_adapter.cpp',
   'dxvk_barrier.cpp',
   'dxvk_buffer.cpp',
@@ -115,7 +115,7 @@ dxvk_src = files([
   'hud/dxvk_hud_font.cpp',
   'hud/dxvk_hud_item.cpp',
   'hud/dxvk_hud_renderer.cpp',
-])
+]
 
 thread_dep = dependency('threads')
 


### PR DESCRIPTION
While I was building Sarek, I spotted a small derp in the D7VK DDraw meson script: it shouldn't link with `d3d9.dll` if `ddraw.dll` is compiled independently of the D3D9 module, but rather list the native d3d9 library as a dependency.

Going from there, I also spotted a similar derp (fixed upstream, probably ages ago) related to `d3d10core.dll` and addressed that as well.

Now there's two less steps to account for during compilation, and a couple of warnings are also gone.

Since I was looking over everything, I also ported back the upstream release script. It has some nice new flags for building only 32/64-bit, which are useful during testing.