### PR TITLE
[d3d7] Backport D7VK v2.0 to Sarek

### DIFF
--- a/src/ddraw/d3d3/d3d3_device.cpp
+++ b/src/ddraw/d3d3/d3d3_device.cpp
@@ -51,14 +51,6 @@ namespace dxvk {
         Logger::warn("D3D3Device: Force enabling AA");
         device9->SetRenderState(d3d9::D3DRS_MULTISAMPLEANTIALIAS, TRUE);
       }
-
-      // The default value of D3DRENDERSTATE_TEXTUREMAPBLEND in D3D3 is D3DTBLEND_MODULATE
-      device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
-      device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
-      device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
-      device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG1);
-      device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-      device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
     } else {
       device9 = m_commonD3DDevice->GetD3D9Device();
       // Very important, otherwise the depth stencil isn't dirtied on draws
@@ -122,47 +114,37 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Device::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> D3D3Device::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
     InitReturnPtr(ppvObject);
 
     if (unlikely(riid == __uuidof(IDirect3DDevice2))) {
-      if (likely(m_commonD3DDevice->GetD3D5Device() != nullptr)) {
-        Logger::debug("D3D3Device::QueryInterface: Query for existing IDirect3DDevice2");
+      if (likely(m_commonD3DDevice->GetD3D5Device() != nullptr))
         return m_commonD3DDevice->GetD3D5Device()->QueryInterface(riid, ppvObject);
-      }
 
       // A D3D3 device shouldn't be able to create a D3D5 device
       // if it doesn't previously exist as a parent/origin device
-      Logger::debug("D3D3Device::QueryInterface: Query for IDirect3DDevice2");
       return E_NOINTERFACE;
     }
     if (unlikely(riid == __uuidof(IDirect3DDevice3))) {
-      if (likely(m_commonD3DDevice->GetD3D6Device() != nullptr)) {
-        Logger::debug("D3D3Device::QueryInterface: Query for existing IDirect3DDevice3");
+      if (likely(m_commonD3DDevice->GetD3D6Device() != nullptr))
         return m_commonD3DDevice->GetD3D6Device()->QueryInterface(riid, ppvObject);
-      }
 
       // A D3D3 device shouldn't be able to create a D3D6 device
       // if it doesn't previously exist as a parent/origin device
-      Logger::debug("D3D3Device::QueryInterface: Query for IDirect3DDevice3");
       return E_NOINTERFACE;
     }
     // None of the below work when the object originates from a higher version device
     if (m_commonD3DDevice->GetOrigin() == this) {
       // If the device is created from a surface, then this must return E_NOINTERFACE
-      if (unlikely(riid == __uuidof(IDirect3DDevice))) {
-        Logger::debug("D3D3Device::QueryInterface: Query for IDirect3DDevice");
+      if (unlikely(riid == __uuidof(IDirect3DDevice)))
         return E_NOINTERFACE;
-      }
+
       // Apparently all of these should return a reference to the parent surface
       if (riid == IID_IDirect3DHALDevice  || riid == IID_IDirect3DRGBDevice  ||
           riid == IID_IDirect3DMMXDevice  || riid == IID_IDirect3DRampDevice ||
           riid == IID_WineD3DDevice) {
-        Logger::debug("D3D3Device::QueryInterface: Query with an IDirect3DDevice IID");
         *ppvObject = ref(m_parent);
         return S_OK;
       }
@@ -170,7 +152,6 @@ namespace dxvk {
       // IDirect3DDevice is quite different than any of the later device interfaces,
       // because it will also expose what is available on its parent surface. An easy
       // way to handle it, since the surface is its parent, is to forward the calls.
-      Logger::debug("D3D3Device::QueryInterface: Forwarding to parent surface");
       return m_parent->QueryInterface(riid, ppvObject);
     }
 
@@ -186,8 +167,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Device::GetCaps(D3DDEVICEDESC *hal_desc, D3DDEVICEDESC *hel_desc) {
-    Logger::debug(">>> D3D3Device::GetCaps");
-
     if (unlikely(hal_desc == nullptr || hel_desc == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -203,15 +182,18 @@ namespace dxvk {
     if (deviceGUID == IID_IDirect3DRGBDevice) {
       desc_HAL.dwFlags = 0;
       desc_HAL.dcmColorModel = 0;
-      // Some applications apparently care about RGB texture caps
+      // Some applications apparently care about HAL texture caps
       desc_HAL.dpcLineCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE
+                                          & ~D3DPTEXTURECAPS_POW2
                                           & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
       desc_HAL.dpcTriCaps.dwTextureCaps  &= ~D3DPTEXTURECAPS_PERSPECTIVE
+                                          & ~D3DPTEXTURECAPS_POW2
                                           & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
-      desc_HEL.dpcLineCaps.dwTextureCaps |= D3DPTEXTURECAPS_POW2;
-      desc_HEL.dpcTriCaps.dwTextureCaps  |= D3DPTEXTURECAPS_POW2;
     } else if (deviceGUID == IID_IDirect3DHALDevice) {
       desc_HEL.dcmColorModel = 0;
+      desc_HEL.dwDevCaps &= ~D3DDEVCAPS_HWTRANSFORMANDLIGHT
+                          & ~D3DDEVCAPS_DRAWPRIMITIVES2
+                          & ~D3DDEVCAPS_DRAWPRIMITIVES2EX;
     } else {
       Logger::warn("D3D3Device::GetCaps: Unhandled device type");
     }
@@ -224,8 +206,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D3Device::SwapTextureHandles(IDirect3DTexture *tex1, IDirect3DTexture *tex2) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D3Device::SwapTextureHandles");
 
     D3D3Texture* texture1 = static_cast<D3D3Texture*>(tex1);
     D3D3Texture* texture2 = static_cast<D3D3Texture*>(tex2);
@@ -251,8 +231,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D3Device::GetStats(D3DSTATS *stats) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D3Device::GetStats");
-
     if (unlikely(stats == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -270,8 +248,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D3Device::AddViewport(IDirect3DViewport *viewport) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D3Device::AddViewport");
-
     if (unlikely(viewport == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -282,8 +258,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D3Device::DeleteViewport(IDirect3DViewport *viewport) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D3Device::DeleteViewport");
 
     if (unlikely(viewport == nullptr))
       return DDERR_INVALIDPARAMS;
@@ -300,8 +274,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D3Device::NextViewport(IDirect3DViewport *lpDirect3DViewport, IDirect3DViewport **lplpAnotherViewport, DWORD flags) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D3Device::NextViewport");
 
     if (unlikely(lplpAnotherViewport == nullptr))
       return DDERR_INVALIDPARAMS;
@@ -326,8 +298,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Device::EnumTextureFormats(LPD3DENUMTEXTUREFORMATSCALLBACK cb, void *ctx) {
-    Logger::debug(">>> D3D3Device::EnumTextureFormats");
-
     if (unlikely(cb == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -392,8 +362,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D3Device::BeginScene() {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D3Device::BeginScene");
-
     RefreshLastUsedDevice();
 
     if (unlikely(m_commonD3DDevice->IsInScene()))
@@ -411,8 +379,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D3Device::EndScene() {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D3Device::EndScene");
-
     RefreshLastUsedDevice();
 
     if (unlikely(!m_commonD3DDevice->IsInScene()))
@@ -428,8 +394,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Device::GetDirect3D(IDirect3D **d3d) {
-    Logger::debug(">>> D3D3Device::GetDirect3D");
-
     if (unlikely(d3d == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -450,8 +414,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Device::Initialize(IDirect3D *d3d, GUID *lpGUID, D3DDEVICEDESC *desc) {
-    Logger::debug(">>> D3D3Device::Initialize");
-
     if (unlikely(d3d == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -459,8 +421,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Device::CreateExecuteBuffer(D3DEXECUTEBUFFERDESC *desc, IDirect3DExecuteBuffer **buffer, IUnknown *pkOuter) {
-    Logger::debug(">>> D3D3Device::CreateExecuteBuffer");
-
     if (unlikely(desc == nullptr || buffer == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -476,8 +436,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D3Device::Execute(IDirect3DExecuteBuffer *buffer, IDirect3DViewport *viewport, DWORD flags) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D3Device::Execute");
 
     if (unlikely(buffer == nullptr || viewport == nullptr))
       return DDERR_INVALIDPARAMS;
@@ -531,8 +489,6 @@ namespace dxvk {
 
       switch (instruction->bOpcode) {
         case D3DOP_BRANCHFORWARD: {
-          Logger::debug("D3D3Device::Execute: D3DOP_BRANCHFORWARD");
-
           D3DBRANCH* branch = reinterpret_cast<D3DBRANCH*>(operation);
           for (uint16_t i = 0; i < instruction->wCount; i++) {
             const D3DBRANCH& b = branch[i];
@@ -553,8 +509,6 @@ namespace dxvk {
           break;
         }
         case D3DOP_LINE: {
-          Logger::debug("D3D3Device::Execute: D3DOP_LINE");
-
           D3DLINE* line = reinterpret_cast<D3DLINE*>(operation);
           DrawLineInternal(line, instruction->wCount, executeData->dwVertexCount, hVertexBuffer);
 
@@ -562,8 +516,6 @@ namespace dxvk {
           break;
         }
         case D3DOP_POINT: {
-          Logger::debug("D3D3Device::Execute: D3DOP_POINT");
-
           D3DPOINT* point = reinterpret_cast<D3DPOINT*>(operation);
           DrawPointInternal(point, instruction->wCount, executeData->dwVertexCount, hVertexBuffer);
 
@@ -571,8 +523,6 @@ namespace dxvk {
           break;
         }
         case D3DOP_TRIANGLE: {
-          Logger::debug("D3D3Device::Execute: D3DOP_TRIANGLE");
-
           D3DTRIANGLE* triangle = reinterpret_cast<D3DTRIANGLE*>(operation);
           DrawTriangleInternal(triangle, instruction->wCount, executeData->dwVertexCount, hVertexBuffer);
 
@@ -580,8 +530,6 @@ namespace dxvk {
           break;
         }
         case D3DOP_MATRIXLOAD: {
-          Logger::debug("D3D3Device::Execute: D3DOP_MATRIXLOAD");
-
           D3DMATRIXLOAD* matrixLoad = reinterpret_cast<D3DMATRIXLOAD*>(operation);
 
           for (uint16_t i = 0; i < instruction->wCount; i++) {
@@ -603,8 +551,6 @@ namespace dxvk {
           break;
         }
         case D3DOP_MATRIXMULTIPLY: {
-          Logger::warn("D3D3Device::Execute: D3DOP_MATRIXMULTIPLY");
-
           D3DMATRIXMULTIPLY* matrixMultiply = reinterpret_cast<D3DMATRIXMULTIPLY*>(operation);
 
           for (uint16_t i = 0; i < instruction->wCount; i++) {
@@ -645,9 +591,7 @@ namespace dxvk {
 
             switch (op) {
               case D3DPROCESSVERTICES_COPY: {
-                Logger::debug("D3D3Device::Execute: D3DOP_PROCESSVERTICES COPY");
                 memcpy(&hVertexBuffer[pv.wDest], &vertexBuffer[pv.wStart], sizeof(D3DTLVERTEX) * pv.dwCount);
-
                 break;
               }
               case D3DPROCESSVERTICES_TRANSFORM:
@@ -655,8 +599,6 @@ namespace dxvk {
                 // "If the rendering device does not have a material assigned to it, the Direct3D lighting engine is disabled."
                 const bool doLighting = op == D3DPROCESSVERTICES_TRANSFORMLIGHT &&
                                         m_commonD3DDevice->GetCurrentMaterialHandle() != 0;
-
-                Logger::debug(str::format("D3D3Device::Execute: D3DOP_PROCESSVERTICES ", doLighting ? "TRANSFORMLIGHT" : "TRANSFORM"));
 
                 D3DCommonViewport* commonViewport = m_currentViewport->GetCommonViewport();
 
@@ -695,8 +637,6 @@ namespace dxvk {
           break;
         }
         case D3DOP_SPAN: {
-          Logger::warn("D3D3Device::Execute: D3DOP_SPAN");
-
           D3DSPAN* span = reinterpret_cast<D3DSPAN*>(operation);
           DrawSpanInternal(span, instruction->wCount, executeData->dwVertexCount, hVertexBuffer);
 
@@ -704,8 +644,6 @@ namespace dxvk {
           break;
         }
         case D3DOP_STATELIGHT: {
-          Logger::debug("D3D3Device::Execute: D3DOP_STATELIGHT");
-
           D3DSTATE* state = reinterpret_cast<D3DSTATE*>(operation);
 
           for (uint16_t i = 0; i < instruction->wCount; i++) {
@@ -717,8 +655,6 @@ namespace dxvk {
           break;
         }
         case D3DOP_STATERENDER: {
-          Logger::debug("D3D3Device::Execute: D3DOP_STATERENDER");
-
           D3DSTATE* state = reinterpret_cast<D3DSTATE*>(operation);
 
           for (uint16_t i = 0; i < instruction->wCount; i++) {
@@ -730,8 +666,6 @@ namespace dxvk {
           break;
         }
         case D3DOP_STATETRANSFORM: {
-          Logger::debug("D3D3Device::Execute: D3DOP_STATETRANSFORM");
-
           D3DSTATE* state = reinterpret_cast<D3DSTATE*>(operation);
           D3DMATRIX matrix;
 
@@ -763,8 +697,6 @@ namespace dxvk {
           break;
         }
         case D3DOP_SETSTATUS: {
-          Logger::debug("D3D3Device::Execute: D3DOP_SETSTATUS");
-
           D3DSTATUS* status = reinterpret_cast<D3DSTATUS*>(operation);
           for (uint16_t i = 0; i < instruction->wCount; i++) {
             executeData->dsStatus = status[i];
@@ -774,8 +706,6 @@ namespace dxvk {
           break;
         }
         case D3DOP_TEXTURELOAD: {
-          Logger::debug("D3D3Device::Execute: D3DOP_TEXTURELOAD");
-
           D3DTEXTURELOAD* textureLoad = reinterpret_cast<D3DTEXTURELOAD*>(operation);
           TextureLoadInternal(textureLoad, instruction->wCount);
 
@@ -828,8 +758,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D3Device::CreateMatrix(D3DMATRIXHANDLE *matrix) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D3Device::CreateMatrix");
-
     m_matrixHandle++;
     m_matrices.emplace(std::piecewise_construct,
                        std::forward_as_tuple(m_matrixHandle),
@@ -842,8 +770,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D3Device::SetMatrix(D3DMATRIXHANDLE handle, D3DMATRIX *matrix) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D3Device::SetMatrix");
 
     if (unlikely(matrix == nullptr))
       return DDERR_INVALIDPARAMS;
@@ -880,8 +806,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D3Device::GetMatrix(D3DMATRIXHANDLE handle, D3DMATRIX *matrix) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D3Device::GetMatrix");
-
     if (unlikely(matrix == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -899,8 +823,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D3Device::DeleteMatrix(D3DMATRIXHANDLE D3DMatHandle) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D3Device::DeleteMatrix");
 
     auto matrixIter = m_matrices.find(D3DMatHandle);
 
@@ -930,16 +852,12 @@ namespace dxvk {
     m_ds = m_rt->GetAttachedDepthStencil();
 
     if (m_ds != nullptr) {
-      Logger::debug("D3D3Device::InitializeDS: Found an attached DS");
-
       HRESULT hrDS = m_ds->InitializeD3D9DepthStencil();
       if (unlikely(FAILED(hrDS))) {
         Logger::err("D3D3Device::InitializeDS: Failed to initialize D3D9 DS");
       } else {
-        Logger::info("D3D3Device::InitializeDS: Got depth stencil from RT");
-
         const RECT* dsRect = m_ds->GetCommonSurface()->GetFullSurfaceRect();
-        Logger::debug(str::format("D3D3Device::InitializeDS: DepthStencil: ", dsRect->right, "x", dsRect->bottom));
+        Logger::info(str::format("D3D3Device::InitializeDS: Depth stencil: ", dsRect->right, "x", dsRect->bottom));
 
         HRESULT hrDS9 = device9->SetDepthStencilSurface(m_ds->GetCommonSurface()->GetD3D9Surface());
         if (unlikely(FAILED(hrDS9))) {
@@ -950,7 +868,6 @@ namespace dxvk {
         }
       }
     } else {
-      Logger::info("D3D3Device::InitializeDS: RT has no depth stencil attached");
       device9->SetDepthStencilSurface(nullptr);
       // Should be superfluous, but play it safe
       device9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_FALSE);
@@ -1013,14 +930,14 @@ namespace dxvk {
   }
 
   inline HRESULT STDMETHODCALLTYPE D3D3Device::SetLightStateInternal(D3DLIGHTSTATETYPE dwLightStateType, DWORD dwLightState) {
-    Logger::debug(">>> D3D3Device::SetLightStateInternal");
-
     d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     switch (dwLightStateType) {
       case D3DLIGHTSTATE_MATERIAL: {
         if (unlikely(!dwLightState)) {
           m_commonD3DDevice->SetCurrentMaterialHandle(dwLightState);
+          static constexpr d3d9::D3DMATERIAL9 DefaultMaterial9 = { };
+          device9->SetMaterial(&DefaultMaterial9);
           return D3D_OK;
         }
 
@@ -1029,7 +946,7 @@ namespace dxvk {
           return DDERR_INVALIDPARAMS;
 
         m_commonD3DDevice->SetCurrentMaterialHandle(dwLightState);
-        Logger::debug(str::format("D3D3Device::SetLightStateInternal: Applying material nr. ", dwLightState, " to D3D9"));
+        //Logger::debug(str::format("D3D3Device::SetLightStateInternal: Applying material nr. ", dwLightState, " to D3D9"));
         device9->SetMaterial(material9);
 
         break;
@@ -1061,14 +978,10 @@ namespace dxvk {
   }
 
   inline HRESULT STDMETHODCALLTYPE D3D3Device::SetRenderStateInternal(D3DRENDERSTATETYPE dwRenderStateType, DWORD dwRenderState) {
-    Logger::debug(str::format(">>> D3D3Device::SetRenderStateInternal: ", dwRenderStateType));
-
     // As opposed to D3D7, D3D3 does not error out on
     // unknown or invalid render states.
-    if (unlikely(!IsValidD3D3RenderStateType(dwRenderStateType))) {
-      Logger::debug(str::format("D3D3Device::SetRenderStateInternal: Invalid render state ", dwRenderStateType));
+    if (unlikely(!IsValidD3D3RenderStateType(dwRenderStateType)))
       return D3D_OK;
-    }
 
     d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
     d3d9::D3DRENDERSTATETYPE State9 = d3d9::D3DRENDERSTATETYPE(dwRenderStateType);
@@ -1152,19 +1065,9 @@ namespace dxvk {
         return D3D_OK;
 
       case D3DRENDERSTATE_MONOENABLE:
-        static bool s_monoEnableErrorShown;
-
-        if (dwRenderState && !std::exchange(s_monoEnableErrorShown, true))
-          Logger::warn("D3D3Device::SetRenderStateInternal: Unimplemented render state D3DRENDERSTATE_MONOENABLE");
-
         return D3D_OK;
 
       case D3DRENDERSTATE_ROP2:
-        static bool s_ROP2ErrorShown;
-
-        if (!std::exchange(s_ROP2ErrorShown, true))
-          Logger::warn("D3D3Device::SetRenderStateInternal: Unimplemented render state D3DRENDERSTATE_ROP2");
-
         return D3D_OK;
 
       // "This render state is not supported by the software rasterizers, and is often ignored by hardware drivers."
@@ -1248,8 +1151,8 @@ namespace dxvk {
             device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
             device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
             device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG1);
-            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_CURRENT);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_CURRENT);
             break;
           // "In this mode, the RGB and alpha values of the texture are blended with the colors
           //  that would have been used with no texturing, according to the following formulas [...]"
@@ -1258,8 +1161,8 @@ namespace dxvk {
             device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
             device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_BLENDTEXTUREALPHA);
             device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG2);
-            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_CURRENT);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_CURRENT);
             break;
           // "In this mode, the RGB values of the texture are multiplied with the RGB values that
           //  would have been used with no texturing, and the alpha values of the texture
@@ -1269,8 +1172,8 @@ namespace dxvk {
             device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
             device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
             device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_MODULATE);
-            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_CURRENT);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_CURRENT);
             break;
           // "Add the Gouraud interpolants to the texture lookup with saturation semantics
           //  (that is, if the color value overflows it is set to the maximum possible value)."
@@ -1279,8 +1182,8 @@ namespace dxvk {
             device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
             device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_ADD);
             device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG2);
-            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_CURRENT);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_CURRENT);
             break;
           // Unsupported
           default:
@@ -1309,27 +1212,15 @@ namespace dxvk {
       case D3DRENDERSTATE_SUBPIXELX:
         return D3D_OK;
 
-      // Tests have shown age accurate GPUs didn't offer support for
-      // stippling at all, so this should be safe to ignore
+      // Tests have shown age accurate GPUs didn't offer support for stippling at all
       case D3DRENDERSTATE_STIPPLEDALPHA:
-        static bool s_stippledAlphaErrorShown;
-
-        if (dwRenderState && !std::exchange(s_stippledAlphaErrorShown, true))
-          Logger::warn("D3D3Device::SetRenderStateInternal: Unimplemented render state D3DRENDERSTATE_STIPPLEDALPHA");
-
         return D3D_OK;
 
-      // Tests have shown age accurate GPUs didn't offer support for
-      // stippling at all, so this should be safe to ignore
+      // Tests have shown age accurate GPUs didn't offer support for stippling at all
       case D3DRENDERSTATE_STIPPLEENABLE:
-        static bool s_stippleEnableErrorShown;
-
-        if (dwRenderState && !std::exchange(s_stippleEnableErrorShown, true))
-          Logger::warn("D3D3Device::SetRenderStateInternal: Unimplemented render state D3DRENDERSTATE_STIPPLEENABLE");
-
         return D3D_OK;
 
-      // TODO:
+      // Tests have shown age accurate GPUs didn't offer support for stippling at all
       case D3DRENDERSTATE_STIPPLEPATTERN00:
       case D3DRENDERSTATE_STIPPLEPATTERN01:
       case D3DRENDERSTATE_STIPPLEPATTERN02:
@@ -1362,11 +1253,6 @@ namespace dxvk {
       case D3DRENDERSTATE_STIPPLEPATTERN29:
       case D3DRENDERSTATE_STIPPLEPATTERN30:
       case D3DRENDERSTATE_STIPPLEPATTERN31:
-        static bool s_stipplePatternErrorShown;
-
-        if (!std::exchange(s_stipplePatternErrorShown, true))
-          Logger::warn("D3D3Device::SetRenderStateInternal: Unimplemented render state D3DRENDERSTATE_STIPPLEPATTERN");
-
         return D3D_OK;
     }
 
@@ -1384,13 +1270,8 @@ namespace dxvk {
     for (uint16_t i = 0; i < count; i++) {
       const D3DTRIANGLE& t = triangle[i];
 
-      if (t.v1 >= vertexCount || t.v2 >= vertexCount || t.v3 >= vertexCount) {
-        static bool s_skipErrorShown;
-        if (!std::exchange(s_skipErrorShown, true))
-          Logger::warn(str::format("D3D3Device::Execute: D3DOP_TRIANGLE skipping triangles draw"));
-
+      if (t.v1 >= vertexCount || t.v2 >= vertexCount || t.v3 >= vertexCount)
         continue;
-      }
 
       // TODO: Ignoring t.wFlags for now as they are relevant only for wireframe mode?
       // (D3DTRIFLAG_START, D3DTRIFLAG_STARTFLAT(1-29), D3DTRIFLAG_ODD(strip),
@@ -1411,8 +1292,6 @@ namespace dxvk {
 
       if (SUCCEEDED(hr)) {
         UpdateSurfaceDirtyTracking(true, true, true);
-
-        Logger::debug(str::format("D3D3Device::Execute: D3DOP_TRIANGLE drawn vertices: ", vertices.size()));
         m_stats.dwTrianglesDrawn += std::max<DWORD>(vertices.size() / 3, 0u);
       } else {
         Logger::err(str::format("D3D3Device::Execute: D3DOP_TRIANGLE failed to draw vertices: ", vertices.size()));
@@ -1449,8 +1328,6 @@ namespace dxvk {
 
       if (SUCCEEDED(hr)) {
         UpdateSurfaceDirtyTracking(true, true, true);
-
-        Logger::debug(str::format("D3D3Device::Execute: D3DOP_LINE drawn vertices: ", vertices.size()));
         m_stats.dwLinesDrawn += std::max<DWORD>(vertices.size() / 2, 0u);
       } else {
         Logger::err(str::format("D3D3Device::Execute: D3DOP_LINE failed to draw vertices: ", vertices.size()));
@@ -1488,8 +1365,6 @@ namespace dxvk {
 
       if (SUCCEEDED(hr)) {
         UpdateSurfaceDirtyTracking(true, true, true);
-
-        Logger::debug(str::format("D3D3Device::Execute: D3DOP_POINT drawn vertices: ", vertices.size()));
         m_stats.dwPointsDrawn += static_cast<DWORD>(vertices.size());
       } else {
         Logger::err(str::format("D3D3Device::Execute: D3DOP_POINT failed to draw vertices: ", vertices.size()));
@@ -1526,8 +1401,6 @@ namespace dxvk {
 
       if (SUCCEEDED(hr)) {
         UpdateSurfaceDirtyTracking(true, true, true);
-
-        Logger::debug(str::format("D3D3Device::Execute: D3DOP_SPAN drawn vertices: ", vertices.size()));
         m_stats.dwSpansDrawn += std::max<DWORD>(vertices.size() - 1, 0u);
       } else {
         Logger::err(str::format("D3D3Device::Execute: D3DOP_SPAN failed to draw vertices: ", vertices.size()));
@@ -1552,31 +1425,23 @@ namespace dxvk {
   }
 
   inline HRESULT D3D3Device::SetTextureInternal(DDrawSurface* surface, DWORD textureHandle) {
-    Logger::debug(">>> D3D3Device::SetTextureInternal");
-
     HRESULT hr;
 
     d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     // Unbinding texture stages
     if (surface == nullptr) {
-      Logger::debug("D3D3Device::SetTextureInternal: Unbiding D3D9 texture");
-
       hr = device9->SetTexture(0, nullptr);
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D3Device::SetTextureInternal: Failed to unbind D3D9 texture");
         return hr;
       }
 
-      if (likely(m_commonD3DDevice->GetCurrentTextureHandle() != 0)) {
-        Logger::debug("D3D3Device::SetTextureInternal: Unbinding local texture");
+      if (likely(m_commonD3DDevice->GetCurrentTextureHandle() != 0))
         m_commonD3DDevice->SetCurrentTextureHandle(0);
-      }
 
       return D3D_OK;
     }
-
-    Logger::debug("D3D3Device::SetTextureInternal: Binding D3D9 texture");
 
     // If textures have been used on a different device, they
     // will get their D3D9 object reinitialized at this point
@@ -1614,7 +1479,6 @@ namespace dxvk {
       const bool validColorKey = surface->GetCommonSurface()->HasValidColorKey();
       m_bridge->SetColorKeyState(validColorKey);
       if (validColorKey) {
-        Logger::debug("D3D3Device::SetTextureInternal: Enabling color key transparency");
         DDCOLORKEY normalizedColorKey = surface->GetCommonSurface()->GetColorKeyNormalized();
         m_bridge->SetColorKey(normalizedColorKey.dwColorSpaceLowValue,
                               normalizedColorKey.dwColorSpaceHighValue);

--- a/src/ddraw/d3d3/d3d3_execute_buffer.cpp
+++ b/src/ddraw/d3d3/d3d3_execute_buffer.cpp
@@ -10,7 +10,7 @@ namespace dxvk {
     : DDrawChildObject<D3D3Device, IDirect3DExecuteBuffer>(pParent) {
     if (likely(pDesc->dwFlags & D3DDEB_BUFSIZE)) {
       m_buffer.resize(pDesc->dwBufferSize);
-      Logger::debug(str::format("D3D3ExecuteBuffer: Buffer is initialized with size ", pDesc->dwBufferSize));
+      Logger::debug(str::format("D3D3ExecuteBuffer: Buffer is initialized with size: ", pDesc->dwBufferSize));
     } else {
       Logger::warn("D3D3ExecuteBuffer: No buffer size specified during initialization");
     }
@@ -25,8 +25,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D3ExecuteBuffer::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">> D3D3ExecuteBuffer::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
@@ -49,8 +47,6 @@ namespace dxvk {
     if (unlikely(m_executed))
       lock = m_parent->LockDevice();
 
-    Logger::debug(">>> D3D3ExecuteBuffer::GetExecuteData");
-
     if (unlikely(lpData == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -65,7 +61,6 @@ namespace dxvk {
   // Docs state: "Returns DDERR_ALREADYINITIALIZED because the
   // Direct3DExecuteBuffer object is initialized when it is created."
   HRESULT STDMETHODCALLTYPE D3D3ExecuteBuffer::Initialize(LPDIRECT3DDEVICE lpDirect3DDevice, LPD3DEXECUTEBUFFERDESC lpDesc) {
-    Logger::debug(">>> D3D3ExecuteBuffer::Initialize");
     return DDERR_ALREADYINITIALIZED;
   }
 
@@ -74,8 +69,6 @@ namespace dxvk {
 
     if (unlikely(m_executed))
       lock = m_parent->LockDevice();
-
-    Logger::debug(">>> D3D3ExecuteBuffer::Lock");
 
     if (unlikely(lpDesc == nullptr))
       return DDERR_INVALIDPARAMS;
@@ -97,7 +90,6 @@ namespace dxvk {
 
   // Docs state: "Not currently implemented."
   HRESULT STDMETHODCALLTYPE D3D3ExecuteBuffer::Optimize(DWORD dwUnknown) {
-    Logger::debug(">>> D3D3ExecuteBuffer::Optimize");
     return DDERR_UNSUPPORTED;
   }
 
@@ -106,8 +98,6 @@ namespace dxvk {
 
     if (unlikely(m_executed))
       lock = m_parent->LockDevice();
-
-    Logger::debug(">>> D3D3ExecuteBuffer::SetExecuteData");
 
     if (unlikely(lpData == nullptr || m_buffer.size() == 0))
       return DDERR_INVALIDPARAMS;
@@ -129,8 +119,6 @@ namespace dxvk {
     if (unlikely(m_executed))
       lock = m_parent->LockDevice();
 
-    Logger::debug(">>> D3D3ExecuteBuffer::Unlock");
-
     if (unlikely(!m_locked))
       return D3DERR_EXECUTE_NOT_LOCKED;
 
@@ -141,7 +129,6 @@ namespace dxvk {
 
   // Docs state: "Not currently implemented."
   HRESULT STDMETHODCALLTYPE D3D3ExecuteBuffer::Validate(LPDWORD lpdwOffset, LPD3DVALIDATECALLBACK lpFunc, LPVOID lpUserArg, DWORD dwReserved) {
-    Logger::debug(">>> D3D3ExecuteBuffer::Validate");
     return DDERR_UNSUPPORTED;
   }
 

--- a/src/ddraw/d3d3/d3d3_interface.cpp
+++ b/src/ddraw/d3d3/d3d3_interface.cpp
@@ -86,37 +86,27 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Interface::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> D3D3Interface::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
     InitReturnPtr(ppvObject);
 
     if (riid == __uuidof(IDirectDraw)) {
-      Logger::debug("D3D3Interface::QueryInterface: Query for IDirectDraw");
       return m_parent->QueryInterface(riid, ppvObject);
     }
     // Deathtrap Dungeon queries for IDirect3D2...
     if (unlikely(riid == __uuidof(IDirect3D2))) {
-      if (likely(m_commonD3DIntf->GetD3D5Interface() != nullptr)) {
-        Logger::debug("D3D3Interface::QueryInterface: Query for existing IDirect3D2");
+      if (likely(m_commonD3DIntf->GetD3D5Interface() != nullptr))
         return m_commonD3DIntf->GetD3D5Interface()->QueryInterface(riid, ppvObject);
-      }
 
-      Logger::debug("D3D3Interface::QueryInterface: Query for IDirect3D2");
       m_d3d5Intf = new D3D5Interface(m_commonD3DIntf.ptr(), m_commonIntf, m_parent);
       *ppvObject = m_d3d5Intf.ref();
       return S_OK;
     }
     // ... and Final Fantasy VIII queries for IDirect3D3, because why not...
     if (unlikely(riid == __uuidof(IDirect3D3))) {
-      if (likely(m_commonD3DIntf->GetD3D6Interface() != nullptr)) {
-        Logger::debug("D3D3Interface::QueryInterface: Query for existing IDirect3D3");
+      if (likely(m_commonD3DIntf->GetD3D6Interface() != nullptr))
         return m_commonD3DIntf->GetD3D6Interface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("D3D3Interface::QueryInterface: Query for IDirect3D3");
 
       // We don't have a proxied object on D3D3Interface, so use the parent
       // DDraw interface to get a proxied object for the queried D3D6Interface
@@ -144,13 +134,10 @@ namespace dxvk {
   // Docs state: "This method is provided for compliance with the COM protocol.
   // Returns DDERR_ALREADYINITIALIZED because the Direct3D object is initialized when it is created."
   HRESULT STDMETHODCALLTYPE D3D3Interface::Initialize(REFIID riid) {
-    Logger::debug(">>> D3D3Interface::Initialize");
     return DDERR_ALREADYINITIALIZED;
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Interface::EnumDevices(LPD3DENUMDEVICESCALLBACK lpEnumDevicesCallback, LPVOID lpUserArg) {
-    Logger::debug(">>> D3D3Interface::EnumDevices");
-
     if (unlikely(lpEnumDevicesCallback == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -175,13 +162,13 @@ namespace dxvk {
     desc3RAMP_HAL.dcmColorModel = 0;
     // RAMP devices use a monochrome color model
     desc3RAMP_HEL.dcmColorModel = D3DCOLOR_MONO;
-    // Some applications apparently care about RGB texture caps
+    // Some applications apparently care about HAL texture caps
     desc3RAMP_HAL.dpcLineCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                            & ~D3DPTEXTURECAPS_POW2;
+                                             & ~D3DPTEXTURECAPS_POW2
+                                             & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
     desc3RAMP_HAL.dpcTriCaps.dwTextureCaps  &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                            & ~D3DPTEXTURECAPS_POW2;
-    desc3RAMP_HEL.dpcLineCaps.dwTextureCaps |= D3DPTEXTURECAPS_POW2;
-    desc3RAMP_HEL.dpcTriCaps.dwTextureCaps  |= D3DPTEXTURECAPS_POW2;
+                                             & ~D3DPTEXTURECAPS_POW2
+                                             & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
     memcpy(&descRAMP_HAL, &desc3RAMP_HAL, sizeof(D3DDEVICEDESC3));
     memcpy(&descRAMP_HEL, &desc3RAMP_HEL, sizeof(D3DDEVICEDESC3));
     if (likely(!d3dOptions->legacyDeviceNames)) {
@@ -206,13 +193,13 @@ namespace dxvk {
     D3DDEVICEDESC descRGB_HEL = { };
     desc3RGB_HAL.dwFlags = 0;
     desc3RGB_HAL.dcmColorModel = 0;
-    // Some applications apparently care about RGB texture caps
+    // Some applications apparently care about HAL texture caps
     desc3RGB_HAL.dpcLineCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                            & ~D3DPTEXTURECAPS_POW2;
+                                            & ~D3DPTEXTURECAPS_POW2
+                                            & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
     desc3RGB_HAL.dpcTriCaps.dwTextureCaps  &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                            & ~D3DPTEXTURECAPS_POW2;
-    desc3RGB_HEL.dpcLineCaps.dwTextureCaps |= D3DPTEXTURECAPS_POW2;
-    desc3RGB_HEL.dpcTriCaps.dwTextureCaps  |= D3DPTEXTURECAPS_POW2;
+                                            & ~D3DPTEXTURECAPS_POW2
+                                            & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
     memcpy(&descRGB_HAL, &desc3RGB_HAL, sizeof(D3DDEVICEDESC3));
     memcpy(&descRGB_HEL, &desc3RGB_HEL, sizeof(D3DDEVICEDESC3));
 
@@ -237,11 +224,13 @@ namespace dxvk {
     D3DDEVICEDESC descHAL_HAL = { };
     D3DDEVICEDESC descHAL_HEL = { };
     desc3HAL_HEL.dcmColorModel = 0;
-    // Some applications apparently care about RGB texture caps
+    // Some applications apparently care about HEL texture caps
     desc3HAL_HEL.dpcLineCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                            & ~D3DPTEXTURECAPS_POW2;
+                                            & ~D3DPTEXTURECAPS_POW2
+                                            & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
     desc3HAL_HEL.dpcTriCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                           & ~D3DPTEXTURECAPS_POW2;
+                                           & ~D3DPTEXTURECAPS_POW2
+                                           & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
     desc3HAL_HEL.dwDevCaps &= ~D3DDEVCAPS_HWTRANSFORMANDLIGHT
                             & ~D3DDEVCAPS_DRAWPRIMITIVES2
                             & ~D3DDEVCAPS_DRAWPRIMITIVES2EX;
@@ -266,8 +255,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Interface::CreateLight(LPDIRECT3DLIGHT *lplpDirect3DLight, IUnknown *pUnkOuter) {
-    Logger::debug(">>> D3D3Interface::CreateLight");
-
     if (unlikely(lplpDirect3DLight == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -279,8 +266,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Interface::CreateMaterial(LPDIRECT3DMATERIAL *lplpDirect3DMaterial, IUnknown *pUnkOuter) {
-    Logger::debug(">>> D3D3Interface::CreateMaterial");
-
     if (unlikely(lplpDirect3DMaterial == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -292,8 +277,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Interface::CreateViewport(LPDIRECT3DVIEWPORT *lplpD3DViewport, IUnknown *pUnkOuter) {
-    Logger::debug(">>> D3D3Interface::CreateViewport");
-
     InitReturnPtr(lplpD3DViewport);
 
     *lplpD3DViewport = ref(new D3D3Viewport(nullptr, this));
@@ -302,8 +285,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Interface::FindDevice(D3DFINDDEVICESEARCH *lpD3DFDS, D3DFINDDEVICERESULT *lpD3DFDR) {
-    Logger::debug(">>> D3D3Interface::FindDevice");
-
     if (unlikely(lpD3DFDS == nullptr || lpD3DFDR == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -320,23 +301,25 @@ namespace dxvk {
     D3DDEVICEDESC3 descRGB_HEL = descRGB_HAL;
     descRGB_HAL.dwFlags = 0;
     descRGB_HAL.dcmColorModel = 0;
-    // Some applications apparently care about RGB texture caps
+    // Some applications apparently care about HAL texture caps
     descRGB_HAL.dpcLineCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                           & ~D3DPTEXTURECAPS_POW2;
+                                           & ~D3DPTEXTURECAPS_POW2
+                                           & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
     descRGB_HAL.dpcTriCaps.dwTextureCaps  &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                           & ~D3DPTEXTURECAPS_POW2;
-    descRGB_HEL.dpcLineCaps.dwTextureCaps |= D3DPTEXTURECAPS_POW2;
-    descRGB_HEL.dpcTriCaps.dwTextureCaps  |= D3DPTEXTURECAPS_POW2;
+                                           & ~D3DPTEXTURECAPS_POW2
+                                           & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
 
     // Hardware acceleration
     D3DDEVICEDESC3 descHAL_HAL = GetD3D3Caps(IID_IDirect3DHALDevice, d3dOptions);
     D3DDEVICEDESC3 descHAL_HEL = descHAL_HAL;
     descHAL_HEL.dcmColorModel = 0;
-    // Some applications apparently care about RGB texture caps
+    // Some applications apparently care about HEL texture caps
     descHAL_HEL.dpcLineCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                           & ~D3DPTEXTURECAPS_POW2;
+                                           & ~D3DPTEXTURECAPS_POW2
+                                           & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
     descHAL_HEL.dpcTriCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                          & ~D3DPTEXTURECAPS_POW2;
+                                          & ~D3DPTEXTURECAPS_POW2
+                                          & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
     descHAL_HEL.dwDevCaps &= ~D3DDEVCAPS_HWTRANSFORMANDLIGHT
                            & ~D3DDEVCAPS_DRAWPRIMITIVES2
                            & ~D3DDEVCAPS_DRAWPRIMITIVES2EX;
@@ -345,17 +328,13 @@ namespace dxvk {
     lpD3DFRD3.dwSize = sizeof(D3DFINDDEVICERESULT3);
 
     if (lpD3DFDS->dwFlags & D3DFDS_GUID) {
-      Logger::debug("D3D3Interface::FindDevice: Matching by device GUID");
-
       if (lpD3DFDS->guid == IID_IDirect3DRGBDevice ||
           lpD3DFDS->guid == IID_IDirect3DMMXDevice ||
           lpD3DFDS->guid == IID_IDirect3DRampDevice) {
-        Logger::debug("D3D3Interface::FindDevice: Matched IID_IDirect3DRGBDevice");
         lpD3DFRD3.guid = IID_IDirect3DRGBDevice;
         lpD3DFRD3.ddHwDesc = descRGB_HAL;
         lpD3DFRD3.ddSwDesc = descRGB_HEL;
       } else if (lpD3DFDS->guid == IID_IDirect3DHALDevice) {
-        Logger::debug("D3D3Interface::FindDevice: Matched IID_IDirect3DHALDevice");
         lpD3DFRD3.guid = IID_IDirect3DHALDevice;
         lpD3DFRD3.ddHwDesc = descHAL_HAL;
         lpD3DFRD3.ddSwDesc = descHAL_HEL;
@@ -366,15 +345,11 @@ namespace dxvk {
 
       memcpy(lpD3DFDR, &lpD3DFRD3, sizeof(D3DFINDDEVICERESULT3));
     } else if (lpD3DFDS->dwFlags & D3DFDS_HARDWARE) {
-      Logger::debug("D3D3Interface::FindDevice: Matching by hardware flag");
-
       if (likely(lpD3DFDS->bHardware == TRUE)) {
-        Logger::debug("D3D3Interface::FindDevice: Matched IID_IDirect3DHALDevice");
         lpD3DFRD3.guid = IID_IDirect3DHALDevice;
         lpD3DFRD3.ddHwDesc = descHAL_HAL;
         lpD3DFRD3.ddSwDesc = descHAL_HEL;
       } else {
-        Logger::debug("D3D3Interface::FindDevice: Matched IID_IDirect3DRGBDevice");
         lpD3DFRD3.guid = IID_IDirect3DRGBDevice;
         lpD3DFRD3.ddHwDesc = descRGB_HAL;
         lpD3DFRD3.ddSwDesc = descRGB_HEL;
@@ -382,18 +357,12 @@ namespace dxvk {
 
       memcpy(lpD3DFDR, &lpD3DFRD3, sizeof(D3DFINDDEVICERESULT3));
     } else if (lpD3DFDS->dwFlags & D3DFDS_COLORMODEL) {
-      Logger::debug("D3D3Interface::FindDevice: Matching by color model");
-
-      Logger::debug("D3D3Interface::FindDevice: Matched IID_IDirect3DHALDevice");
       lpD3DFRD3.guid = IID_IDirect3DHALDevice;
       lpD3DFRD3.ddHwDesc = descHAL_HAL;
       lpD3DFRD3.ddSwDesc = descHAL_HEL;
 
       memcpy(lpD3DFDR, &lpD3DFRD3, sizeof(D3DFINDDEVICERESULT3));
     } else if (lpD3DFDS->dwFlags == 0) {
-      Logger::debug("D3D3Interface::FindDevice: No matching criteria specified");
-
-      Logger::debug("D3D3Interface::FindDevice: Matched IID_IDirect3DHALDevice");
       lpD3DFRD3.guid = IID_IDirect3DHALDevice;
       lpD3DFRD3.ddHwDesc = descHAL_HAL;
       lpD3DFRD3.ddSwDesc = descHAL_HEL;

--- a/src/ddraw/d3d3/d3d3_material.cpp
+++ b/src/ddraw/d3d3/d3d3_material.cpp
@@ -32,8 +32,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Material::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> D3D3Material::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
@@ -53,13 +51,10 @@ namespace dxvk {
   // Docs state: "Returns DDERR_ALREADYINITIALIZED because the
   // Direct3DMaterial object is initialized when it is created."
   HRESULT STDMETHODCALLTYPE D3D3Material::Initialize(LPDIRECT3D lpDirect3D) {
-    Logger::debug(">>> D3D3Material::Initialize");
     return DDERR_ALREADYINITIALIZED;
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Material::SetMaterial(D3DMATERIAL *data) {
-    Logger::debug(">>> D3D3Material::SetMaterial");
-
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -81,8 +76,8 @@ namespace dxvk {
     if (likely(commonDevice != nullptr)) {
       const D3DMATERIALHANDLE handle        = m_commonMaterial->GetMaterialHandle();
       const D3DMATERIALHANDLE currentHandle = commonDevice->GetCurrentMaterialHandle();
-      if (currentHandle == handle) {
-        Logger::debug(str::format("D3D3Material::SetMaterial: Applying material nr. ", handle, " to D3D9"));
+      if (handle && currentHandle == handle) {
+        //Logger::debug(str::format("D3D3Material::SetMaterial: Applying material nr. ", handle, " to D3D9"));
         commonDevice->GetD3D9Device()->SetMaterial(material9);
       }
     }
@@ -91,8 +86,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Material::GetMaterial(D3DMATERIAL *data) {
-    Logger::debug(">>> D3D3Material::GetMaterial");
-
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -108,8 +101,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Material::GetHandle(IDirect3DDevice *device, D3DMATERIALHANDLE *handle) {
-    Logger::debug(">>> D3D3Material::GetHandle");
-
     if (unlikely(device == nullptr || handle == nullptr))
       return DDERR_INVALIDPARAMS;
 

--- a/src/ddraw/d3d3/d3d3_texture.cpp
+++ b/src/ddraw/d3d3/d3d3_texture.cpp
@@ -45,44 +45,34 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Texture::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> D3D3Texture::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
     InitReturnPtr(ppvObject);
 
     if (unlikely(riid == __uuidof(IDirect3DTexture2))) {
-      Logger::debug("D3D3Texture::QueryInterface: Query for IDirect3DTexture");
       return m_parent->QueryInterface(riid, ppvObject);
     }
     if (unlikely(riid == __uuidof(IDirectDrawGammaControl))) {
-      Logger::debug("D3D3Texture::QueryInterface: Query for IDirectDrawGammaControl");
       return m_parent->QueryInterface(riid, ppvObject);
     }
     if (unlikely(riid == __uuidof(IDirectDrawColorControl))) {
-      Logger::debug("D3D3Texture::QueryInterface: Query for IDirectDrawColorControl");
       return E_NOINTERFACE;
     }
     if (unlikely(riid == __uuidof(IUnknown)
               || riid == __uuidof(IDirectDrawSurface))) {
-      Logger::debug("D3D3Texture::QueryInterface: Query for IDirectDrawSurface");
       return m_parent->QueryInterface(riid, ppvObject);
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface2))) {
-      Logger::debug("D3D3Texture::QueryInterface: Query for IDirectDrawSurface2");
       return m_parent->QueryInterface(riid, ppvObject);
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface3))) {
-      Logger::debug("D3D3Texture::QueryInterface: Query for IDirectDrawSurface3");
       return m_parent->QueryInterface(riid, ppvObject);
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface4))) {
-      Logger::debug("D3D3Texture::QueryInterface: Query for IDirectDrawSurface4");
       return m_parent->QueryInterface(riid, ppvObject);
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface7))) {
-      Logger::debug("D3D3Texture::QueryInterface: Query for IDirectDrawSurface7");
       return m_parent->QueryInterface(riid, ppvObject);
     }
 
@@ -98,8 +88,6 @@ namespace dxvk {
 
   // Frogger gets texture handles from IDirect3DTexture objects and uses them in calls on a IDirect3DDevice2
   HRESULT STDMETHODCALLTYPE D3D3Texture::GetHandle(LPDIRECT3DDEVICE lpDirect3DDevice, LPD3DTEXTUREHANDLE lpHandle) {
-    Logger::debug(">>> D3D3Texture::GetHandle");
-
     if (unlikely(lpDirect3DDevice == nullptr || lpHandle == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -109,7 +97,6 @@ namespace dxvk {
       // The Sims tries to get a handle from a surface which wasn't created with the DDSCAPS_TEXTURE flag,
       // so manually flag it as a texture before we initialize its D3D9 object
       if (likely(!commonSurf->IsInitialized())) {
-        Logger::debug("D3D3Texture::GetHandle: Parent surface isn't a texture");
         m_commonTex->GetCommonSurface()->MarkWithTextureHandle();
       // If for some reason this happens after it's initialized, there's nothing we can do but log an error
       } else {
@@ -131,13 +118,10 @@ namespace dxvk {
   // Docs state: "This method only affects the legacy ramp device.
   // For all other devices, this method takes no action and returns D3D_OK."
   HRESULT STDMETHODCALLTYPE D3D3Texture::PaletteChanged(DWORD dwStart, DWORD dwCount) {
-    Logger::debug(">>> D3D3Texture::PaletteChanged");
     return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Texture::Load(LPDIRECT3DTEXTURE lpD3DTexture) {
-    Logger::debug("<<< D3D3Texture::Load: Proxy");
-
     Com<D3D3Texture> d3d3Texture = static_cast<D3D3Texture*>(lpD3DTexture);
 
     // Note: Will not work if IDirect3DTexture is queried directly
@@ -167,13 +151,11 @@ namespace dxvk {
 
   // Docs state: "Returns DDERR_ALREADYINITIALIZED because the Direct3DTexture object is initialized when it is created."
   HRESULT STDMETHODCALLTYPE D3D3Texture::Initialize(LPDIRECT3DDEVICE lpDirect3DDevice, LPDIRECTDRAWSURFACE lpDDSurface) {
-    Logger::debug(">>> D3D3Texture::Initialize");
     return DDERR_ALREADYINITIALIZED;
   }
 
   // Nothing to do here, this isn't managed texture unloading
   HRESULT STDMETHODCALLTYPE D3D3Texture::Unload() {
-    Logger::debug(">>> D3D3Texture::Unload");
     return D3D_OK;
   }
 

--- a/src/ddraw/d3d3/d3d3_viewport.cpp
+++ b/src/ddraw/d3d3/d3d3_viewport.cpp
@@ -78,20 +78,14 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Viewport::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> D3D3Viewport::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
     InitReturnPtr(ppvObject);
 
     if (unlikely(riid == __uuidof(IDirect3DViewport2))) {
-      if (m_commonViewport->GetD3D5Viewport() != nullptr) {
-        Logger::debug("D3D3Viewport::QueryInterface: Query for existing IDirect3DViewport2");
+      if (m_commonViewport->GetD3D5Viewport() != nullptr)
         return m_commonViewport->GetD3D5Viewport()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("D3D3Viewport::QueryInterface: Query for IDirect3DViewport2");
 
       m_viewport5 = new D3D5Viewport(m_commonViewport.ptr(), nullptr);
       *ppvObject = m_viewport5.ref();
@@ -99,12 +93,8 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirect3DViewport3))) {
-      if (m_commonViewport->GetD3D6Viewport() != nullptr) {
-        Logger::debug("D3D3Viewport::QueryInterface: Query for existing IDirect3DViewport3");
+      if (m_commonViewport->GetD3D6Viewport() != nullptr)
         return m_commonViewport->GetD3D6Viewport()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("D3D3Viewport::QueryInterface: Query for IDirect3DViewport3");
 
       m_viewport6 = new D3D6Viewport(m_commonViewport.ptr(), nullptr);
       *ppvObject = m_viewport6.ref();
@@ -125,13 +115,10 @@ namespace dxvk {
 
   // Docs state: "The IDirect3DViewport2::Initialize method is not implemented."
   HRESULT STDMETHODCALLTYPE D3D3Viewport::Initialize(LPDIRECT3D lpDirect3D) {
-    Logger::debug(">>> D3D3Viewport::Initialize");
     return DDERR_ALREADYINITIALIZED;
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Viewport::GetViewport(D3DVIEWPORT *data) {
-    Logger::debug(">>> D3D3Viewport::GetViewport");
-
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -162,8 +149,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Viewport::SetViewport(D3DVIEWPORT *data) {
-    Logger::debug(">>> D3D3Viewport::SetViewport");
-
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -214,12 +199,8 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Viewport::TransformVertices(DWORD vertex_count, D3DTRANSFORMDATA *data, DWORD flags, DWORD *offscreen) {
-    Logger::debug(">>> D3D3Viewport::TransformVertices");
-
-    if (unlikely(!m_commonViewport->HasDevice())) {
-      Logger::warn("D3D3Viewport::TransformVertices: Viewport isn't attached to a device");
+    if (unlikely(!m_commonViewport->HasDevice()))
       return D3DERR_VIEWPORTHASNODEVICE;
-    }
 
     d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
 
@@ -247,19 +228,10 @@ namespace dxvk {
 
   // Docs state: "The IDirect3DViewport::LightElements method is not currently implemented."
   HRESULT STDMETHODCALLTYPE D3D3Viewport::LightElements(DWORD element_count, D3DLIGHTDATA *data) {
-    Logger::warn(">>> D3D3Viewport::LightElements");
     return DDERR_UNSUPPORTED;
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Viewport::SetBackground(D3DMATERIALHANDLE hMat) {
-    // Workaround: Revenant sets the background on a IDirect3DViewport viewport
-    if (unlikely(m_commonViewport->GetD3D6Viewport() != nullptr)) {
-      Logger::debug(">>> D3D3Viewport::SetBackground");
-      return m_commonViewport->GetD3D6Viewport()->SetBackground(hMat);
-    }
-
-    Logger::debug(">>> D3D3Viewport::SetBackground");
-
     if (unlikely(m_commonViewport->GetMaterialHandle() == hMat))
       return D3D_OK;
 
@@ -276,8 +248,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Viewport::GetBackground(D3DMATERIALHANDLE *material, BOOL *valid) {
-    Logger::debug(">>> D3D3Viewport::GetBackground");
-
     if (unlikely(material == nullptr || valid == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -288,22 +258,24 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Viewport::SetBackgroundDepth(IDirectDrawSurface *surface) {
-    Logger::debug(">>> D3D3Viewport::SetBackgroundDepth");
-
-    if (unlikely(!DDrawCommonInterface::IsWrappedSurface(surface))) {
+    if (unlikely(surface != nullptr
+             && !DDrawCommonInterface::IsWrappedSurface(surface))) {
       Logger::err("D3D3Viewport::SetBackgroundDepth: Received an unwrapped surface");
       return DDERR_UNSUPPORTED;
     }
 
-    m_backgroundDepth = reinterpret_cast<DDrawSurface*>(surface);
-    m_isBackgroundDepthSet = true;
+    if (unlikely(surface == nullptr)) {
+      m_backgroundDepth = nullptr;
+      m_isBackgroundDepthSet = false;
+    } else {
+      m_backgroundDepth = reinterpret_cast<DDrawSurface*>(surface);
+      m_isBackgroundDepthSet = true;
+    }
 
     return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Viewport::GetBackgroundDepth(IDirectDrawSurface **surface, BOOL *valid) {
-    Logger::debug(">>> D3D3Viewport::GetBackgroundDepth");
-
     if (unlikely(surface == nullptr || valid == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -316,14 +288,12 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Viewport::Clear(DWORD count, D3DRECT *rects, DWORD flags) {
-    Logger::debug(">>> D3D3Viewport::Clear");
+    // Early D3D viewport fast skip
+    if (unlikely(!count || !rects))
+      return D3D_OK;
 
     if (unlikely(!m_commonViewport->HasDevice()))
       return D3DERR_VIEWPORTHASNODEVICE;
-
-    // Early D3D viewport fast skip
-    if (unlikely(!count || (count && rects == nullptr)))
-      return D3D_OK;
 
     const bool clearRenderTarget = flags & D3DCLEAR_TARGET;
     const bool clearDepthStencil = flags & D3DCLEAR_ZBUFFER;
@@ -335,7 +305,7 @@ namespace dxvk {
       if (likely(rt != nullptr)) {
         // If this isn't a full surface clear, we need to first upload the DDraw surface
         if (unlikely(count > 1 || !rt->IsFullSurfaceLock(reinterpret_cast<RECT*>(rects), nullptr))) {
-          Logger::debug("D3D3Viewport::Clear: Partial render target clear");
+          //Logger::debug("D3D3Viewport::Clear: Partial render target clear");
           // Use a common surface helper, because we want to handle all
           // possible surface interfaces that may be alive at this time
           rt->InitializeOrUploadD3D9();
@@ -347,7 +317,7 @@ namespace dxvk {
       if (likely(ds != nullptr)) {
         // If this isn't a full surface clear, we need to first upload the DDraw surface
         if (unlikely(count > 1 || !ds->IsFullSurfaceLock(reinterpret_cast<RECT*>(rects), nullptr))) {
-          Logger::debug("D3D3Viewport::Clear: Partial depth stencil clear");
+          //Logger::debug("D3D3Viewport::Clear: Partial depth stencil clear");
           // Use a common surface helper, because we want to handle all
           // possible surface interfaces that may be alive at this time
           ds->InitializeOrUploadD3D9();
@@ -359,7 +329,8 @@ namespace dxvk {
 
     // Temporarily activate this viewport in order to clear it
     d3d9::D3DVIEWPORT9 currentViewport9;
-    if (!m_commonViewport->IsCurrentViewport()) {
+    const bool isCurrentViewport = m_commonViewport->IsCurrentViewport();
+    if (!isCurrentViewport) {
       D3D3Viewport* currentViewport = m_commonViewport->GetCurrentD3D3Viewport();
       if (currentViewport != nullptr) {
         currentViewport9 = *currentViewport->GetCommonViewport()->GetD3D9Viewport();
@@ -379,14 +350,14 @@ namespace dxvk {
     HRESULT hr = d3d9Device->Clear(count, rects, flags, clearColor, 1.0f, 0u);
 
     // Restore the previously active viewport
-    if (!m_commonViewport->IsCurrentViewport()) {
+    if (!isCurrentViewport) {
       d3d9Device->SetViewport(&currentViewport9);
     }
 
-    // Clear() will only ever silently fail
+    // Can fail in D3D9 only in case of a missing depth stencil surface
     if (unlikely(FAILED(hr))) {
-      Logger::debug("D3D3Viewport::Clear: Failed D3D9 Clear call");
-      return D3D_OK;
+      // Fix up expected return codes
+      return D3DERR_ZBUFFER_NOTPRESENT;
     }
 
     if (clearRenderTarget && rt != nullptr)
@@ -400,8 +371,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Viewport::AddLight(IDirect3DLight *light) {
-    Logger::debug(">>> D3D3Viewport::AddLight");
-
     if (unlikely(light == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -423,8 +392,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Viewport::DeleteLight(IDirect3DLight *light) {
-    Logger::debug(">>> D3D3Viewport::DeleteLight");
-
     if (unlikely(light == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -439,7 +406,7 @@ namespace dxvk {
     if (likely(it != lights.end())) {
       const DWORD lightIndex = d3dLight->GetIndex();
       if (m_commonViewport->HasDevice() && m_commonViewport->IsCurrentViewport() && d3dLight->IsActive()) {
-        Logger::debug(str::format("D3D3Viewport: Disabling light nr. ", lightIndex));
+        //Logger::debug(str::format("D3D3Viewport: Disabling light nr. ", lightIndex));
         d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
         d3d9Device->LightEnable(lightIndex, FALSE);
       }
@@ -454,8 +421,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Viewport::NextLight(IDirect3DLight *lpDirect3DLight, IDirect3DLight **lplpDirect3DLight, DWORD flags) {
-    Logger::debug(">>> D3D3Viewport::NextLight");
-
     if (unlikely(lplpDirect3DLight == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -484,8 +449,6 @@ namespace dxvk {
     if (!m_commonViewport->IsViewportSet())
       return D3D_OK;
 
-    Logger::debug("D3D3Viewport: Applying viewport to D3D9");
-
     d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
 
     HRESULT hr = d3d9Device->SetViewport(m_commonViewport->GetD3D9Viewport());
@@ -503,8 +466,6 @@ namespace dxvk {
     if (!lights.size())
       return D3D_OK;
 
-    Logger::debug("D3D3Viewport: Applying lights to D3D9");
-
     for (auto light: lights)
       ApplyAndActivateLight(light->GetIndex(), light.ptr());
 
@@ -517,14 +478,12 @@ namespace dxvk {
     if (!lights.size())
       return D3D_OK;
 
-    Logger::debug("D3D3Viewport: Deactivating D3D9 lights");
-
     d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
 
     for (auto light: lights) {
       const DWORD lightIndex = light->GetIndex();
       if (m_commonViewport->HasDevice() && m_commonViewport->IsCurrentViewport() && light->IsActive()) {
-        Logger::debug(str::format("D3D3Viewport: Disabling light nr. ", lightIndex));
+        //Logger::debug(str::format("D3D3Viewport: Disabling light nr. ", lightIndex));
         d3d9Device->LightEnable(lightIndex, FALSE);
       }
     }
@@ -542,12 +501,12 @@ namespace dxvk {
     }
 
     if (light->IsActive()) {
-      Logger::debug(str::format("D3D3Viewport: Enabling D3D9 light nr. ", index));
+      //Logger::debug(str::format("D3D3Viewport: Enabling D3D9 light nr. ", index));
       hr = d3d9Device->LightEnable(index, TRUE);
       if (unlikely(FAILED(hr)))
         Logger::err("D3D3Viewport: Failed D3D9 LightEnable call (TRUE)");
     } else {
-      Logger::debug(str::format("D3D3Viewport: Disabling D3D9 light nr. ", index));
+      //Logger::debug(str::format("D3D3Viewport: Disabling D3D9 light nr. ", index));
       hr = d3d9Device->LightEnable(index, FALSE);
       if (unlikely(FAILED(hr)))
         Logger::err("D3D3Viewport: Failed D3D9 LightEnable call (FALSE)");

--- a/src/ddraw/d3d5/d3d5_device.cpp
+++ b/src/ddraw/d3d5/d3d5_device.cpp
@@ -60,14 +60,6 @@ namespace dxvk {
         Logger::warn("D3D5Device: Force enabling AA");
         device9->SetRenderState(d3d9::D3DRS_MULTISAMPLEANTIALIAS, TRUE);
       }
-
-      // The default value of D3DRENDERSTATE_TEXTUREMAPBLEND in D3D5 is D3DTBLEND_MODULATE
-      device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
-      device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
-      device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
-      device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG1);
-      device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-      device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
     } else {
       device9 = m_commonD3DDevice->GetD3D9Device();
       // Very important, otherwise the depth stencil isn't dirtied on draws
@@ -131,20 +123,14 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Device::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> D3D5Device::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
     InitReturnPtr(ppvObject);
 
     if (unlikely(riid == __uuidof(IDirect3DDevice))) {
-      if (m_commonD3DDevice->GetD3D3Device() != nullptr) {
-        Logger::debug("D3D3Device::QueryInterface: Query for existing IDirect3DDevice");
+      if (m_commonD3DDevice->GetD3D3Device() != nullptr)
         return m_commonD3DDevice->GetD3D3Device()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("D3D5Device::QueryInterface: Query for IDirect3DDevice");
 
       // Reuse the existing D3D9 device in situations where games want
       // to get access only to D3D3 execute buffers on a D3D5 device
@@ -157,14 +143,11 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirect3DDevice3))) {
-      if (m_commonD3DDevice->GetD3D6Device() != nullptr) {
-        Logger::debug("D3D5Device::QueryInterface: Query for existing IDirect3DDevice3");
+      if (m_commonD3DDevice->GetD3D6Device() != nullptr)
         return m_commonD3DDevice->GetD3D6Device()->QueryInterface(riid, ppvObject);
-      }
 
       // A D3D5 device shouldn't be able to create a D3D6 device
       // if it doesn't previously exist as a parent/origin device
-      Logger::err("D3D5Device::QueryInterface: Query for IDirect3DDevice3");
       return E_NOINTERFACE;
     }
 
@@ -180,8 +163,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Device::GetCaps(D3DDEVICEDESC *hal_desc, D3DDEVICEDESC *hel_desc) {
-    Logger::debug(">>> D3D5Device::GetCaps");
-
     if (unlikely(hal_desc == nullptr || hel_desc == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -197,13 +178,13 @@ namespace dxvk {
     if (deviceGUID == IID_IDirect3DRGBDevice) {
       desc_HAL.dwFlags = 0;
       desc_HAL.dcmColorModel = 0;
-      // Some applications apparently care about RGB texture caps
+      // Some applications apparently care about HAL texture caps
       desc_HAL.dpcLineCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE
+                                          & ~D3DPTEXTURECAPS_POW2
                                           & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
       desc_HAL.dpcTriCaps.dwTextureCaps  &= ~D3DPTEXTURECAPS_PERSPECTIVE
+                                          & ~D3DPTEXTURECAPS_POW2
                                           & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
-      desc_HEL.dpcLineCaps.dwTextureCaps |= D3DPTEXTURECAPS_POW2;
-      desc_HEL.dpcTriCaps.dwTextureCaps  |= D3DPTEXTURECAPS_POW2;
     } else if (deviceGUID == IID_IDirect3DHALDevice) {
       desc_HEL.dcmColorModel = 0;
       desc_HEL.dwDevCaps &= ~D3DDEVCAPS_HWTRANSFORMANDLIGHT
@@ -221,8 +202,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D5Device::SwapTextureHandles(IDirect3DTexture2 *tex1, IDirect3DTexture2 *tex2) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D5Device::SwapTextureHandles");
 
     D3D5Texture* texture1 = static_cast<D3D5Texture*>(tex1);
     D3D5Texture* texture2 = static_cast<D3D5Texture*>(tex2);
@@ -248,8 +227,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D5Device::GetStats(D3DSTATS *stats) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D5Device::GetStats");
-
     if (unlikely(stats == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -272,8 +249,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D5Device::AddViewport(IDirect3DViewport2 *viewport) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D5Device::AddViewport");
-
     if (unlikely(viewport == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -284,8 +259,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D5Device::DeleteViewport(IDirect3DViewport2 *viewport) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D5Device::DeleteViewport");
 
     if (unlikely(viewport == nullptr))
       return DDERR_INVALIDPARAMS;
@@ -302,8 +275,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D5Device::NextViewport(IDirect3DViewport2 *lpDirect3DViewport, IDirect3DViewport2 **lplpAnotherViewport, DWORD flags) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D5Device::NextViewport");
 
     if (unlikely(lplpAnotherViewport == nullptr))
       return DDERR_INVALIDPARAMS;
@@ -328,8 +299,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Device::EnumTextureFormats(LPD3DENUMTEXTUREFORMATSCALLBACK cb, void *ctx) {
-    Logger::debug(">>> D3D5Device::EnumTextureFormats");
-
     if (unlikely(cb == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -395,8 +364,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D5Device::BeginScene() {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D5Device::BeginScene");
-
     RefreshLastUsedDevice();
 
     if (unlikely(m_commonD3DDevice->IsInScene()))
@@ -414,8 +381,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D5Device::EndScene() {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D5Device::EndScene");
-
     RefreshLastUsedDevice();
 
     if (unlikely(!m_commonD3DDevice->IsInScene()))
@@ -431,8 +396,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Device::GetDirect3D(IDirect3D2 **d3d) {
-    Logger::debug(">>> D3D5Device::GetDirect3D");
-
     if (unlikely(d3d == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -450,8 +413,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D5Device::SetCurrentViewport(IDirect3DViewport2 *viewport) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D5Device::SetCurrentViewport");
 
     if (unlikely(viewport == nullptr))
       return DDERR_INVALIDPARAMS;
@@ -482,8 +443,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D5Device::GetCurrentViewport(IDirect3DViewport2 **viewport) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D5Device::GetCurrentViewport");
-
     // This does indeed return D3DERR_NOCURRENTVIEWPORT...
     if (unlikely(viewport == nullptr))
       return D3DERR_NOCURRENTVIEWPORT;
@@ -502,12 +461,8 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D5Device::SetRenderTarget(IDirectDrawSurface *surface, DWORD flags) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D5Device::SetRenderTarget");
-
-    if (unlikely(surface == nullptr)) {
-      Logger::err("D3D5Device::SetRenderTarget: NULL render target");
+    if (unlikely(surface == nullptr))
       return DDERR_INVALIDPARAMS;
-    }
 
     if (unlikely(!DDrawCommonInterface::IsWrappedSurface(surface))) {
       Logger::err("D3D5Device::SetRenderTarget: Received an unwrapped RT");
@@ -538,8 +493,6 @@ namespace dxvk {
     m_ds = m_rt->GetAttachedDepthStencil();
 
     if (m_ds != nullptr) {
-      Logger::debug("D3D5Device::SetRenderTarget: Found an attached DS");
-
       hr = m_ds->InitializeD3D9DepthStencil();
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D5Device::SetRenderTarget: Failed to initialize/upload D3D9 DS");
@@ -552,8 +505,6 @@ namespace dxvk {
         return hr;
       }
     } else {
-      Logger::debug("D3D5Device::SetRenderTarget: RT has no depth stencil attached");
-
       hr = device9->SetDepthStencilSurface(nullptr);
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D5Device::SetRenderTarget: Failed to clear the D3D9 DS");
@@ -567,8 +518,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D5Device::GetRenderTarget(IDirectDrawSurface **surface) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D5Device::GetRenderTarget");
-
     if (unlikely(surface == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -579,8 +528,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D5Device::Begin(D3DPRIMITIVETYPE d3dptPrimitiveType, D3DVERTEXTYPE dwVertexTypeDesc, DWORD dwFlags) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D5Device::Begin");
 
     m_vertexStreamInfo.d3dpt = d3dptPrimitiveType;
     m_vertexStreamInfo.d3dvt = dwVertexTypeDesc;
@@ -596,8 +543,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D5Device::Vertex(void *vertex) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D5Device::Vertex");
 
     if (unlikely(vertex == nullptr))
       return DDERR_INVALIDPARAMS;
@@ -623,8 +568,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D5Device::End(DWORD dwFlags) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D5Device::End");
 
     HRESULT hr;
     if (m_vertexStreamInfo.d3dvt == D3DVT_VERTEX) {
@@ -655,8 +598,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D5Device::GetRenderState(D3DRENDERSTATETYPE dwRenderStateType, LPDWORD lpdwRenderState) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(str::format(">>> D3D5Device::GetRenderState: ", dwRenderStateType));
-
     if (unlikely(lpdwRenderState == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -664,7 +605,6 @@ namespace dxvk {
     // unknown or invalid render states.
     if (unlikely(!IsValidD3D5RenderStateType(dwRenderStateType)
               && !m_commonIntf->GetOptions()->apitraceMode)) {
-      Logger::debug(str::format("D3D5Device::GetRenderState: Invalid render state ", dwRenderStateType));
       *lpdwRenderState = 0;
       return D3D_OK;
     }
@@ -856,14 +796,10 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D5Device::SetRenderState(D3DRENDERSTATETYPE dwRenderStateType, DWORD dwRenderState) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(str::format(">>> D3D5Device::SetRenderState: ", dwRenderStateType));
-
     // As opposed to D3D7, D3D5 does not error out on
     // unknown or invalid render states.
-    if (unlikely(!IsValidD3D5RenderStateType(dwRenderStateType))) {
-      Logger::debug(str::format("D3D5Device::SetRenderState: Invalid render state ", dwRenderStateType));
+    if (unlikely(!IsValidD3D5RenderStateType(dwRenderStateType)))
       return D3D_OK;
-    }
 
     d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
     d3d9::D3DRENDERSTATETYPE State9 = d3d9::D3DRENDERSTATETYPE(dwRenderStateType);
@@ -956,19 +892,9 @@ namespace dxvk {
         return D3D_OK;
 
       case D3DRENDERSTATE_MONOENABLE:
-        static bool s_monoEnableErrorShown;
-
-        if (dwRenderState && !std::exchange(s_monoEnableErrorShown, true))
-          Logger::warn("D3D5Device::SetRenderState: Unimplemented render state D3DRENDERSTATE_MONOENABLE");
-
         return D3D_OK;
 
       case D3DRENDERSTATE_ROP2:
-        static bool s_ROP2ErrorShown;
-
-        if (!std::exchange(s_ROP2ErrorShown, true))
-          Logger::warn("D3D5Device::SetRenderState: Unimplemented render state D3DRENDERSTATE_ROP2");
-
         return D3D_OK;
 
       // "This render state is not supported by the software rasterizers, and is often ignored by hardware drivers."
@@ -1052,8 +978,8 @@ namespace dxvk {
             device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
             device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
             device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG1);
-            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_CURRENT);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_CURRENT);
             break;
           // "In this mode, the RGB and alpha values of the texture are blended with the colors
           //  that would have been used with no texturing, according to the following formulas [...]"
@@ -1062,8 +988,8 @@ namespace dxvk {
             device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
             device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_BLENDTEXTUREALPHA);
             device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG2);
-            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_CURRENT);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_CURRENT);
             break;
           // "In this mode, the RGB values of the texture are multiplied with the RGB values that
           //  would have been used with no texturing, and the alpha values of the texture
@@ -1073,8 +999,8 @@ namespace dxvk {
             device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
             device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
             device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_MODULATE);
-            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_CURRENT);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_CURRENT);
             break;
           // "Add the Gouraud interpolants to the texture lookup with saturation semantics
           //  (that is, if the color value overflows it is set to the maximum possible value)."
@@ -1083,8 +1009,8 @@ namespace dxvk {
             device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
             device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_ADD);
             device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG2);
-            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_CURRENT);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_CURRENT);
             break;
           // Unsupported
           default:
@@ -1113,24 +1039,12 @@ namespace dxvk {
       case D3DRENDERSTATE_SUBPIXELX:
         return D3D_OK;
 
-      // Tests have shown age accurate GPUs didn't offer support for
-      // stippling at all, so this should be safe to ignore
+      // Tests have shown age accurate GPUs didn't offer support for stippling at all
       case D3DRENDERSTATE_STIPPLEDALPHA:
-        static bool s_stippledAlphaErrorShown;
-
-        if (dwRenderState && !std::exchange(s_stippledAlphaErrorShown, true))
-          Logger::warn("D3D5Device::SetRenderState: Unimplemented render state D3DRENDERSTATE_STIPPLEDALPHA");
-
         return D3D_OK;
 
-      // Tests have shown age accurate GPUs didn't offer support for
-      // stippling at all, so this should be safe to ignore
+      // Tests have shown age accurate GPUs didn't offer support for stippling at all
       case D3DRENDERSTATE_STIPPLEENABLE:
-        static bool s_stippleEnableErrorShown;
-
-        if (dwRenderState && !std::exchange(s_stippleEnableErrorShown, true))
-          Logger::warn("D3D5Device::SetRenderState: Unimplemented render state D3DRENDERSTATE_STIPPLEENABLE");
-
         return D3D_OK;
 
       case D3DRENDERSTATE_EDGEANTIALIAS:
@@ -1190,7 +1104,7 @@ namespace dxvk {
       case D3DRENDERSTATE_FLUSHBATCH:
         return D3D_OK;
 
-      // TODO:
+      // Tests have shown age accurate GPUs didn't offer support for stippling at all
       case D3DRENDERSTATE_STIPPLEPATTERN00:
       case D3DRENDERSTATE_STIPPLEPATTERN01:
       case D3DRENDERSTATE_STIPPLEPATTERN02:
@@ -1223,11 +1137,6 @@ namespace dxvk {
       case D3DRENDERSTATE_STIPPLEPATTERN29:
       case D3DRENDERSTATE_STIPPLEPATTERN30:
       case D3DRENDERSTATE_STIPPLEPATTERN31:
-        static bool s_stipplePatternErrorShown;
-
-        if (!std::exchange(s_stipplePatternErrorShown, true))
-          Logger::warn("D3D5Device::SetRenderState: Unimplemented render state D3DRENDERSTATE_STIPPLEPATTERN");
-
         return D3D_OK;
     }
 
@@ -1237,8 +1146,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D5Device::GetLightState(D3DLIGHTSTATETYPE dwLightStateType, LPDWORD lpdwLightState) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D5Device::GetLightState");
 
     if (unlikely(lpdwLightState == nullptr))
       return DDERR_INVALIDPARAMS;
@@ -1277,14 +1184,14 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D5Device::SetLightState(D3DLIGHTSTATETYPE dwLightStateType, DWORD dwLightState) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D5Device::SetLightState");
-
     d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     switch (dwLightStateType) {
       case D3DLIGHTSTATE_MATERIAL: {
         if (unlikely(!dwLightState)) {
           m_commonD3DDevice->SetCurrentMaterialHandle(dwLightState);
+          static constexpr d3d9::D3DMATERIAL9 DefaultMaterial9 = { };
+          device9->SetMaterial(&DefaultMaterial9);
           return D3D_OK;
         }
 
@@ -1293,7 +1200,7 @@ namespace dxvk {
           return DDERR_INVALIDPARAMS;
 
         m_commonD3DDevice->SetCurrentMaterialHandle(dwLightState);
-        Logger::debug(str::format("D3D5Device::SetLightState: Applying material nr. ", dwLightState, " to D3D9"));
+        //Logger::debug(str::format("D3D5Device::SetLightState: Applying material nr. ", dwLightState, " to D3D9"));
         device9->SetMaterial(material9);
 
         break;
@@ -1325,24 +1232,19 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Device::SetTransform(D3DTRANSFORMSTATETYPE state, D3DMATRIX *matrix) {
-    Logger::debug(">>> D3D5Device::SetTransform");
     return m_commonD3DDevice->GetD3D9Device()->SetTransform(ConvertTransformState(state), matrix);
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Device::GetTransform(D3DTRANSFORMSTATETYPE state, D3DMATRIX *matrix) {
-    Logger::debug(">>> D3D5Device::GetTransform");
     return m_commonD3DDevice->GetD3D9Device()->GetTransform(ConvertTransformState(state), matrix);
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Device::MultiplyTransform(D3DTRANSFORMSTATETYPE state, D3DMATRIX *matrix) {
-    Logger::debug(">>> D3D5Device::MultiplyTransform");
     return m_commonD3DDevice->GetD3D9Device()->MultiplyTransform(ConvertTransformState(state), matrix);
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Device::DrawPrimitive(D3DPRIMITIVETYPE primitive_type, D3DVERTEXTYPE vertex_type, void *vertices, DWORD vertex_count, DWORD flags) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D5Device::DrawPrimitive");
 
     RefreshLastUsedDevice();
 
@@ -1388,8 +1290,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D5Device::DrawIndexedPrimitive(D3DPRIMITIVETYPE primitive_type, D3DVERTEXTYPE fvf, void *vertices, DWORD vertex_count, WORD *indices, DWORD index_count, DWORD flags) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D5Device::DrawIndexedPrimitive");
 
     RefreshLastUsedDevice();
 
@@ -1438,8 +1338,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Device::SetClipStatus(D3DCLIPSTATUS *clip_status) {
-    Logger::debug(">>> D3D5Device::SetClipStatus");
-
     if (unlikely(clip_status == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -1447,8 +1345,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Device::GetClipStatus(D3DCLIPSTATUS *clip_status) {
-    Logger::debug(">>> D3D5Device::GetClipStatus");
-
     if (unlikely(clip_status == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -1475,16 +1371,12 @@ namespace dxvk {
     m_ds = m_rt->GetAttachedDepthStencil();
 
     if (m_ds != nullptr) {
-      Logger::debug("D3D5Device::InitializeDS: Found an attached DS");
-
       HRESULT hrDS = m_ds->InitializeD3D9DepthStencil();
       if (unlikely(FAILED(hrDS))) {
         Logger::err("D3D5Device::InitializeDS: Failed to initialize D3D9 DS");
       } else {
-        Logger::info("D3D5Device::InitializeDS: Got depth stencil from RT");
-
         const RECT* dsRect = m_ds->GetCommonSurface()->GetFullSurfaceRect();
-        Logger::debug(str::format("D3D5Device::InitializeDS: DepthStencil: ", dsRect->right, "x", dsRect->bottom));
+        Logger::info(str::format("D3D5Device::InitializeDS: Depth stencil: ", dsRect->right, "x", dsRect->bottom));
 
         HRESULT hrDS9 = device9->SetDepthStencilSurface(m_ds->GetCommonSurface()->GetD3D9Surface());
         if (unlikely(FAILED(hrDS9))) {
@@ -1495,7 +1387,6 @@ namespace dxvk {
         }
       }
     } else {
-      Logger::info("D3D5Device::InitializeDS: RT has no depth stencil attached");
       device9->SetDepthStencilSurface(nullptr);
       // Should be superfluous, but play it safe
       device9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_FALSE);
@@ -1558,31 +1449,23 @@ namespace dxvk {
   }
 
   inline HRESULT D3D5Device::SetTextureInternal(DDrawSurface* surface, DWORD textureHandle) {
-    Logger::debug(">>> D3D5Device::SetTextureInternal");
-
     HRESULT hr;
 
     d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     // Unbinding texture stages
     if (surface == nullptr) {
-      Logger::debug("D3D5Device::SetTextureInternal: Unbiding D3D9 texture");
-
       hr = device9->SetTexture(0, nullptr);
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D5Device::SetTextureInternal: Failed to unbind D3D9 texture");
         return hr;
       }
 
-      if (likely(m_commonD3DDevice->GetCurrentTextureHandle() != 0)) {
-        Logger::debug("D3D5Device::SetTextureInternal: Unbinding local texture");
+      if (likely(m_commonD3DDevice->GetCurrentTextureHandle() != 0))
         m_commonD3DDevice->SetCurrentTextureHandle(0);
-      }
 
       return D3D_OK;
     }
-
-    Logger::debug("D3D5Device::SetTextureInternal: Binding D3D9 texture");
 
     // If textures have been used on a different device, they
     // will get their D3D9 object reinitialized at this point

--- a/src/ddraw/d3d5/d3d5_device.h
+++ b/src/ddraw/d3d5/d3d5_device.h
@@ -151,7 +151,6 @@ namespace dxvk {
         m_legacyProjection = m_currentViewport->GetCommonViewport()->GetLegacyProjectionMatrix(drawFlags);
 
         if (m_legacyProjection != nullptr) {
-          //Logger::debug("D3D5Device: Applying legacy projection");
           device9->GetTransform(d3d9::D3DTS_PROJECTION, &m_projectionMatrix);
           device9->MultiplyTransform(d3d9::D3DTS_PROJECTION, m_legacyProjection);
         }
@@ -160,7 +159,6 @@ namespace dxvk {
 
     inline void HandlePostDrawLegacyProjection(d3d9::IDirect3DDevice9* device9) {
       if (m_legacyProjection != nullptr) {
-        //Logger::debug("D3D5Device: Reverting legacy projection");
         device9->SetTransform(d3d9::D3DTS_PROJECTION, &m_projectionMatrix);
       }
     }

--- a/src/ddraw/d3d5/d3d5_interface.cpp
+++ b/src/ddraw/d3d5/d3d5_interface.cpp
@@ -82,29 +82,21 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Interface::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> D3D5Interface::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
     InitReturnPtr(ppvObject);
 
     if (riid == __uuidof(IDirectDraw)) {
-      Logger::debug("D3D5Interface::QueryInterface: Query for IDirectDraw");
       return m_parent->QueryInterface(riid, ppvObject);
     }
     if (riid == __uuidof(IDirectDraw2)) {
-      Logger::debug("D3D5Interface::QueryInterface: Query for IDirectDraw2");
       return m_parent->QueryInterface(riid, ppvObject);
     }
     // Some games query for legacy D3D interfaces
     if (unlikely(riid == __uuidof(IDirect3D))) {
-      if (m_commonD3DIntf->GetD3D3Interface() != nullptr) {
-        Logger::debug("D3D5Interface::QueryInterface: Query for existing IDirect3D");
+      if (m_commonD3DIntf->GetD3D3Interface() != nullptr)
         return m_commonD3DIntf->GetD3D3Interface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("D3D5Interface::QueryInterface: Query for IDirect3D");
 
       m_d3d3Intf = new D3D3Interface(m_commonD3DIntf.ptr(), m_commonIntf, m_parent);
       m_commonIntf->SetD3D3Interface(m_d3d3Intf.ptr());
@@ -113,12 +105,8 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirect3D3))) {
-      if (m_commonD3DIntf->GetD3D6Interface() != nullptr) {
-        Logger::debug("D3D5Interface::QueryInterface: Query for existing IDirect3D3");
+      if (m_commonD3DIntf->GetD3D6Interface() != nullptr)
         return m_commonD3DIntf->GetD3D6Interface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("D3D5Interface::QueryInterface: Query for IDirect3D3");
 
       // We don't have a proxied object on D3D5Interface, so use the parent
       // DDraw interface to get a proxied object for the queried D3D6Interface
@@ -145,8 +133,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Interface::EnumDevices(LPD3DENUMDEVICESCALLBACK lpEnumDevicesCallback, LPVOID lpUserArg) {
-    Logger::debug(">>> D3D5Interface::EnumDevices");
-
     if (unlikely(lpEnumDevicesCallback == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -171,13 +157,13 @@ namespace dxvk {
     desc2RAMP_HAL.dcmColorModel = 0;
     // RAMP devices use a monochrome color model
     desc2RAMP_HEL.dcmColorModel = D3DCOLOR_MONO;
-    // Some applications apparently care about RGB texture caps
+    // Some applications apparently care about HAL texture caps
     desc2RAMP_HAL.dpcLineCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                             & ~D3DPTEXTURECAPS_POW2;
+                                             & ~D3DPTEXTURECAPS_POW2
+                                             & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
     desc2RAMP_HAL.dpcTriCaps.dwTextureCaps  &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                             & ~D3DPTEXTURECAPS_POW2;
-    desc2RAMP_HEL.dpcLineCaps.dwTextureCaps |= D3DPTEXTURECAPS_POW2;
-    desc2RAMP_HEL.dpcTriCaps.dwTextureCaps  |= D3DPTEXTURECAPS_POW2;
+                                             & ~D3DPTEXTURECAPS_POW2
+                                             & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
     memcpy(&descRAMP_HAL, &desc2RAMP_HAL, sizeof(D3DDEVICEDESC2));
     memcpy(&descRAMP_HEL, &desc2RAMP_HEL, sizeof(D3DDEVICEDESC2));
     if (likely(!d3dOptions->legacyDeviceNames)) {
@@ -202,13 +188,13 @@ namespace dxvk {
     D3DDEVICEDESC descRGB_HEL = { };
     desc2RGB_HAL.dwFlags = 0;
     desc2RGB_HAL.dcmColorModel = 0;
-    // Some applications apparently care about RGB texture caps
+    // Some applications apparently care about HAL texture caps
     desc2RGB_HAL.dpcLineCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                            & ~D3DPTEXTURECAPS_POW2;
+                                            & ~D3DPTEXTURECAPS_POW2
+                                            & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
     desc2RGB_HAL.dpcTriCaps.dwTextureCaps  &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                            & ~D3DPTEXTURECAPS_POW2;
-    desc2RGB_HEL.dpcLineCaps.dwTextureCaps |= D3DPTEXTURECAPS_POW2;
-    desc2RGB_HEL.dpcTriCaps.dwTextureCaps  |= D3DPTEXTURECAPS_POW2;
+                                            & ~D3DPTEXTURECAPS_POW2
+                                            & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
     memcpy(&descRGB_HAL, &desc2RGB_HAL, sizeof(D3DDEVICEDESC2));
     memcpy(&descRGB_HEL, &desc2RGB_HEL, sizeof(D3DDEVICEDESC2));
 
@@ -233,11 +219,13 @@ namespace dxvk {
     D3DDEVICEDESC descHAL_HAL = { };
     D3DDEVICEDESC descHAL_HEL = { };
     desc2HAL_HEL.dcmColorModel = 0;
-    // Some applications apparently care about RGB texture caps
+    // Some applications apparently care about HEL texture caps
     desc2HAL_HEL.dpcLineCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                            & ~D3DPTEXTURECAPS_POW2;
+                                            & ~D3DPTEXTURECAPS_POW2
+                                            & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
     desc2HAL_HEL.dpcTriCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                           & ~D3DPTEXTURECAPS_POW2;
+                                           & ~D3DPTEXTURECAPS_POW2
+                                           & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
     desc2HAL_HEL.dwDevCaps &= ~D3DDEVCAPS_HWTRANSFORMANDLIGHT
                             & ~D3DDEVCAPS_DRAWPRIMITIVES2
                             & ~D3DDEVCAPS_DRAWPRIMITIVES2EX;
@@ -262,8 +250,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Interface::CreateLight(LPDIRECT3DLIGHT *lplpDirect3DLight, IUnknown *pUnkOuter) {
-    Logger::debug(">>> D3D5Interface::CreateLight");
-
     if (unlikely(lplpDirect3DLight == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -275,8 +261,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Interface::CreateMaterial(LPDIRECT3DMATERIAL2 *lplpDirect3DMaterial, IUnknown *pUnkOuter) {
-    Logger::debug(">>> D3D5Interface::CreateMaterial");
-
     if (unlikely(lplpDirect3DMaterial == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -288,8 +272,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Interface::CreateViewport(LPDIRECT3DVIEWPORT2 *lplpD3DViewport, IUnknown *pUnkOuter) {
-    Logger::debug(">>> D3D5Interface::CreateViewport");
-
     InitReturnPtr(lplpD3DViewport);
 
     *lplpD3DViewport = ref(new D3D5Viewport(nullptr, this));
@@ -299,8 +281,6 @@ namespace dxvk {
 
   // Minimal implementation which should suffice in most cases
   HRESULT STDMETHODCALLTYPE D3D5Interface::FindDevice(D3DFINDDEVICESEARCH *lpD3DFDS, D3DFINDDEVICERESULT *lpD3DFDR) {
-    Logger::debug(">>> D3D5Interface::FindDevice");
-
     if (unlikely(lpD3DFDS == nullptr || lpD3DFDR == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -317,23 +297,25 @@ namespace dxvk {
     D3DDEVICEDESC2 descRGB_HEL = descRGB_HAL;
     descRGB_HAL.dwFlags = 0;
     descRGB_HAL.dcmColorModel = 0;
-    // Some applications apparently care about RGB texture caps
+    // Some applications apparently care about HAL texture caps
     descRGB_HAL.dpcLineCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                           & ~D3DPTEXTURECAPS_POW2;
+                                           & ~D3DPTEXTURECAPS_POW2
+                                           & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
     descRGB_HAL.dpcTriCaps.dwTextureCaps  &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                           & ~D3DPTEXTURECAPS_POW2;
-    descRGB_HEL.dpcLineCaps.dwTextureCaps |= D3DPTEXTURECAPS_POW2;
-    descRGB_HEL.dpcTriCaps.dwTextureCaps  |= D3DPTEXTURECAPS_POW2;
+                                           & ~D3DPTEXTURECAPS_POW2
+                                           & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
 
     // Hardware acceleration
     D3DDEVICEDESC2 descHAL_HAL = GetD3D5Caps(IID_IDirect3DHALDevice, d3dOptions);
     D3DDEVICEDESC2 descHAL_HEL = descHAL_HAL;
     descHAL_HEL.dcmColorModel = 0;
-    // Some applications apparently care about RGB texture caps
+    // Some applications apparently care about HEL texture caps
     descHAL_HEL.dpcLineCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                           & ~D3DPTEXTURECAPS_POW2;
+                                           & ~D3DPTEXTURECAPS_POW2
+                                           & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
     descHAL_HEL.dpcTriCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                          & ~D3DPTEXTURECAPS_POW2;
+                                          & ~D3DPTEXTURECAPS_POW2
+                                          & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
     descHAL_HEL.dwDevCaps &= ~D3DDEVCAPS_HWTRANSFORMANDLIGHT
                            & ~D3DDEVCAPS_DRAWPRIMITIVES2
                            & ~D3DDEVCAPS_DRAWPRIMITIVES2EX;
@@ -342,17 +324,13 @@ namespace dxvk {
     lpD3DFRD2.dwSize = sizeof(D3DFINDDEVICERESULT2);
 
     if (lpD3DFDS->dwFlags & D3DFDS_GUID) {
-      Logger::debug("D3D5Interface::FindDevice: Matching by device GUID");
-
       if (lpD3DFDS->guid == IID_IDirect3DRGBDevice ||
           lpD3DFDS->guid == IID_IDirect3DMMXDevice ||
           lpD3DFDS->guid == IID_IDirect3DRampDevice) {
-        Logger::debug("D3D5Interface::FindDevice: Matched IID_IDirect3DRGBDevice");
         lpD3DFRD2.guid = IID_IDirect3DRGBDevice;
         lpD3DFRD2.ddHwDesc = descRGB_HAL;
         lpD3DFRD2.ddSwDesc = descRGB_HEL;
       } else if (lpD3DFDS->guid == IID_IDirect3DHALDevice) {
-        Logger::debug("D3D5Interface::FindDevice: Matched IID_IDirect3DHALDevice");
         lpD3DFRD2.guid = IID_IDirect3DHALDevice;
         lpD3DFRD2.ddHwDesc = descHAL_HAL;
         lpD3DFRD2.ddSwDesc = descHAL_HEL;
@@ -363,15 +341,11 @@ namespace dxvk {
 
       memcpy(lpD3DFDR, &lpD3DFRD2, sizeof(D3DFINDDEVICERESULT2));
     } else if (lpD3DFDS->dwFlags & D3DFDS_HARDWARE) {
-      Logger::debug("D3D5Interface::FindDevice: Matching by hardware flag");
-
       if (likely(lpD3DFDS->bHardware == TRUE)) {
-        Logger::debug("D3D5Interface::FindDevice: Matched IID_IDirect3DHALDevice");
         lpD3DFRD2.guid = IID_IDirect3DHALDevice;
         lpD3DFRD2.ddHwDesc = descHAL_HAL;
         lpD3DFRD2.ddSwDesc = descHAL_HEL;
       } else {
-        Logger::debug("D3D5Interface::FindDevice: Matched IID_IDirect3DRGBDevice");
         lpD3DFRD2.guid = IID_IDirect3DRGBDevice;
         lpD3DFRD2.ddHwDesc = descRGB_HAL;
         lpD3DFRD2.ddSwDesc = descRGB_HEL;
@@ -379,18 +353,12 @@ namespace dxvk {
 
       memcpy(lpD3DFDR, &lpD3DFRD2, sizeof(D3DFINDDEVICERESULT2));
     } else if (lpD3DFDS->dwFlags & D3DFDS_COLORMODEL) {
-      Logger::debug("D3D5Interface::FindDevice: Matching by color model");
-
-      Logger::debug("D3D5Interface::FindDevice: Matched IID_IDirect3DHALDevice");
       lpD3DFRD2.guid = IID_IDirect3DHALDevice;
       lpD3DFRD2.ddHwDesc = descHAL_HAL;
       lpD3DFRD2.ddSwDesc = descHAL_HEL;
 
       memcpy(lpD3DFDR, &lpD3DFRD2, sizeof(D3DFINDDEVICERESULT2));
     } else if (lpD3DFDS->dwFlags == 0) {
-      Logger::debug("D3D5Interface::FindDevice: No matching criteria specified");
-
-      Logger::debug("D3D5Interface::FindDevice: Matched IID_IDirect3DHALDevice");
       lpD3DFRD2.guid = IID_IDirect3DHALDevice;
       lpD3DFRD2.ddHwDesc = descHAL_HAL;
       lpD3DFRD2.ddSwDesc = descHAL_HEL;
@@ -405,26 +373,23 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Interface::CreateDevice(REFCLSID rclsid, LPDIRECTDRAWSURFACE lpDDS, LPDIRECT3DDEVICE2 *lplpD3DDevice) {
-    Logger::debug(">>> D3D5Interface::CreateDevice");
-
     if (unlikely(lplpD3DDevice == nullptr))
       return DDERR_INVALIDPARAMS;
 
     InitReturnPtr(lplpD3DDevice);
 
-    if (unlikely(lpDDS == nullptr)) {
-      Logger::err("D3D5Interface::CreateDevice: Null surface provided");
+    if (unlikely(lpDDS == nullptr))
       return DDERR_INVALIDPARAMS;
-    }
 
     const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
 
     DWORD deviceCreationFlags9 = D3DCREATE_SOFTWARE_VERTEXPROCESSING;
     bool  isHALDevice          = false;
+    bool  halFallback          = false;
     bool  rgbFallback          = false;
 
     if (likely(!d3dOptions->forceSWVP)) {
-      if (rclsid == IID_IDirect3DHALDevice || rclsid == IID_WineD3DDevice) {
+      if (rclsid == IID_IDirect3DHALDevice) {
         Logger::info("D3D5Interface::CreateDevice: Creating an IID_IDirect3DHALDevice device");
         deviceCreationFlags9 = D3DCREATE_MIXED_VERTEXPROCESSING;
         isHALDevice = true;
@@ -437,13 +402,19 @@ namespace dxvk {
         Logger::warn("D3D5Interface::CreateDevice: Unsupported Ramp device, falling back to RGB");
         rgbFallback = true;
       } else {
-        Logger::warn("D3D5Interface::CreateDevice: Unknown device identifier, falling back to RGB");
-        Logger::warn(str::format(rclsid));
-        rgbFallback = true;
+        if (unlikely(rclsid != IID_WineD3DDevice)) {
+          Logger::warn("D3D5Interface::CreateDevice: Unknown device type, falling back to HAL");
+          Logger::warn(str::format(rclsid));
+        } else {
+          Logger::info("D3D5Interface::CreateDevice: Creating an IID_WineD3DDevice HAL device");
+        }
+        halFallback = true;
+        // Don't enforce isHALDevice RT validations
       }
     }
 
-    const IID rclsidOverride = rgbFallback ? IID_IDirect3DRGBDevice : rclsid;
+    const IID rclsidOverride = halFallback ? IID_IDirect3DHALDevice :
+                               rgbFallback ? IID_IDirect3DRGBDevice : rclsid;
 
     HWND hWnd = m_commonIntf->GetHWND();
     // Needed to sometimes safely skip intro playback on legacy devices
@@ -455,7 +426,6 @@ namespace dxvk {
     if (unlikely(!DDrawCommonInterface::IsWrappedSurface(lpDDS))) {
       // Nightmare Creatures passes an IDirectDrawSurface3 surface as RT
       if (unlikely(DDrawCommonInterface::IsWrappedSurface(reinterpret_cast<IDirectDrawSurface3*>(lpDDS)))) {
-        Logger::debug("D3D5Interface::CreateDevice: IDirectDrawSurface3 surface passed as RT");
         DDraw3Surface* ddraw3Surface = reinterpret_cast<DDraw3Surface*>(lpDDS);
         // A DDrawSurface usually exists, because a DDraw3Surface is obtained from it via
         // QueryInterface, however the passed surface can be obtained by GetAttachedSurface() calls
@@ -503,7 +473,6 @@ namespace dxvk {
         if ((modeSize->width  && modeSize->width  < desc.dwWidth)
          || (modeSize->height && modeSize->height < desc.dwHeight)) {
           Logger::info("D3D5Interface::CreateDevice: Enforcing mode dimensions");
-
           backBufferWidth  = modeSize->width;
           BackBufferHeight = modeSize->height;
         }

--- a/src/ddraw/d3d5/d3d5_material.cpp
+++ b/src/ddraw/d3d5/d3d5_material.cpp
@@ -32,8 +32,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Material::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> D3D5Material::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
@@ -51,8 +49,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Material::SetMaterial(D3DMATERIAL *data) {
-    Logger::debug(">>> D3D5Material::SetMaterial");
-
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -74,8 +70,8 @@ namespace dxvk {
     if (likely(commonDevice != nullptr)) {
       const D3DMATERIALHANDLE handle        = m_commonMaterial->GetMaterialHandle();
       const D3DMATERIALHANDLE currentHandle = commonDevice->GetCurrentMaterialHandle();
-      if (currentHandle == handle) {
-        Logger::debug(str::format("D3D5Material::SetMaterial: Applying material nr. ", handle, " to D3D9"));
+      if (handle && currentHandle == handle) {
+        //Logger::debug(str::format("D3D5Material::SetMaterial: Applying material nr. ", handle, " to D3D9"));
         commonDevice->GetD3D9Device()->SetMaterial(material9);
       }
     }
@@ -84,8 +80,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Material::GetMaterial(D3DMATERIAL *data) {
-    Logger::debug(">>> D3D5Material::GetMaterial");
-
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -101,8 +95,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Material::GetHandle(IDirect3DDevice2 *device, D3DMATERIALHANDLE *handle) {
-    Logger::debug(">>> D3D5Material::GetHandle");
-
     if (unlikely(device == nullptr || handle == nullptr))
       return DDERR_INVALIDPARAMS;
 

--- a/src/ddraw/d3d5/d3d5_texture.cpp
+++ b/src/ddraw/d3d5/d3d5_texture.cpp
@@ -53,44 +53,34 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Texture::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(str::format(">>> ", m_objectType, "::QueryInterface"));
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
     InitReturnPtr(ppvObject);
 
     if (unlikely(riid == __uuidof(IDirect3DTexture))) {
-      Logger::debug(str::format(m_objectType, "::QueryInterface: Query for IDirect3DTexture"));
       return m_parent->QueryInterface(riid, ppvObject);
     }
     if (unlikely(riid == __uuidof(IDirectDrawGammaControl))) {
-      Logger::debug(str::format(m_objectType, "::QueryInterface: Query for IDirectDrawGammaControl"));
       return m_parent->QueryInterface(riid, ppvObject);
     }
     if (unlikely(riid == __uuidof(IDirectDrawColorControl))) {
-      Logger::debug(str::format(m_objectType, "::QueryInterface: Query for IDirectDrawColorControl"));
       return E_NOINTERFACE;
     }
     if (unlikely(riid == __uuidof(IUnknown)
               || riid == __uuidof(IDirectDrawSurface))) {
-      Logger::debug(str::format(m_objectType, "::QueryInterface: Query for IDirectDrawSurface"));
       return m_parent->QueryInterface(riid, ppvObject);
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface2))) {
-      Logger::debug(str::format(m_objectType, "::QueryInterface: Query for IDirectDrawSurface2"));
       return m_parent->QueryInterface(riid, ppvObject);
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface3))) {
-      Logger::debug(str::format(m_objectType, "::QueryInterface: Query for IDirectDrawSurface3"));
       return m_parent->QueryInterface(riid, ppvObject);
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface4))) {
-      Logger::debug(str::format(m_objectType, "::QueryInterface: Query for IDirectDrawSurface4"));
       return m_parent->QueryInterface(riid, ppvObject);
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface7))) {
-      Logger::debug(str::format(m_objectType, "::QueryInterface: Query for IDirectDrawSurface7"));
       return m_parent->QueryInterface(riid, ppvObject);
     }
 
@@ -105,8 +95,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Texture::GetHandle(LPDIRECT3DDEVICE2 lpDirect3DDevice2, LPD3DTEXTUREHANDLE lpHandle) {
-    Logger::debug(str::format(">>> ", m_objectType, "::GetHandle"));
-
     if (unlikely(lpDirect3DDevice2 == nullptr || lpHandle == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -116,7 +104,6 @@ namespace dxvk {
       // The Sims tries to get a handle from a surface which wasn't created with the DDSCAPS_TEXTURE flag,
       // so manually flag it as a texture before we initialize its D3D9 object
       if (likely(!commonSurf->IsInitialized())) {
-        Logger::debug(str::format(m_objectType, "::GetHandle: Parent surface isn't a texture"));
         m_commonTex->GetCommonSurface()->MarkWithTextureHandle();
       // If for some reason this happens after it's initialized, there's nothing we can do but log an error
       } else {
@@ -139,13 +126,10 @@ namespace dxvk {
   // Docs state: "This method only affects the legacy ramp device.
   // For all other devices, this method takes no action and returns D3D_OK."
   HRESULT STDMETHODCALLTYPE D3D5Texture::PaletteChanged(DWORD dwStart, DWORD dwCount) {
-    Logger::debug(str::format(">>> ", m_objectType, "::PaletteChanged"));
     return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Texture::Load(LPDIRECT3DTEXTURE2 lpD3DTexture2) {
-    Logger::debug(str::format("<<< ", m_objectType, "::Load: Proxy"));
-
     Com<D3D5Texture> d3d5Texture = static_cast<D3D5Texture*>(lpD3DTexture2);
 
     // IDirect3DTexture2 is guaranteed to have a IDirectDrawSurface4 parent,

--- a/src/ddraw/d3d5/d3d5_viewport.cpp
+++ b/src/ddraw/d3d5/d3d5_viewport.cpp
@@ -78,8 +78,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Viewport::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> D3D5Viewport::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
@@ -87,12 +85,8 @@ namespace dxvk {
 
     // Some games query for legacy viewport interfaces
     if (unlikely(riid == __uuidof(IDirect3DViewport))) {
-      if (m_commonViewport->GetD3D3Viewport() != nullptr) {
-        Logger::debug("D3D5Viewport::QueryInterface: Query for existing IDirect3DViewport");
+      if (m_commonViewport->GetD3D3Viewport() != nullptr)
         return m_commonViewport->GetD3D3Viewport()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("D3D5Viewport::QueryInterface: Query for IDirect3DViewport");
 
       m_viewport3 = new D3D3Viewport(m_commonViewport.ptr(), nullptr);
       *ppvObject = m_viewport3.ref();
@@ -100,12 +94,8 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirect3DViewport3))) {
-      if (m_commonViewport->GetD3D6Viewport() != nullptr) {
-        Logger::debug("D3D5Viewport::QueryInterface: Query for existing IDirect3DViewport3");
+      if (m_commonViewport->GetD3D6Viewport() != nullptr)
         return m_commonViewport->GetD3D6Viewport()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("D3D5Viewport::QueryInterface: Query for IDirect3DViewport3");
 
       m_viewport6 = new D3D6Viewport(m_commonViewport.ptr(), nullptr);
       *ppvObject = m_viewport6.ref();
@@ -126,13 +116,10 @@ namespace dxvk {
 
   // Docs state: "The IDirect3DViewport2::Initialize method is not implemented."
   HRESULT STDMETHODCALLTYPE D3D5Viewport::Initialize(LPDIRECT3D lpDirect3D) {
-    Logger::debug(">>> D3D5Viewport::Initialize");
     return DDERR_ALREADYINITIALIZED;
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Viewport::GetViewport(D3DVIEWPORT *data) {
-    Logger::debug(">>> D3D5Viewport::GetViewport");
-
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -163,8 +150,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Viewport::SetViewport(D3DVIEWPORT *data) {
-    Logger::debug(">>> D3D5Viewport::SetViewport");
-
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -212,12 +197,8 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Viewport::TransformVertices(DWORD vertex_count, D3DTRANSFORMDATA *data, DWORD flags, DWORD *offscreen) {
-    Logger::debug(">>> D3D5Viewport::TransformVertices");
-
-    if (unlikely(!m_commonViewport->HasDevice())) {
-      Logger::warn("D3D5Viewport::TransformVertices: Viewport isn't attached to a device");
+    if (unlikely(!m_commonViewport->HasDevice()))
       return D3DERR_VIEWPORTHASNODEVICE;
-    }
 
     d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
 
@@ -245,13 +226,10 @@ namespace dxvk {
 
   // Docs state: "The IDirect3DViewport2::LightElements method is not currently implemented."
   HRESULT STDMETHODCALLTYPE D3D5Viewport::LightElements(DWORD element_count, D3DLIGHTDATA *data) {
-    Logger::warn(">>> D3D5Viewport::LightElements");
     return DDERR_UNSUPPORTED;
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Viewport::SetBackground(D3DMATERIALHANDLE hMat) {
-    Logger::debug(">>> D3D5Viewport::SetBackground");
-
     if (unlikely(m_commonViewport->GetMaterialHandle() == hMat))
       return D3D_OK;
 
@@ -268,8 +246,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Viewport::GetBackground(D3DMATERIALHANDLE *material, BOOL *valid) {
-    Logger::debug(">>> D3D5Viewport::GetBackground");
-
     if (unlikely(material == nullptr || valid == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -280,22 +256,24 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Viewport::SetBackgroundDepth(IDirectDrawSurface *surface) {
-    Logger::debug(">>> D3D5Viewport::SetBackgroundDepth");
-
-    if (unlikely(!DDrawCommonInterface::IsWrappedSurface(surface))) {
+    if (unlikely(surface != nullptr
+             && !DDrawCommonInterface::IsWrappedSurface(surface))) {
       Logger::err("D3D5Viewport::SetBackgroundDepth: Received an unwrapped surface");
       return DDERR_UNSUPPORTED;
     }
 
-    m_backgroundDepth = reinterpret_cast<DDrawSurface*>(surface);
-    m_isBackgroundDepthSet = true;
+    if (unlikely(surface == nullptr)) {
+      m_backgroundDepth = nullptr;
+      m_isBackgroundDepthSet = false;
+    } else {
+      m_backgroundDepth = reinterpret_cast<DDrawSurface*>(surface);
+      m_isBackgroundDepthSet = true;
+    }
 
     return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Viewport::GetBackgroundDepth(IDirectDrawSurface **surface, BOOL *valid) {
-    Logger::debug(">>> D3D5Viewport::GetBackgroundDepth");
-
     if (unlikely(surface == nullptr || valid == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -308,14 +286,12 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Viewport::Clear(DWORD count, D3DRECT *rects, DWORD flags) {
-    Logger::debug(">>> D3D5Viewport::Clear");
+    // Early D3D viewport fast skip
+    if (unlikely(!count || !rects))
+      return D3D_OK;
 
     if (unlikely(!m_commonViewport->HasDevice()))
       return D3DERR_VIEWPORTHASNODEVICE;
-
-    // Early D3D viewport fast skip
-    if (unlikely(!count || (count && rects == nullptr)))
-      return D3D_OK;
 
     const bool clearRenderTarget = flags & D3DCLEAR_TARGET;
     const bool clearDepthStencil = flags & D3DCLEAR_ZBUFFER;
@@ -327,7 +303,7 @@ namespace dxvk {
       if (likely(rt != nullptr)) {
         // If this isn't a full surface clear, we need to first upload the DDraw surface
         if (unlikely(count > 1 || !rt->IsFullSurfaceLock(reinterpret_cast<RECT*>(rects), nullptr))) {
-          Logger::debug("D3D5Viewport::Clear: Partial render target clear");
+          //Logger::debug("D3D5Viewport::Clear: Partial render target clear");
           // Use a common surface helper, because we want to handle all
           // possible surface interfaces that may be alive at this time
           rt->InitializeOrUploadD3D9();
@@ -339,7 +315,7 @@ namespace dxvk {
       if (likely(ds != nullptr)) {
         // If this isn't a full surface clear, we need to first upload the DDraw surface
         if (unlikely(count > 1 || !ds->IsFullSurfaceLock(reinterpret_cast<RECT*>(rects), nullptr))) {
-          Logger::debug("D3D5Viewport::Clear: Partial depth stencil clear");
+          //Logger::debug("D3D5Viewport::Clear: Partial depth stencil clear");
           // Use a common surface helper, because we want to handle all
           // possible surface interfaces that may be alive at this time
           ds->InitializeOrUploadD3D9();
@@ -351,7 +327,8 @@ namespace dxvk {
 
     // Temporarily activate this viewport in order to clear it
     d3d9::D3DVIEWPORT9 currentViewport9;
-    if (!m_commonViewport->IsCurrentViewport()) {
+    const bool isCurrentViewport = m_commonViewport->IsCurrentViewport();
+    if (!isCurrentViewport) {
       D3D5Viewport* currentViewport = m_commonViewport->GetCurrentD3D5Viewport();
       if (currentViewport != nullptr) {
         currentViewport9 = *currentViewport->GetCommonViewport()->GetD3D9Viewport();
@@ -371,14 +348,14 @@ namespace dxvk {
     HRESULT hr = d3d9Device->Clear(count, rects, flags, clearColor, 1.0f, 0u);
 
     // Restore the previously active viewport
-    if (!m_commonViewport->IsCurrentViewport()) {
+    if (!isCurrentViewport) {
       d3d9Device->SetViewport(&currentViewport9);
     }
 
-    // Clear() will only ever silently fail
+    // Can fail in D3D9 only in case of a missing depth stencil surface
     if (unlikely(FAILED(hr))) {
-      Logger::debug("D3D5Viewport::Clear: Failed D3D9 Clear call");
-      return D3D_OK;
+      // Fix up expected return codes
+      return D3DERR_ZBUFFER_NOTPRESENT;
     }
 
     if (clearRenderTarget && rt != nullptr)
@@ -392,8 +369,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Viewport::AddLight(IDirect3DLight *light) {
-    Logger::debug(">>> D3D5Viewport::AddLight");
-
     if (unlikely(light == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -415,8 +390,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Viewport::DeleteLight(IDirect3DLight *light) {
-    Logger::debug(">>> D3D5Viewport::DeleteLight");
-
     if (unlikely(light == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -431,7 +404,7 @@ namespace dxvk {
     if (likely(it != lights.end())) {
       const DWORD lightIndex = d3dLight->GetIndex();
       if (m_commonViewport->HasDevice() && m_commonViewport->IsCurrentViewport() && d3dLight->IsActive()) {
-        Logger::debug(str::format("D3D5Viewport: Disabling light nr. ", lightIndex));
+        //Logger::debug(str::format("D3D5Viewport: Disabling light nr. ", lightIndex));
         d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
         d3d9Device->LightEnable(lightIndex, FALSE);
       }
@@ -446,8 +419,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Viewport::NextLight(IDirect3DLight *lpDirect3DLight, IDirect3DLight **lplpDirect3DLight, DWORD flags) {
-    Logger::debug(">>> D3D5Viewport::NextLight");
-
     if (unlikely(lplpDirect3DLight == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -473,8 +444,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Viewport::GetViewport2(D3DVIEWPORT2 *data) {
-    Logger::debug(">>> D3D5Viewport::GetViewport2");
-
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -504,8 +473,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Viewport::SetViewport2(D3DVIEWPORT2 *data) {
-    Logger::debug(">>> D3D5Viewport::SetViewport2");
-
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -554,8 +521,6 @@ namespace dxvk {
     if (!m_commonViewport->IsViewportSet())
       return D3D_OK;
 
-    Logger::debug("D3D5Viewport: Applying viewport to D3D9");
-
     d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
 
     HRESULT hr = d3d9Device->SetViewport(m_commonViewport->GetD3D9Viewport());
@@ -573,8 +538,6 @@ namespace dxvk {
     if (!lights.size())
       return D3D_OK;
 
-    Logger::debug("D3D5Viewport: Applying lights to D3D9");
-
     for (auto light: lights)
       ApplyAndActivateLight(light->GetIndex(), light.ptr());
 
@@ -587,14 +550,12 @@ namespace dxvk {
     if (!lights.size())
       return D3D_OK;
 
-    Logger::debug("D3D5Viewport: Deactivating D3D9 lights");
-
     d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
 
     for (auto light: lights) {
       const DWORD lightIndex = light->GetIndex();
       if (m_commonViewport->HasDevice() && m_commonViewport->IsCurrentViewport() && light->IsActive()) {
-        Logger::debug(str::format("D3D5Viewport: Disabling light nr. ", lightIndex));
+        //Logger::debug(str::format("D3D5Viewport: Disabling light nr. ", lightIndex));
         d3d9Device->LightEnable(lightIndex, FALSE);
       }
     }
@@ -612,12 +573,12 @@ namespace dxvk {
     }
 
     if (light->IsActive()) {
-      Logger::debug(str::format("D3D5Viewport: Enabling D3D9 light nr. ", index));
+      //Logger::debug(str::format("D3D5Viewport: Enabling D3D9 light nr. ", index));
       hr = d3d9Device->LightEnable(index, TRUE);
       if (unlikely(FAILED(hr)))
         Logger::err("D3D5Viewport: Failed D3D9 LightEnable call (TRUE)");
     } else {
-      Logger::debug(str::format("D3D5Viewport: Disabling D3D9 light nr. ", index));
+      //Logger::debug(str::format("D3D5Viewport: Disabling D3D9 light nr. ", index));
       hr = d3d9Device->LightEnable(index, FALSE);
       if (unlikely(FAILED(hr)))
         Logger::err("D3D5Viewport: Failed D3D9 LightEnable call (FALSE)");

--- a/src/ddraw/d3d6/d3d6_buffer.cpp
+++ b/src/ddraw/d3d6/d3d6_buffer.cpp
@@ -35,8 +35,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6VertexBuffer::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> D3D6VertexBuffer::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
@@ -54,8 +52,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6VertexBuffer::GetVertexBufferDesc(LPD3DVERTEXBUFFERDESC lpVBDesc) {
-    Logger::debug(">>> D3D6VertexBuffer::GetVertexBufferDesc");
-
     if (unlikely(lpVBDesc == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -70,8 +66,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6VertexBuffer::Lock(DWORD flags, void **data, DWORD *data_size) {
-    Logger::debug(">>> D3D6VertexBuffer::Lock");
-
     if (unlikely(IsOptimized()))
       return D3DERR_VERTEXBUFFEROPTIMIZED;
 
@@ -95,8 +89,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6VertexBuffer::Unlock() {
-    Logger::debug(">>> D3D6VertexBuffer::Unlock");
-
     RefreshD3DDevice();
     if (unlikely(!IsInitialized())) {
       HRESULT hrInit = InitializeD3D9();
@@ -114,8 +106,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6VertexBuffer::ProcessVertices(DWORD dwVertexOp, DWORD dwDestIndex, DWORD dwCount, LPDIRECT3DVERTEXBUFFER lpSrcBuffer, DWORD dwSrcIndex, LPDIRECT3DDEVICE3 lpD3DDevice, DWORD dwFlags) {
-    Logger::debug(">>> D3D6VertexBuffer::ProcessVertices");
-
     if (unlikely(!dwCount))
       return D3D_OK;
 
@@ -249,8 +239,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6VertexBuffer::Optimize(LPDIRECT3DDEVICE3 lpD3DDevice, DWORD dwFlags) {
-    Logger::debug(">>> D3D6VertexBuffer::Optimize");
-
     if (unlikely(lpD3DDevice == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -272,22 +260,23 @@ namespace dxvk {
       return DDERR_GENERIC;
     }
 
-    d3d9::IDirect3DDevice9* device9 = m_d3d6Device->GetCommonD3DDevice()->GetD3D9Device();
+    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
 
-    const d3d9::D3DPOOL pool = (m_desc.dwCaps & D3DVBCAPS_SYSTEMMEMORY) ? d3d9::D3DPOOL_SYSTEMMEM : d3d9::D3DPOOL_DEFAULT;
-    const char* poolPlacement = pool == d3d9::D3DPOOL_DEFAULT ? "D3DPOOL_DEFAULT" : "D3DPOOL_SYSTEMMEM";
+    const d3d9::D3DPOOL pool = (m_desc.dwCaps & D3DVBCAPS_SYSTEMMEMORY) ? d3d9::D3DPOOL_SYSTEMMEM :
+                               d3dOptions->managedVertexBuffers ? d3d9::D3DPOOL_MANAGED : d3d9::D3DPOOL_DEFAULT;
+    const DWORD usage = ConvertD3D6UsageFlags(m_desc.dwCaps, m_creationFlags, pool);
 
+    const char* poolPlacement = pool == d3d9::D3DPOOL_DEFAULT ? "D3DPOOL_DEFAULT" :
+                                pool == d3d9::D3DPOOL_SYSTEMMEM ? "D3DPOOL_SYSTEMMEM" : "D3DPOOL_MANAGED";
     Logger::debug(str::format("D3D6VertexBuffer::InitializeD3D9: Placing in: ", poolPlacement));
 
-    const DWORD usage = ConvertD3D6UsageFlags(m_desc.dwCaps, m_creationFlags);
+    d3d9::IDirect3DDevice9* device9 = m_d3d6Device->GetCommonD3DDevice()->GetD3D9Device();
     HRESULT hr = device9->CreateVertexBuffer(m_size, usage, m_desc.dwFVF, pool, &m_vb9, nullptr);
 
     if (unlikely(FAILED(hr))) {
       Logger::err("D3D6VertexBuffer::InitializeD3D9: Failed to create D3D9 vertex buffer");
       return hr;
     }
-
-    Logger::debug("D3D6VertexBuffer::InitializeD3D9: Created D3D9 vertex buffer");
 
     return D3D_OK;
   }

--- a/src/ddraw/d3d6/d3d6_device.cpp
+++ b/src/ddraw/d3d6/d3d6_device.cpp
@@ -53,14 +53,6 @@ namespace dxvk {
         Logger::warn("D3D6Device: Force enabling AA");
         device9->SetRenderState(d3d9::D3DRS_MULTISAMPLEANTIALIAS, TRUE);
       }
-
-      // The default value of D3DRENDERSTATE_TEXTUREMAPBLEND in D3D6 is D3DTBLEND_MODULATE
-      device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG1, D3DTA_TEXTURE);
-      device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
-      device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
-      device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG1);
-      device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-      device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
     } else {
       device9 = m_commonD3DDevice->GetD3D9Device();
       // Very important, otherwise the depth stencil isn't dirtied on draws
@@ -145,20 +137,14 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Device::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> D3D6Device::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
     InitReturnPtr(ppvObject);
 
     if (unlikely(riid == __uuidof(IDirect3DDevice))) {
-      if (m_commonD3DDevice->GetD3D3Device() != nullptr) {
-        Logger::debug("D3D6Device::QueryInterface: Query for existing IDirect3DDevice");
+      if (m_commonD3DDevice->GetD3D3Device() != nullptr)
         return m_commonD3DDevice->GetD3D3Device()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("D3D6Device::QueryInterface: Query for IDirect3DDevice");
 
       Com<DDrawSurface> rt = m_rt->GetCommonSurface()->GetDDSurface();
       // Manually retrieve a DDrawSurface object if it doesn't otherwise exist
@@ -181,12 +167,8 @@ namespace dxvk {
     // Some games, such as Hype: The Time Quest, apparently query this
     // as well, albeit without actually using the returned object...
     if (unlikely(riid == __uuidof(IDirect3DDevice2))) {
-      if (m_commonD3DDevice->GetD3D5Device() != nullptr) {
-        Logger::debug("D3D6Device::QueryInterface: Query for existing IDirect3DDevice2");
+      if (m_commonD3DDevice->GetD3D5Device() != nullptr)
         return m_commonD3DDevice->GetD3D5Device()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("D3D6Device::QueryInterface: Query for IDirect3DDevice2");
 
       Com<DDrawSurface> rt = m_rt->GetCommonSurface()->GetDDSurface();
       // Manually retrieve a DDrawSurface object if it doesn't otherwise exist
@@ -217,8 +199,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Device::GetCaps(D3DDEVICEDESC *hal_desc, D3DDEVICEDESC *hel_desc) {
-    Logger::debug(">>> D3D6Device::GetCaps");
-
     if (unlikely(hal_desc == nullptr || hel_desc == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -234,13 +214,13 @@ namespace dxvk {
     if (deviceGUID == IID_IDirect3DRGBDevice) {
       desc_HAL.dwFlags = 0;
       desc_HAL.dcmColorModel = 0;
-      // Some applications apparently care about RGB texture caps
+      // Some applications apparently care about HAL texture caps
       desc_HAL.dpcLineCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE
+                                          & ~D3DPTEXTURECAPS_POW2
                                           & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
       desc_HAL.dpcTriCaps.dwTextureCaps  &= ~D3DPTEXTURECAPS_PERSPECTIVE
+                                          & ~D3DPTEXTURECAPS_POW2
                                           & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
-      desc_HEL.dpcLineCaps.dwTextureCaps |= D3DPTEXTURECAPS_POW2;
-      desc_HEL.dpcTriCaps.dwTextureCaps  |= D3DPTEXTURECAPS_POW2;
     } else if (deviceGUID == IID_IDirect3DHALDevice) {
       desc_HEL.dcmColorModel = 0;
       desc_HEL.dwDevCaps &= ~D3DDEVCAPS_HWTRANSFORMANDLIGHT
@@ -259,14 +239,11 @@ namespace dxvk {
   // Docs state: "The IDirect3DDevice3::GetStats method is obsolete,
   // and not implemented in the IDirect3DDevice3 interface."
   HRESULT STDMETHODCALLTYPE D3D6Device::GetStats(D3DSTATS *stats) {
-    Logger::debug(">>> D3D6Device::GetStats");
     return DDERR_UNSUPPORTED;
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Device::AddViewport(IDirect3DViewport3 *viewport) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D6Device::AddViewport");
 
     if (unlikely(viewport == nullptr))
       return DDERR_INVALIDPARAMS;
@@ -278,8 +255,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D6Device::DeleteViewport(IDirect3DViewport3 *viewport) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D6Device::DeleteViewport");
 
     if (unlikely(viewport == nullptr))
       return DDERR_INVALIDPARAMS;
@@ -296,8 +271,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D6Device::NextViewport(IDirect3DViewport3 *lpDirect3DViewport, IDirect3DViewport3 **lplpAnotherViewport, DWORD flags) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D6Device::NextViewport");
 
     if (unlikely(lplpAnotherViewport == nullptr))
       return DDERR_INVALIDPARAMS;
@@ -322,8 +295,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Device::EnumTextureFormats(LPD3DENUMPIXELFORMATSCALLBACK cb, void *ctx) {
-    Logger::debug(">>> D3D6Device::EnumTextureFormats");
-
     if (unlikely(cb == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -423,8 +394,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D6Device::BeginScene() {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D6Device::BeginScene");
-
     RefreshLastUsedDevice();
 
     if (unlikely(m_commonD3DDevice->IsInScene()))
@@ -442,8 +411,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D6Device::EndScene() {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D6Device::EndScene");
-
     RefreshLastUsedDevice();
 
     if (unlikely(!m_commonD3DDevice->IsInScene()))
@@ -459,8 +426,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Device::GetDirect3D(IDirect3D3 **d3d) {
-    Logger::debug(">>> D3D6Device::GetDirect3D");
-
     if (unlikely(d3d == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -478,8 +443,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D6Device::SetCurrentViewport(IDirect3DViewport3 *viewport) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D6Device::SetCurrentViewport");
 
     if (unlikely(viewport == nullptr))
       return DDERR_INVALIDPARAMS;
@@ -510,8 +473,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D6Device::GetCurrentViewport(IDirect3DViewport3 **viewport) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D6Device::GetCurrentViewport");
-
     // This does indeed return D3DERR_NOCURRENTVIEWPORT...
     if (unlikely(viewport == nullptr))
       return D3DERR_NOCURRENTVIEWPORT;
@@ -530,12 +491,8 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D6Device::SetRenderTarget(IDirectDrawSurface4 *surface, DWORD flags) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D6Device::SetRenderTarget");
-
-    if (unlikely(surface == nullptr)) {
-      Logger::err("D3D6Device::SetRenderTarget: NULL render target");
+    if (unlikely(surface == nullptr))
       return DDERR_INVALIDPARAMS;
-    }
 
     if (unlikely(!DDrawCommonInterface::IsWrappedSurface(surface))) {
       Logger::err("D3D6Device::SetRenderTarget: Received an unwrapped RT");
@@ -566,8 +523,6 @@ namespace dxvk {
     m_ds = m_rt->GetAttachedDepthStencil();
 
     if (m_ds != nullptr) {
-      Logger::debug("D3D6Device::SetRenderTarget: Found an attached DS");
-
       hr = m_ds->InitializeD3D9DepthStencil();
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D6Device::SetRenderTarget: Failed to initialize/upload D3D9 DS");
@@ -580,8 +535,6 @@ namespace dxvk {
         return hr;
       }
     } else {
-      Logger::debug("D3D6Device::SetRenderTarget: RT has no depth stencil attached");
-
       hr = device9->SetDepthStencilSurface(nullptr);
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D6Device::SetRenderTarget: Failed to clear the D3D9 DS");
@@ -595,8 +548,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D6Device::GetRenderTarget(IDirectDrawSurface4 **surface) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D6Device::GetRenderTarget");
-
     if (unlikely(surface == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -607,8 +558,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D6Device::Begin(D3DPRIMITIVETYPE d3dptPrimitiveType, DWORD dwVertexTypeDesc, DWORD dwFlags) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D6Device::Begin");
 
     // All FVF combinations are technically supported,
     // but I doubt that is the case in practice
@@ -634,8 +583,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D6Device::Vertex(void *vertex) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D6Device::Vertex");
-
     if (unlikely(vertex == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -660,8 +607,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D6Device::End(DWORD dwFlags) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D6Device::End");
 
     HRESULT hr;
     if (m_vertexStreamInfo.d3dvt == D3DVT_VERTEX) {
@@ -692,8 +637,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D6Device::GetRenderState(D3DRENDERSTATETYPE dwRenderStateType, LPDWORD lpdwRenderState) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(str::format(">>> D3D6Device::GetRenderState: ", dwRenderStateType));
-
     if (unlikely(lpdwRenderState == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -701,7 +644,6 @@ namespace dxvk {
     // unknown or invalid render states.
     if (unlikely(!IsValidD3D6RenderStateType(dwRenderStateType)
               && !m_commonIntf->GetOptions()->apitraceMode)) {
-      Logger::debug(str::format("D3D6Device::GetRenderState: Invalid render state ", dwRenderStateType));
       *lpdwRenderState = 0;
       return D3D_OK;
     }
@@ -888,14 +830,10 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D6Device::SetRenderState(D3DRENDERSTATETYPE dwRenderStateType, DWORD dwRenderState) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(str::format(">>> D3D6Device::SetRenderState: ", dwRenderStateType));
-
     // As opposed to D3D7, D3D6 does not error out on
     // unknown or invalid render states.
-    if (unlikely(!IsValidD3D6RenderStateType(dwRenderStateType))) {
-      Logger::debug(str::format("D3D6Device::SetRenderState: Invalid render state ", dwRenderStateType));
+    if (unlikely(!IsValidD3D6RenderStateType(dwRenderStateType)))
       return D3D_OK;
-    }
 
     d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
     d3d9::D3DRENDERSTATETYPE State9 = d3d9::D3DRENDERSTATETYPE(dwRenderStateType);
@@ -989,19 +927,9 @@ namespace dxvk {
         return D3D_OK;
 
       case D3DRENDERSTATE_MONOENABLE:
-        static bool s_monoEnableErrorShown;
-
-        if (dwRenderState && !std::exchange(s_monoEnableErrorShown, true))
-          Logger::warn("D3D6Device::SetRenderState: Unimplemented render state D3DRENDERSTATE_MONOENABLE");
-
         return D3D_OK;
 
       case D3DRENDERSTATE_ROP2:
-        static bool s_ROP2ErrorShown;
-
-        if (!std::exchange(s_ROP2ErrorShown, true))
-          Logger::warn("D3D6Device::SetRenderState: Unimplemented render state D3DRENDERSTATE_ROP2");
-
         return D3D_OK;
 
       // Docs state: "This render state is not supported by the software
@@ -1088,8 +1016,8 @@ namespace dxvk {
             device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
             device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
             device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG1);
-            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_CURRENT);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_CURRENT);
             break;
           // "In this mode, the RGB and alpha values of the texture are blended with the colors
           //  that would have been used with no texturing, according to the following formulas [...]"
@@ -1098,8 +1026,8 @@ namespace dxvk {
             device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
             device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_BLENDTEXTUREALPHA);
             device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG2);
-            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_CURRENT);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_CURRENT);
             break;
           // "In this mode, the RGB values of the texture are multiplied with the RGB values that
           //  would have been used with no texturing, and the alpha values of the texture
@@ -1109,8 +1037,8 @@ namespace dxvk {
             device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
             device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_MODULATE);
             device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_MODULATE);
-            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_CURRENT);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_CURRENT);
             break;
           // "Add the Gouraud interpolants to the texture lookup with saturation semantics
           //  (that is, if the color value overflows it is set to the maximum possible value)."
@@ -1119,8 +1047,8 @@ namespace dxvk {
             device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
             device9->SetTextureStageState(0, d3d9::D3DTSS_COLOROP,   D3DTOP_ADD);
             device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP,   D3DTOP_SELECTARG2);
-            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_COLORARG2, D3DTA_CURRENT);
+            device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAARG2, D3DTA_CURRENT);
             break;
           // Unsupported
           default:
@@ -1142,24 +1070,12 @@ namespace dxvk {
       case D3DRENDERSTATE_SUBPIXELX:
         return D3D_OK;
 
-      // Tests have shown age accurate GPUs didn't offer support for
-      // stippling at all, so this should be safe to ignore
+      // Tests have shown age accurate GPUs didn't offer support for stippling at all
       case D3DRENDERSTATE_STIPPLEDALPHA:
-        static bool s_stippledAlphaErrorShown;
-
-        if (dwRenderState && !std::exchange(s_stippledAlphaErrorShown, true))
-          Logger::warn("D3D6Device::SetRenderState: Unimplemented render state D3DRENDERSTATE_STIPPLEDALPHA");
-
         return D3D_OK;
 
-      // Tests have shown age accurate GPUs didn't offer support for
-      // stippling at all, so this should be safe to ignore
+      // Tests have shown age accurate GPUs didn't offer support for stippling at all
       case D3DRENDERSTATE_STIPPLEENABLE:
-        static bool s_stippleEnableErrorShown;
-
-        if (dwRenderState && !std::exchange(s_stippleEnableErrorShown, true))
-          Logger::warn("D3D6Device::SetRenderState: Unimplemented render state D3DRENDERSTATE_STIPPLEENABLE");
-
         return D3D_OK;
 
       case D3DRENDERSTATE_EDGEANTIALIAS:
@@ -1218,7 +1134,7 @@ namespace dxvk {
       case D3DRENDERSTATE_TRANSLUCENTSORTINDEPENDENT:
         return D3D_OK;
 
-      // TODO:
+      // Tests have shown age accurate GPUs didn't offer support for stippling at all
       case D3DRENDERSTATE_STIPPLEPATTERN00:
       case D3DRENDERSTATE_STIPPLEPATTERN01:
       case D3DRENDERSTATE_STIPPLEPATTERN02:
@@ -1251,11 +1167,6 @@ namespace dxvk {
       case D3DRENDERSTATE_STIPPLEPATTERN29:
       case D3DRENDERSTATE_STIPPLEPATTERN30:
       case D3DRENDERSTATE_STIPPLEPATTERN31:
-        static bool s_stipplePatternErrorShown;
-
-        if (!std::exchange(s_stipplePatternErrorShown, true))
-          Logger::warn("D3D6Device::SetRenderState: Unimplemented render state D3DRENDERSTATE_STIPPLEPATTERN");
-
         return D3D_OK;
     }
 
@@ -1265,8 +1176,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D6Device::GetLightState(D3DLIGHTSTATETYPE dwLightStateType, LPDWORD lpdwLightState) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D6Device::GetLightState");
 
     if (unlikely(lpdwLightState == nullptr))
       return DDERR_INVALIDPARAMS;
@@ -1308,14 +1217,14 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D6Device::SetLightState(D3DLIGHTSTATETYPE dwLightStateType, DWORD dwLightState) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D6Device::SetLightState");
-
     d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     switch (dwLightStateType) {
       case D3DLIGHTSTATE_MATERIAL: {
         if (unlikely(!dwLightState)) {
           m_commonD3DDevice->SetCurrentMaterialHandle(dwLightState);
+          static constexpr d3d9::D3DMATERIAL9 DefaultMaterial9 = { };
+          device9->SetMaterial(&DefaultMaterial9);
           return D3D_OK;
         }
 
@@ -1324,7 +1233,7 @@ namespace dxvk {
           return DDERR_INVALIDPARAMS;
 
         m_commonD3DDevice->SetCurrentMaterialHandle(dwLightState);
-        Logger::debug(str::format("D3D6Device::SetLightState: Applying material nr. ", dwLightState, " to D3D9"));
+        //Logger::debug(str::format("D3D6Device::SetLightState: Applying material nr. ", dwLightState, " to D3D9"));
         device9->SetMaterial(material9);
 
         break;
@@ -1359,24 +1268,19 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Device::SetTransform(D3DTRANSFORMSTATETYPE state, D3DMATRIX *matrix) {
-    Logger::debug(">>> D3D6Device::SetTransform");
     return m_commonD3DDevice->GetD3D9Device()->SetTransform(ConvertTransformState(state), matrix);
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Device::GetTransform(D3DTRANSFORMSTATETYPE state, D3DMATRIX *matrix) {
-    Logger::debug(">>> D3D6Device::GetTransform");
     return m_commonD3DDevice->GetD3D9Device()->GetTransform(ConvertTransformState(state), matrix);
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Device::MultiplyTransform(D3DTRANSFORMSTATETYPE state, D3DMATRIX *matrix) {
-    Logger::debug(">>> D3D6Device::MultiplyTransform");
     return m_commonD3DDevice->GetD3D9Device()->MultiplyTransform(ConvertTransformState(state), matrix);
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Device::DrawPrimitive(D3DPRIMITIVETYPE primitive_type, DWORD vertex_type, void *vertices, DWORD vertex_count, DWORD flags) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D6Device::DrawPrimitive");
 
     RefreshLastUsedDevice();
 
@@ -1421,8 +1325,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D6Device::DrawIndexedPrimitive(D3DPRIMITIVETYPE primitive_type, DWORD fvf, void *vertices, DWORD vertex_count, WORD *indices, DWORD index_count, DWORD flags) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D6Device::DrawIndexedPrimitive");
 
     RefreshLastUsedDevice();
 
@@ -1470,8 +1372,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Device::SetClipStatus(D3DCLIPSTATUS *clip_status) {
-    Logger::debug(">>> D3D6Device::SetClipStatus");
-
     if (unlikely(clip_status == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -1479,8 +1379,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Device::GetClipStatus(D3DCLIPSTATUS *clip_status) {
-    Logger::debug(">>> D3D6Device::GetClipStatus");
-
     if (unlikely(clip_status == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -1501,8 +1399,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D6Device::DrawPrimitiveStrided(D3DPRIMITIVETYPE primitive_type, DWORD fvf, D3DDRAWPRIMITIVESTRIDEDDATA *strided_data, DWORD vertex_count, DWORD flags) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D6Device::DrawPrimitiveStrided");
 
     RefreshLastUsedDevice();
 
@@ -1550,8 +1446,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D6Device::DrawIndexedPrimitiveStrided(D3DPRIMITIVETYPE primitive_type, DWORD fvf, D3DDRAWPRIMITIVESTRIDEDDATA *strided_data, DWORD vertex_count, WORD *indices, DWORD index_count, DWORD flags) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D6Device::DrawIndexedPrimitiveStrided");
 
     RefreshLastUsedDevice();
 
@@ -1604,8 +1498,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D6Device::DrawPrimitiveVB(D3DPRIMITIVETYPE primitive_type, IDirect3DVertexBuffer *vb, DWORD start_vertex, DWORD vertex_count, DWORD flags) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D6Device::DrawPrimitiveVB");
-
     RefreshLastUsedDevice();
 
     if (unlikely(!vertex_count))
@@ -1656,8 +1548,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D6Device::DrawIndexedPrimitiveVB(D3DPRIMITIVETYPE primitive_type, IDirect3DVertexBuffer *vb, WORD *indices, DWORD index_count, DWORD flags) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D6Device::DrawIndexedPrimitiveVB");
 
     RefreshLastUsedDevice();
 
@@ -1727,8 +1617,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Device::ComputeSphereVisibility(D3DVECTOR *lpCenters, D3DVALUE *lpRadii, DWORD dwNumSpheres, DWORD dwFlags, DWORD *lpdwReturnValues) {
-    Logger::debug(">>> D3D6Device::ComputeSphereVisibility");
-
     if (unlikely(lpCenters == nullptr || lpRadii == nullptr || lpdwReturnValues == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -1749,15 +1637,11 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D6Device::GetTexture(DWORD stage, IDirect3DTexture2 **texture) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D6Device::GetTexture");
-
     if (unlikely(texture == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    if (unlikely(stage >= ddrawCaps::TextureStageCount)) {
-      Logger::err(str::format("D3D6Device::GetTexture: Invalid texture stage: ", stage));
+    if (unlikely(stage >= ddrawCaps::TextureStageCount))
       return DDERR_INVALIDPARAMS;
-    }
 
     *texture = m_textures[stage].ref();
 
@@ -1767,12 +1651,8 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D6Device::SetTexture(DWORD stage, IDirect3DTexture2 *texture) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D6Device::SetTexture");
-
-    if (unlikely(stage >= ddrawCaps::TextureStageCount)) {
-      Logger::err(str::format("D3D6Device::SetTexture: Invalid texture stage: ", stage));
+    if (unlikely(stage >= ddrawCaps::TextureStageCount))
       return DDERR_INVALIDPARAMS;
-    }
 
     d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
@@ -1780,8 +1660,6 @@ namespace dxvk {
 
     // Unbinding texture stages
     if (texture == nullptr) {
-      Logger::debug("D3D6Device::SetTexture: Unbiding D3D9 texture");
-
       hr = device9->SetTexture(stage, nullptr);
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D6Device::SetTexture: Failed to unbind D3D9 texture");
@@ -1789,7 +1667,6 @@ namespace dxvk {
       }
 
       if (likely(m_textures[stage] != nullptr)) {
-        Logger::debug("D3D6Device::SetTexture: Unbinding local texture");
         m_textures[stage] = nullptr;
 
         if (likely(stage == 0))
@@ -1808,8 +1685,6 @@ namespace dxvk {
       Logger::err("D3D6Device::SetTexture: Failed to retrieve parent surface");
       return DDERR_UNSUPPORTED;
     }
-
-    Logger::debug("D3D6Device::SetTexture: Binding D3D9 texture");
 
     // If textures have been used on a different device, they
     // will get their D3D9 object reinitialized at this point
@@ -1863,8 +1738,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Device::GetTextureStageState(DWORD dwStage, D3DTEXTURESTAGESTATETYPE d3dTexStageStateType, LPDWORD lpdwState) {
-    Logger::debug(">>> D3D6Device::GetTextureStageState");
-
     if (unlikely(lpdwState == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -1901,8 +1774,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Device::SetTextureStageState(DWORD dwStage, D3DTEXTURESTAGESTATETYPE d3dTexStageStateType, DWORD dwState) {
-    Logger::debug(">>> D3D6Device::SetTextureStageState");
-
     d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     // In the case of D3DTSS_ADDRESS, which is exclusive to D3D7
@@ -1934,8 +1805,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Device::ValidateDevice(LPDWORD lpdwPasses) {
-    Logger::debug(">>> D3D6Device::ValidateDevice");
-
     HRESULT hr = m_commonD3DDevice->GetD3D9Device()->ValidateDevice(lpdwPasses);
     if (unlikely(FAILED(hr)))
       return DDERR_INVALIDPARAMS;
@@ -1951,16 +1820,12 @@ namespace dxvk {
     m_ds = m_rt->GetAttachedDepthStencil();
 
     if (m_ds != nullptr) {
-      Logger::debug("D3D6Device::InitializeDS: Found an attached DS");
-
       HRESULT hrDS = m_ds->InitializeD3D9DepthStencil();
       if (unlikely(FAILED(hrDS))) {
         Logger::err("D3D6Device::InitializeDS: Failed to initialize D3D9 DS");
       } else {
-        Logger::info("D3D6Device::InitializeDS: Got depth stencil from RT");
-
         const RECT* dsRect = m_ds->GetCommonSurface()->GetFullSurfaceRect();
-        Logger::debug(str::format("D3D6Device::InitializeDS: DepthStencil: ", dsRect->right, "x", dsRect->bottom));
+        Logger::info(str::format("D3D6Device::InitializeDS: Depth stencil: ", dsRect->right, "x", dsRect->bottom));
 
         HRESULT hrDS9 = device9->SetDepthStencilSurface(m_ds->GetCommonSurface()->GetD3D9Surface());
         if (unlikely(FAILED(hrDS9))) {
@@ -1971,7 +1836,6 @@ namespace dxvk {
         }
       }
     } else {
-      Logger::info("D3D6Device::InitializeDS: RT has no depth stencil attached");
       device9->SetDepthStencilSurface(nullptr);
       // Should be superfluous, but play it safe
       device9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_FALSE);
@@ -2003,8 +1867,6 @@ namespace dxvk {
       return hr;
     }
 
-    Logger::debug("D3D6Device::ResetD3D9Swapchain: Resetting the render target");
-
     m_rt->GetCommonSurface()->SetD3D9Surface(nullptr);
     m_rt->GetCommonSurface()->UnDirtyD3D9Surface();
 
@@ -2012,8 +1874,6 @@ namespace dxvk {
     DDraw4Surface* nextFlippable = m_rt->GetNextFlippable();
 
     while (nextFlippable != nullptr) {
-      Logger::debug("D3D6Device::ResetD3D9Swapchain: Resetting child surface");
-
       nextFlippable->GetCommonSurface()->SetD3D9Surface(nullptr);
       nextFlippable->GetCommonSurface()->UnDirtyD3D9Surface();
 
@@ -2024,8 +1884,6 @@ namespace dxvk {
     DDraw4Surface* parentSurf = m_rt->GetParentSurface();
 
     while (parentSurf != nullptr) {
-      Logger::debug("D3D6Device::ResetD3D9Swapchain: Resetting parent surface");
-
       parentSurf->GetCommonSurface()->SetD3D9Surface(nullptr);
       parentSurf->GetCommonSurface()->UnDirtyD3D9Surface();
 
@@ -2058,8 +1916,6 @@ namespace dxvk {
   }
 
   inline void D3D6Device::UploadIndices(d3d9::IDirect3DIndexBuffer9* ib9, WORD* indices, DWORD indexCount) {
-    Logger::debug(str::format("D3D6Device::UploadIndices: Uploading ", indexCount, " indices"));
-
     const size_t size = indexCount * sizeof(WORD);
     void* pData = nullptr;
 
@@ -2111,31 +1967,23 @@ namespace dxvk {
   }
 
   inline HRESULT D3D6Device::SetTextureWithHandle(DDraw4Surface* surface, DWORD textureHandle) {
-    Logger::debug(">>> D3D6Device::SetTextureWithHandle");
-
     HRESULT hr;
 
     d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     // Unbinding texture stages
     if (surface == nullptr) {
-      Logger::debug("D3D6Device::SetTextureWithHandle: Unbiding D3D9 texture");
-
       hr = device9->SetTexture(0, nullptr);
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D6Device::SetTextureWithHandle: Failed to unbind D3D9 texture");
         return hr;
       }
 
-      if (likely(m_commonD3DDevice->GetCurrentTextureHandle() != 0)) {
-        Logger::debug("D3D6Device::SetTextureWithHandle: Unbinding local texture");
+      if (likely(m_commonD3DDevice->GetCurrentTextureHandle() != 0))
         m_commonD3DDevice->SetCurrentTextureHandle(0);
-      }
 
       return D3D_OK;
     }
-
-    Logger::debug("D3D6Device::SetTextureWithHandle: Binding D3D9 texture");
 
     // If textures have been used on a different device, they
     // will get their D3D9 object reinitialized at this point

--- a/src/ddraw/d3d6/d3d6_device.h
+++ b/src/ddraw/d3d6/d3d6_device.h
@@ -188,7 +188,6 @@ namespace dxvk {
         m_legacyProjection = m_currentViewport->GetCommonViewport()->GetLegacyProjectionMatrix(drawFlags);
 
         if (m_legacyProjection != nullptr) {
-          //Logger::debug("D3D6Device: Applying legacy projection");
           device9->GetTransform(d3d9::D3DTS_PROJECTION, &m_projectionMatrix);
           device9->MultiplyTransform(d3d9::D3DTS_PROJECTION, m_legacyProjection);
         }
@@ -197,7 +196,6 @@ namespace dxvk {
 
     inline void HandlePostDrawLegacyProjection(d3d9::IDirect3DDevice9* device9) {
       if (m_legacyProjection != nullptr) {
-        //Logger::debug("D3D6Device: Reverting legacy projection");
         device9->SetTransform(d3d9::D3DTS_PROJECTION, &m_projectionMatrix);
       }
     }

--- a/src/ddraw/d3d6/d3d6_interface.cpp
+++ b/src/ddraw/d3d6/d3d6_interface.cpp
@@ -83,33 +83,24 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Interface::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> D3D6Interface::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
     InitReturnPtr(ppvObject);
 
     if (unlikely(riid == __uuidof(IDirectDraw))) {
-      Logger::debug("D3D6Interface::QueryInterface: Query for IDirectDraw");
       return m_parent->QueryInterface(riid, ppvObject);
     }
     if (unlikely(riid == __uuidof(IDirectDraw2))) {
-      Logger::debug("D3D6Interface::QueryInterface: Query for IDirectDraw2");
       return m_parent->QueryInterface(riid, ppvObject);
     }
     if (riid == __uuidof(IDirectDraw4)) {
-      Logger::debug("D3D6Interface::QueryInterface: Query for IDirectDraw4");
       return m_parent->QueryInterface(riid, ppvObject);
     }
     // Some games query for legacy D3D interfaces
     if (unlikely(riid == __uuidof(IDirect3D))) {
-      if (m_commonD3DIntf->GetD3D3Interface() != nullptr) {
-        Logger::debug("D3D6Interface::QueryInterface: Query for existing IDirect3D");
+      if (m_commonD3DIntf->GetD3D3Interface() != nullptr)
         return m_commonD3DIntf->GetD3D3Interface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("D3D6Interface::QueryInterface: Query for IDirect3D");
 
       m_d3d3Intf = new D3D3Interface(m_commonD3DIntf.ptr(), m_commonIntf, m_parent);
       m_commonIntf->SetD3D3Interface(m_d3d3Intf.ptr());
@@ -118,12 +109,8 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirect3D2))) {
-      if (m_commonD3DIntf->GetD3D5Interface() != nullptr) {
-        Logger::debug("D3D6Interface::QueryInterface: Query for existing IDirect3D2");
+      if (m_commonD3DIntf->GetD3D5Interface() != nullptr)
         return m_commonD3DIntf->GetD3D5Interface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("D3D6Interface::QueryInterface: Query for IDirect3D2");
 
       m_d3d5Intf = new D3D5Interface(m_commonD3DIntf.ptr(), m_commonIntf, m_parent);
       *ppvObject = m_d3d5Intf.ref();
@@ -143,8 +130,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Interface::EnumDevices(LPD3DENUMDEVICESCALLBACK lpEnumDevicesCallback, LPVOID lpUserArg) {
-    Logger::debug(">>> D3D6Interface::EnumDevices");
-
     if (unlikely(lpEnumDevicesCallback == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -162,15 +147,13 @@ namespace dxvk {
     D3DDEVICEDESC descRGB_HEL = descRGB_HAL;
     descRGB_HAL.dwFlags = 0;
     descRGB_HAL.dcmColorModel = 0;
-    // Some applications apparently care about RGB texture caps
+    // Some applications apparently care about HAL texture caps
     descRGB_HAL.dpcLineCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                           & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL
-                                           & ~D3DPTEXTURECAPS_POW2;
+                                           & ~D3DPTEXTURECAPS_POW2
+                                           & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
     descRGB_HAL.dpcTriCaps.dwTextureCaps  &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                           & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL
-                                           & ~D3DPTEXTURECAPS_POW2;
-    descRGB_HEL.dpcLineCaps.dwTextureCaps |= D3DPTEXTURECAPS_POW2;
-    descRGB_HEL.dpcTriCaps.dwTextureCaps  |= D3DPTEXTURECAPS_POW2;
+                                           & ~D3DPTEXTURECAPS_POW2
+                                           & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
 
     if (likely(!d3dOptions->legacyDeviceNames)) {
       static char deviceDescRGB[100] = "D6VK RGB";
@@ -193,11 +176,11 @@ namespace dxvk {
     descHAL_HEL.dcmColorModel = 0;
     // Some applications apparently care about RGB texture caps
     descHAL_HEL.dpcLineCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                           & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL
-                                           & ~D3DPTEXTURECAPS_POW2;
+                                           & ~D3DPTEXTURECAPS_POW2
+                                           & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
     descHAL_HEL.dpcTriCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                          & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL
-                                          & ~D3DPTEXTURECAPS_POW2;
+                                          & ~D3DPTEXTURECAPS_POW2
+                                          & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
     descHAL_HEL.dwDevCaps &= ~D3DDEVCAPS_HWTRANSFORMANDLIGHT
                            & ~D3DDEVCAPS_DRAWPRIMITIVES2
                            & ~D3DDEVCAPS_DRAWPRIMITIVES2EX;
@@ -220,8 +203,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Interface::CreateLight(LPDIRECT3DLIGHT *lplpDirect3DLight, IUnknown *pUnkOuter) {
-    Logger::debug(">>> D3D6Interface::CreateLight");
-
     if (unlikely(lplpDirect3DLight == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -233,8 +214,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Interface::CreateMaterial(LPDIRECT3DMATERIAL3 *lplpDirect3DMaterial, IUnknown *pUnkOuter) {
-    Logger::debug(">>> D3D6Interface::CreateMaterial");
-
     if (unlikely(lplpDirect3DMaterial == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -246,8 +225,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Interface::CreateViewport(LPDIRECT3DVIEWPORT3 *lplpD3DViewport, IUnknown *pUnkOuter) {
-    Logger::debug(">>> D3D6Interface::CreateViewport");
-
     InitReturnPtr(lplpD3DViewport);
 
     *lplpD3DViewport = ref(new D3D6Viewport(nullptr, this));
@@ -257,8 +234,6 @@ namespace dxvk {
 
   // Minimal implementation which should suffice in most cases
   HRESULT STDMETHODCALLTYPE D3D6Interface::FindDevice(D3DFINDDEVICESEARCH *lpD3DFDS, D3DFINDDEVICERESULT *lpD3DFDR) {
-    Logger::debug(">>> D3D6Interface::FindDevice");
-
     if (unlikely(lpD3DFDS == nullptr || lpD3DFDR == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -275,27 +250,25 @@ namespace dxvk {
     D3DDEVICEDESC descRGB_HEL = descRGB_HAL;
     descRGB_HAL.dwFlags = 0;
     descRGB_HAL.dcmColorModel = 0;
-    // Some applications apparently care about RGB texture caps
+    // Some applications apparently care about HAL texture caps
     descRGB_HAL.dpcLineCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                           & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL
-                                           & ~D3DPTEXTURECAPS_POW2;
+                                           & ~D3DPTEXTURECAPS_POW2
+                                           & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
     descRGB_HAL.dpcTriCaps.dwTextureCaps  &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                           & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL
-                                           & ~D3DPTEXTURECAPS_POW2;
-    descRGB_HEL.dpcLineCaps.dwTextureCaps |= D3DPTEXTURECAPS_POW2;
-    descRGB_HEL.dpcTriCaps.dwTextureCaps  |= D3DPTEXTURECAPS_POW2;
+                                           & ~D3DPTEXTURECAPS_POW2
+                                           & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
 
     // Hardware acceleration
     D3DDEVICEDESC descHAL_HAL = GetD3D6Caps(IID_IDirect3DHALDevice, d3dOptions);
     D3DDEVICEDESC descHAL_HEL = descHAL_HAL;
     descHAL_HEL.dcmColorModel = 0;
-    // Some applications apparently care about RGB texture caps
+    // Some applications apparently care about HEL texture caps
     descHAL_HEL.dpcLineCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                           & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL
-                                           & ~D3DPTEXTURECAPS_POW2;
+                                           & ~D3DPTEXTURECAPS_POW2
+                                           & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
     descHAL_HEL.dpcTriCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE
-                                          & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL
-                                          & ~D3DPTEXTURECAPS_POW2;
+                                          & ~D3DPTEXTURECAPS_POW2
+                                          & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
     descHAL_HEL.dwDevCaps &= ~D3DDEVCAPS_HWTRANSFORMANDLIGHT
                            & ~D3DDEVCAPS_DRAWPRIMITIVES2
                            & ~D3DDEVCAPS_DRAWPRIMITIVES2EX;
@@ -303,16 +276,12 @@ namespace dxvk {
     lpD3DFDR->dwSize = sizeof(D3DFINDDEVICERESULT);
 
     if (lpD3DFDS->dwFlags & D3DFDS_GUID) {
-      Logger::debug("D3D6Interface::FindDevice: Matching by device GUID");
-
       // IID_IDirect3DRampDevice and IID_IDirect3DMMXDevice return DDERR_NOTFOUND in D3D6
       if (lpD3DFDS->guid == IID_IDirect3DRGBDevice) {
-        Logger::debug("D3D6Interface::FindDevice: Matched IID_IDirect3DRGBDevice");
         lpD3DFDR->guid = IID_IDirect3DRGBDevice;
         lpD3DFDR->ddHwDesc = descRGB_HAL;
         lpD3DFDR->ddSwDesc = descRGB_HEL;
       } else if (lpD3DFDS->guid == IID_IDirect3DHALDevice) {
-        Logger::debug("D3D6Interface::FindDevice: Matched IID_IDirect3DHALDevice");
         lpD3DFDR->guid = IID_IDirect3DHALDevice;
         lpD3DFDR->ddHwDesc = descHAL_HAL;
         lpD3DFDR->ddSwDesc = descHAL_HEL;
@@ -321,30 +290,20 @@ namespace dxvk {
         return DDERR_NOTFOUND;
       }
     } else if (lpD3DFDS->dwFlags & D3DFDS_HARDWARE) {
-      Logger::debug("D3D6Interface::FindDevice: Matching by hardware flag");
-
       if (likely(lpD3DFDS->bHardware == TRUE)) {
-        Logger::debug("D3D6Interface::FindDevice: Matched IID_IDirect3DHALDevice");
         lpD3DFDR->guid = IID_IDirect3DHALDevice;
         lpD3DFDR->ddHwDesc = descHAL_HAL;
         lpD3DFDR->ddSwDesc = descHAL_HEL;
       } else {
-        Logger::debug("D3D6Interface::FindDevice: Matched IID_IDirect3DRGBDevice");
         lpD3DFDR->guid = IID_IDirect3DRGBDevice;
         lpD3DFDR->ddHwDesc = descRGB_HAL;
         lpD3DFDR->ddSwDesc = descRGB_HEL;
       }
     } else if (lpD3DFDS->dwFlags & D3DFDS_COLORMODEL) {
-      Logger::debug("D3D6Interface::FindDevice: Matching by color model");
-
-      Logger::debug("D3D6Interface::FindDevice: Matched IID_IDirect3DHALDevice");
       lpD3DFDR->guid = IID_IDirect3DHALDevice;
       lpD3DFDR->ddHwDesc = descHAL_HAL;
       lpD3DFDR->ddSwDesc = descHAL_HEL;
     } else if (lpD3DFDS->dwFlags == 0) {
-      Logger::debug("D3D6Interface::FindDevice: No matching criteria specified");
-
-      Logger::debug("D3D6Interface::FindDevice: Matched IID_IDirect3DHALDevice");
       lpD3DFDR->guid = IID_IDirect3DHALDevice;
       lpD3DFDR->ddHwDesc = descHAL_HAL;
       lpD3DFDR->ddSwDesc = descHAL_HEL;
@@ -357,26 +316,23 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Interface::CreateDevice(REFCLSID rclsid, LPDIRECTDRAWSURFACE4 lpDDS, LPDIRECT3DDEVICE3 *lplpD3DDevice, IUnknown *pUnkOuter) {
-    Logger::debug(">>> D3D6Interface::CreateDevice");
-
     if (unlikely(lplpD3DDevice == nullptr))
       return DDERR_INVALIDPARAMS;
 
     InitReturnPtr(lplpD3DDevice);
 
-    if (unlikely(lpDDS == nullptr)) {
-      Logger::err("D3D6Interface::CreateDevice: Null surface provided");
+    if (unlikely(lpDDS == nullptr))
       return DDERR_INVALIDPARAMS;
-    }
 
     const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
 
     DWORD deviceCreationFlags9 = D3DCREATE_SOFTWARE_VERTEXPROCESSING;
     bool  isHALDevice          = false;
+    bool  halFallback          = false;
     bool  rgbFallback          = false;
 
     if (likely(!d3dOptions->forceSWVP)) {
-      if (rclsid == IID_IDirect3DHALDevice || rclsid == IID_WineD3DDevice) {
+      if (rclsid == IID_IDirect3DHALDevice) {
         Logger::info("D3D6Interface::CreateDevice: Creating an IID_IDirect3DHALDevice device");
         deviceCreationFlags9 = D3DCREATE_MIXED_VERTEXPROCESSING;
         isHALDevice = true;
@@ -385,15 +341,24 @@ namespace dxvk {
       } else if (rclsid == IID_IDirect3DMMXDevice) {
         Logger::warn("D3D6Interface::CreateDevice: Unsupported MMX device, falling back to RGB");
         rgbFallback = true;
-      } else {
-        // Revenant uses a rclsid of 7a31a548-0000-0007-26ed-780000000000...
-        Logger::warn("D3D6Interface::CreateDevice: Unsupported device type, falling back to RGB");
-        Logger::warn(str::format(rclsid));
+      } else if (rclsid == IID_IDirect3DRampDevice) {
+        Logger::warn("D3D6Interface::CreateDevice: Unsupported Ramp device, falling back to RGB");
         rgbFallback = true;
+      } else {
+        // Revenant uses a bogus rclsid (not WineD3D's), so fall back to HAL in these cases
+        if (unlikely(rclsid != IID_WineD3DDevice)) {
+          Logger::warn("D3D6Interface::CreateDevice: Unknown device type, falling back to HAL");
+          Logger::warn(str::format(rclsid));
+        } else {
+          Logger::info("D3D6Interface::CreateDevice: Creating an IID_WineD3DDevice HAL device");
+        }
+        halFallback = true;
+        // Don't enforce isHALDevice RT validations
       }
     }
 
-    const IID rclsidOverride = rgbFallback ? IID_IDirect3DRGBDevice : rclsid;
+    const IID rclsidOverride = halFallback ? IID_IDirect3DHALDevice :
+                               rgbFallback ? IID_IDirect3DRGBDevice : rclsid;
 
     HWND hWnd = m_commonIntf->GetHWND();
     // Needed to sometimes safely skip intro playback on legacy devices
@@ -430,7 +395,6 @@ namespace dxvk {
         if ((modeSize->width  && modeSize->width  < desc.dwWidth)
          || (modeSize->height && modeSize->height < desc.dwHeight)) {
           Logger::info("D3D6Interface::CreateDevice: Enforcing mode dimensions");
-
           backBufferWidth  = modeSize->width;
           BackBufferHeight = modeSize->height;
         }
@@ -517,8 +481,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Interface::CreateVertexBuffer(LPD3DVERTEXBUFFERDESC lpVBDesc, LPDIRECT3DVERTEXBUFFER *lpD3DVertexBuffer, DWORD dwFlags, IUnknown *pUnkOuter) {
-    Logger::debug(">>> D3D6Interface::CreateVertexBuffer");
-
     if (unlikely(lpVBDesc == nullptr || lpD3DVertexBuffer == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -532,8 +494,6 @@ namespace dxvk {
   // Total Club Manager 2003 uses a D3D6 interface to query for supported Z buffer formats,
   // so report what we know is supported by D3D9, otherwise the game will error out on startup
   HRESULT STDMETHODCALLTYPE D3D6Interface::EnumZBufferFormats(REFCLSID riidDevice, LPD3DENUMPIXELFORMATSCALLBACK lpEnumCallback, LPVOID lpContext) {
-    Logger::debug(">>> D3D6Interface::EnumZBufferFormats");
-
     if (unlikely(lpEnumCallback == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -578,8 +538,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Interface::EvictManagedTextures() {
-    Logger::debug(">>> D3D6Interface::EvictManagedTextures");
-
     HRESULT hr = m_proxy->EvictManagedTextures();
     if (unlikely(FAILED(hr)))
       return hr;

--- a/src/ddraw/d3d6/d3d6_material.cpp
+++ b/src/ddraw/d3d6/d3d6_material.cpp
@@ -32,8 +32,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Material::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> D3D6Material::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
@@ -51,8 +49,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Material::SetMaterial(D3DMATERIAL *data) {
-    Logger::debug(">>> D3D6Material::SetMaterial");
-
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -74,8 +70,8 @@ namespace dxvk {
     if (likely(commonDevice != nullptr)) {
       const D3DMATERIALHANDLE handle        = m_commonMaterial->GetMaterialHandle();
       const D3DMATERIALHANDLE currentHandle = commonDevice->GetCurrentMaterialHandle();
-      if (currentHandle == handle) {
-        Logger::debug(str::format("D3D6Material::SetMaterial: Applying material nr. ", handle, " to D3D9"));
+      if (handle && currentHandle == handle) {
+        //Logger::debug(str::format("D3D6Material::SetMaterial: Applying material nr. ", handle, " to D3D9"));
         commonDevice->GetD3D9Device()->SetMaterial(material9);
       }
     }
@@ -84,8 +80,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Material::GetMaterial(D3DMATERIAL *data) {
-    Logger::debug(">>> D3D6Material::GetMaterial");
-
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -101,8 +95,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Material::GetHandle(IDirect3DDevice3 *device, D3DMATERIALHANDLE *handle) {
-    Logger::debug(">>> D3D6Material::GetHandle");
-
     if (unlikely(device == nullptr || handle == nullptr))
       return DDERR_INVALIDPARAMS;
 

--- a/src/ddraw/d3d6/d3d6_viewport.cpp
+++ b/src/ddraw/d3d6/d3d6_viewport.cpp
@@ -79,8 +79,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Viewport::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> D3D6Viewport::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
@@ -88,12 +86,8 @@ namespace dxvk {
 
     // Some games query for legacy viewport interfaces
     if (unlikely(riid == __uuidof(IDirect3DViewport))) {
-      if (m_commonViewport->GetD3D3Viewport() != nullptr) {
-        Logger::debug("D3D6Viewport::QueryInterface: Query for existing IDirect3DViewport");
+      if (m_commonViewport->GetD3D3Viewport() != nullptr)
         return m_commonViewport->GetD3D3Viewport()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("D3D6Viewport::QueryInterface: Query for IDirect3DViewport");
 
       m_viewport3 = new D3D3Viewport(m_commonViewport.ptr(), nullptr);
       *ppvObject = m_viewport3.ref();
@@ -101,12 +95,8 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirect3DViewport2))) {
-      if (m_commonViewport->GetD3D5Viewport() != nullptr) {
-        Logger::debug("D3D6Viewport::QueryInterface: Query for existing IDirect3DViewport2");
+      if (m_commonViewport->GetD3D5Viewport() != nullptr)
         return m_commonViewport->GetD3D5Viewport()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("D3D6Viewport::QueryInterface: Query for IDirect3DViewport2");
 
       m_viewport5 = new D3D5Viewport(m_commonViewport.ptr(), nullptr);
       *ppvObject = m_viewport5.ref();
@@ -127,13 +117,10 @@ namespace dxvk {
 
   // Docs state: "The IDirect3DViewport3::Initialize method is not implemented."
   HRESULT STDMETHODCALLTYPE D3D6Viewport::Initialize(IDirect3D *d3d) {
-    Logger::debug(">>> D3D6Viewport::Initialize");
     return DDERR_ALREADYINITIALIZED;
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Viewport::GetViewport(D3DVIEWPORT *data) {
-    Logger::debug(">>> D3D6Viewport::GetViewport");
-
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -163,8 +150,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Viewport::SetViewport(D3DVIEWPORT *data) {
-    Logger::debug(">>> D3D6Viewport::SetViewport");
-
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -212,12 +197,8 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Viewport::TransformVertices(DWORD vertex_count, D3DTRANSFORMDATA *data, DWORD flags, DWORD *offscreen) {
-    Logger::debug(">>> D3D6Viewport::TransformVertices");
-
-    if (unlikely(!m_commonViewport->HasDevice())) {
-      Logger::warn("D3D6Viewport::TransformVertices: Viewport isn't attached to a device");
+    if (unlikely(!m_commonViewport->HasDevice()))
       return D3DERR_VIEWPORTHASNODEVICE;
-    }
 
     d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
 
@@ -245,13 +226,10 @@ namespace dxvk {
 
   // Docs state: "The IDirect3DViewport3::LightElements method is not currently implemented."
   HRESULT STDMETHODCALLTYPE D3D6Viewport::LightElements(DWORD element_count, D3DLIGHTDATA *data) {
-    Logger::warn(">>> D3D6Viewport::LightElements");
     return DDERR_UNSUPPORTED;
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Viewport::SetBackground(D3DMATERIALHANDLE hMat) {
-    Logger::debug(">>> D3D6Viewport::SetBackground");
-
     if (unlikely(m_commonViewport->GetMaterialHandle() == hMat))
       return D3D_OK;
 
@@ -268,8 +246,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Viewport::GetBackground(D3DMATERIALHANDLE *material, BOOL *valid) {
-    Logger::debug(">>> D3D6Viewport::GetBackground");
-
     if (unlikely(material == nullptr || valid == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -280,22 +256,24 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Viewport::SetBackgroundDepth(IDirectDrawSurface *surface) {
-    Logger::debug(">>> D3D6Viewport::SetBackgroundDepth");
-
-    if (unlikely(!DDrawCommonInterface::IsWrappedSurface(surface))) {
+    if (unlikely(surface != nullptr
+             && !DDrawCommonInterface::IsWrappedSurface(surface))) {
       Logger::err("D3D6Viewport::SetBackgroundDepth: Received an unwrapped surface");
       return DDERR_UNSUPPORTED;
     }
 
-    m_backgroundDepth = reinterpret_cast<DDrawSurface*>(surface);
-    m_isBackgroundDepthSet = true;
+    if (unlikely(surface == nullptr)) {
+      m_backgroundDepth = nullptr;
+      m_isBackgroundDepthSet = false;
+    } else {
+      m_backgroundDepth = reinterpret_cast<DDrawSurface*>(surface);
+      m_isBackgroundDepthSet = true;
+    }
 
     return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Viewport::GetBackgroundDepth(IDirectDrawSurface **surface, BOOL *valid) {
-    Logger::debug(">>> D3D6Viewport::GetBackgroundDepth");
-
     if (unlikely(surface == nullptr || valid == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -308,14 +286,12 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Viewport::Clear(DWORD count, D3DRECT *rects, DWORD flags) {
-    Logger::debug(">>> D3D6Viewport::Clear");
+    // Early D3D viewport fast skip
+    if (unlikely(!count || !rects))
+      return D3D_OK;
 
     if (unlikely(!m_commonViewport->HasDevice()))
       return D3DERR_VIEWPORTHASNODEVICE;
-
-    // Early D3D viewport fast skip
-    if (unlikely(!count || (count && rects == nullptr)))
-      return D3D_OK;
 
     const bool clearRenderTarget = flags & D3DCLEAR_TARGET;
     const bool clearDepthStencil = flags & D3DCLEAR_ZBUFFER;
@@ -327,7 +303,7 @@ namespace dxvk {
       if (likely(rt != nullptr)) {
         // If this isn't a full surface clear, we need to first upload the DDraw surface
         if (unlikely(count > 1 || !rt->IsFullSurfaceLock(reinterpret_cast<RECT*>(rects), nullptr))) {
-          Logger::debug("D3D6Viewport::Clear: Partial render target clear");
+          //Logger::debug("D3D6Viewport::Clear: Partial render target clear");
           // Use a common surface helper, because we want to handle all
           // possible surface interfaces that may be alive at this time
           rt->InitializeOrUploadD3D9();
@@ -339,7 +315,7 @@ namespace dxvk {
       if (likely(ds != nullptr)) {
         // If this isn't a full surface clear, we need to first upload the DDraw surface
         if (unlikely(count > 1 || !ds->IsFullSurfaceLock(reinterpret_cast<RECT*>(rects), nullptr))) {
-          Logger::debug("D3D6Viewport::Clear: Partial depth stencil clear");
+          //Logger::debug("D3D6Viewport::Clear: Partial depth stencil clear");
           // Use a common surface helper, because we want to handle all
           // possible surface interfaces that may be alive at this time
           ds->InitializeOrUploadD3D9();
@@ -351,7 +327,8 @@ namespace dxvk {
 
     // Temporarily activate this viewport in order to clear it
     d3d9::D3DVIEWPORT9 currentViewport9;
-    if (!m_commonViewport->IsCurrentViewport()) {
+    const bool isCurrentViewport = m_commonViewport->IsCurrentViewport();
+    if (!isCurrentViewport) {
       D3D6Viewport* currentViewport = m_commonViewport->GetCurrentD3D6Viewport();
       if (currentViewport != nullptr) {
         currentViewport9 = *currentViewport->GetCommonViewport()->GetD3D9Viewport();
@@ -371,14 +348,14 @@ namespace dxvk {
     HRESULT hr = d3d9Device->Clear(count, rects, flags, clearColor, 1.0f, 0u);
 
     // Restore the previously active viewport
-    if (!m_commonViewport->IsCurrentViewport()) {
+    if (!isCurrentViewport) {
       d3d9Device->SetViewport(&currentViewport9);
     }
 
-    // Clear() will only ever silently fail
+    // Can fail in D3D9 only in case of a missing depth stencil surface
     if (unlikely(FAILED(hr))) {
-      Logger::debug("D3D6Viewport::Clear: Failed D3D9 Clear call");
-      return D3D_OK;
+      // Fix up expected return codes
+      return D3DERR_ZBUFFER_NOTPRESENT;
     }
 
     if (clearRenderTarget && rt != nullptr)
@@ -392,8 +369,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Viewport::AddLight(IDirect3DLight *light) {
-    Logger::debug(">>> D3D6Viewport::AddLight");
-
     if (unlikely(light == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -415,8 +390,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Viewport::DeleteLight(IDirect3DLight *light) {
-    Logger::debug(">>> D3D6Viewport::DeleteLight");
-
     if (unlikely(light == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -431,7 +404,7 @@ namespace dxvk {
     if (likely(it != lights.end())) {
       const DWORD lightIndex = d3dLight->GetIndex();
       if (m_commonViewport->HasDevice() && m_commonViewport->IsCurrentViewport() && d3dLight->IsActive()) {
-        Logger::debug(str::format("D3D6Viewport: Disabling light nr. ", lightIndex));
+        //Logger::debug(str::format("D3D6Viewport: Disabling light nr. ", lightIndex));
         d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
         d3d9Device->LightEnable(lightIndex, FALSE);
       }
@@ -446,8 +419,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Viewport::NextLight(IDirect3DLight *lpDirect3DLight, IDirect3DLight **lplpDirect3DLight, DWORD flags) {
-    Logger::debug(">>> D3D6Viewport::NextLight");
-
     if (unlikely(lplpDirect3DLight == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -473,8 +444,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Viewport::GetViewport2(D3DVIEWPORT2 *data) {
-    Logger::debug(">>> D3D6Viewport::GetViewport2");
-
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -504,8 +473,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Viewport::SetViewport2(D3DVIEWPORT2 *data) {
-    Logger::debug(">>> D3D6Viewport::SetViewport2");
-
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -551,22 +518,24 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Viewport::SetBackgroundDepth2(IDirectDrawSurface4 *surface) {
-    Logger::debug(">>> D3D6Viewport::SetBackgroundDepth2");
-
-    if (unlikely(!DDrawCommonInterface::IsWrappedSurface(surface))) {
+    if (unlikely(surface != nullptr
+             && !DDrawCommonInterface::IsWrappedSurface(surface))) {
       Logger::err("D3D6Viewport::SetBackgroundDepth2: Received an unwrapped surface");
       return DDERR_UNSUPPORTED;
     }
 
-    m_backgroundDepth4 = reinterpret_cast<DDraw4Surface*>(surface);
-    m_isBackgroundDepth4Set = true;
+    if (unlikely(surface == nullptr)) {
+      m_backgroundDepth4 = nullptr;
+      m_isBackgroundDepth4Set = false;
+    } else {
+      m_backgroundDepth4 = reinterpret_cast<DDraw4Surface*>(surface);
+      m_isBackgroundDepth4Set = true;
+    }
 
     return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Viewport::GetBackgroundDepth2(IDirectDrawSurface4 **surface, BOOL *valid) {
-    Logger::debug(">>> D3D6Viewport::GetBackgroundDepth2");
-
     if (unlikely(surface == nullptr || valid == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -579,14 +548,12 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Viewport::Clear2(DWORD count, D3DRECT *rects, DWORD flags, DWORD color, D3DVALUE z, DWORD stencil) {
-    Logger::debug(">>> D3D6Viewport::Clear2");
+    // Early D3D viewport fast skip
+    if (unlikely(!count || !rects))
+      return D3D_OK;
 
     if (unlikely(!m_commonViewport->HasDevice()))
       return D3DERR_VIEWPORTHASNODEVICE;
-
-    // Early D3D viewport fast skip
-    if (unlikely(!count || (count && rects == nullptr)))
-      return D3D_OK;
 
     const bool clearRenderTarget = flags & D3DCLEAR_TARGET;
     const bool clearDepthStencil = (flags & D3DCLEAR_ZBUFFER) || (flags & D3DCLEAR_STENCIL);
@@ -598,7 +565,7 @@ namespace dxvk {
       if (likely(rt != nullptr)) {
         // If this isn't a full surface clear, we need to first upload the DDraw surface
         if (unlikely(count > 1 || !rt->IsFullSurfaceLock(reinterpret_cast<RECT*>(rects), nullptr))) {
-          Logger::debug("D3D6Viewport::Clear2: Partial render target clear");
+          //Logger::debug("D3D6Viewport::Clear2: Partial render target clear");
           // Use a common surface helper, because we want to handle all
           // possible surface interfaces that may be alive at this time
           rt->InitializeOrUploadD3D9();
@@ -610,7 +577,7 @@ namespace dxvk {
       if (likely(ds != nullptr)) {
         // If this isn't a full surface clear, we need to first upload the DDraw surface
         if (unlikely(count > 1 || !ds->IsFullSurfaceLock(reinterpret_cast<RECT*>(rects), nullptr))) {
-          Logger::debug("D3D6Viewport::Clear2: Partial depth stencil clear");
+          //Logger::debug("D3D6Viewport::Clear2: Partial depth stencil clear");
           // Use a common surface helper, because we want to handle all
           // possible surface interfaces that may be alive at this time
           ds->InitializeOrUploadD3D9();
@@ -622,7 +589,8 @@ namespace dxvk {
 
     // Temporarily activate this viewport in order to clear it
     d3d9::D3DVIEWPORT9 currentViewport9;
-    if (!m_commonViewport->IsCurrentViewport()) {
+    const bool isCurrentViewport = m_commonViewport->IsCurrentViewport();
+    if (!isCurrentViewport) {
       D3D6Viewport* currentViewport = m_commonViewport->GetCurrentD3D6Viewport();
       if (currentViewport != nullptr) {
         currentViewport9 = *currentViewport->GetCommonViewport()->GetD3D9Viewport();
@@ -635,15 +603,18 @@ namespace dxvk {
     HRESULT hr = d3d9Device->Clear(count, rects, flags, color, z, stencil);
 
     // Restore the previously active viewport
-    if (!m_commonViewport->IsCurrentViewport()) {
+    if (!isCurrentViewport) {
       d3d9Device->SetViewport(&currentViewport9);
     }
 
-    // Unlike Clear(), Clear2() is supposed to error out on
-    // z/stencil clears and no z/stencil attachments
+    // Can fail in D3D9 only in case of a missing depth stencil surface
     if (unlikely(FAILED(hr))) {
-      Logger::debug("D3D6Viewport::Clear2: Failed D3D9 Clear call");
-      return hr;
+      // Fix up expected return codes
+      if (flags & D3DCLEAR_ZBUFFER) {
+        return D3DERR_ZBUFFER_NOTPRESENT;
+      } else {
+        return D3DERR_STENCILBUFFER_NOTPRESENT;
+      }
     }
 
     if (clearRenderTarget && rt != nullptr)
@@ -659,8 +630,6 @@ namespace dxvk {
   HRESULT D3D6Viewport::ApplyViewport() {
     if (!m_commonViewport->IsViewportSet())
       return D3D_OK;
-
-    Logger::debug("D3D6Viewport: Applying viewport to D3D9");
 
     d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
 
@@ -679,8 +648,6 @@ namespace dxvk {
     if (!lights.size())
       return D3D_OK;
 
-    Logger::debug("D3D6Viewport: Applying lights to D3D9");
-
     for (auto light: lights)
       ApplyAndActivateLight(light->GetIndex(), light.ptr());
 
@@ -693,14 +660,12 @@ namespace dxvk {
     if (!lights.size())
       return D3D_OK;
 
-    Logger::debug("D3D6Viewport: Deactivating D3D9 lights");
-
     d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
 
     for (auto light: lights) {
       const DWORD lightIndex = light->GetIndex();
       if (m_commonViewport->HasDevice() && m_commonViewport->IsCurrentViewport() && light->IsActive()) {
-        Logger::debug(str::format("D3D6Viewport: Disabling light nr. ", lightIndex));
+        //Logger::debug(str::format("D3D6Viewport: Disabling light nr. ", lightIndex));
         d3d9Device->LightEnable(lightIndex, FALSE);
       }
     }
@@ -718,12 +683,12 @@ namespace dxvk {
     }
 
     if (light->IsActive()) {
-      Logger::debug(str::format("D3D6Viewport: Enabling D3D9 light nr. ", index));
+      //Logger::debug(str::format("D3D6Viewport: Enabling D3D9 light nr. ", index));
       hr = d3d9Device->LightEnable(index, TRUE);
       if (unlikely(FAILED(hr)))
         Logger::err("D3D6Viewport: Failed D3D9 LightEnable call (TRUE)");
     } else {
-      Logger::debug(str::format("D3D6Viewport: Disabling D3D9 light nr. ", index));
+      //Logger::debug(str::format("D3D6Viewport: Disabling D3D9 light nr. ", index));
       hr = d3d9Device->LightEnable(index, FALSE);
       if (unlikely(FAILED(hr)))
         Logger::err("D3D6Viewport: Failed D3D9 LightEnable call (FALSE)");

--- a/src/ddraw/d3d7/d3d7_buffer.cpp
+++ b/src/ddraw/d3d7/d3d7_buffer.cpp
@@ -37,8 +37,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7VertexBuffer::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> D3D7VertexBuffer::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
@@ -56,8 +54,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7VertexBuffer::GetVertexBufferDesc(LPD3DVERTEXBUFFERDESC lpVBDesc) {
-    Logger::debug(">>> D3D7VertexBuffer::GetVertexBufferDesc");
-
     if (unlikely(lpVBDesc == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -72,8 +68,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7VertexBuffer::Lock(DWORD flags, void **data, DWORD *data_size) {
-    Logger::debug(">>> D3D7VertexBuffer::Lock");
-
     if (unlikely(IsOptimized()))
       return D3DERR_VERTEXBUFFEROPTIMIZED;
 
@@ -102,8 +96,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7VertexBuffer::Unlock() {
-    Logger::debug(">>> D3D7VertexBuffer::Unlock");
-
     RefreshD3DDevice();
     if (unlikely(!IsInitialized())) {
       HRESULT hrInit = InitializeD3D9();
@@ -121,8 +113,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7VertexBuffer::ProcessVertices(DWORD dwVertexOp, DWORD dwDestIndex, DWORD dwCount, LPDIRECT3DVERTEXBUFFER7 lpSrcBuffer, DWORD dwSrcIndex, LPDIRECT3DDEVICE7 lpD3DDevice, DWORD dwFlags) {
-    Logger::debug(">>> D3D7VertexBuffer::ProcessVertices");
-
     if (unlikely(!dwCount))
       return D3D_OK;
 
@@ -261,8 +251,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7VertexBuffer::Optimize(LPDIRECT3DDEVICE7 lpD3DDevice, DWORD dwFlags) {
-    Logger::debug(">>> D3D7VertexBuffer::Optimize");
-
     if (unlikely(lpD3DDevice == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -284,23 +272,24 @@ namespace dxvk {
       return DDERR_GENERIC;
     }
 
-    d3d9::IDirect3DDevice9* device9 = m_d3d7Device->GetCommonD3DDevice()->GetD3D9Device();
+    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
 
-    const d3d9::D3DPOOL pool = (m_desc.dwCaps & D3DVBCAPS_SYSTEMMEMORY) ? d3d9::D3DPOOL_SYSTEMMEM : d3d9::D3DPOOL_DEFAULT;
-    const char* poolPlacement = pool == d3d9::D3DPOOL_DEFAULT ? "D3DPOOL_DEFAULT" : "D3DPOOL_SYSTEMMEM";
-
-    Logger::debug(str::format("D3D7VertexBuffer::InitializeD3D9: Placing in: ", poolPlacement));
-
-    const DWORD usage = ConvertD3D7UsageFlags(m_desc.dwCaps);
+    const d3d9::D3DPOOL pool = (m_desc.dwCaps & D3DVBCAPS_SYSTEMMEMORY) ? d3d9::D3DPOOL_SYSTEMMEM :
+                               d3dOptions->managedVertexBuffers ? d3d9::D3DPOOL_MANAGED : d3d9::D3DPOOL_DEFAULT;
+    const DWORD usage = ConvertD3D7UsageFlags(m_desc.dwCaps, pool);
     m_legacyDiscard = m_commonIntf->GetOptions()->forceLegacyDiscard &&
                       (usage & D3DUSAGE_DYNAMIC) && (usage & D3DUSAGE_WRITEONLY);
+
+    const char* poolPlacement = pool == d3d9::D3DPOOL_DEFAULT ? "D3DPOOL_DEFAULT" :
+                                pool == d3d9::D3DPOOL_SYSTEMMEM ? "D3DPOOL_SYSTEMMEM" : "D3DPOOL_MANAGED";
+    Logger::debug(str::format("D3D7VertexBuffer::InitializeD3D9: Placing in: ", poolPlacement));
+
+    d3d9::IDirect3DDevice9* device9 = m_d3d7Device->GetCommonD3DDevice()->GetD3D9Device();
     HRESULT hr = device9->CreateVertexBuffer(m_size, usage, m_desc.dwFVF, pool, &m_vb9, nullptr);
     if (unlikely(FAILED(hr))) {
       Logger::err("D3D7VertexBuffer::InitializeD3D9: Failed to create D3D9 vertex buffer");
       return hr;
     }
-
-    Logger::debug("D3D7VertexBuffer::InitializeD3D9: Created D3D9 vertex buffer");
 
     return D3D_OK;
   }

--- a/src/ddraw/d3d7/d3d7_device.cpp
+++ b/src/ddraw/d3d7/d3d7_device.cpp
@@ -107,25 +107,20 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> D3D7Device::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
     InitReturnPtr(ppvObject);
 
     if (unlikely(riid == __uuidof(IDirect3DDevice))) {
-      Logger::debug("D3D7Device::QueryInterface: Query for IDirect3DDevice");
       return E_NOINTERFACE;
     }
     if (unlikely(riid == __uuidof(IDirect3DDevice2))) {
-      Logger::debug("D3D7Device::QueryInterface: Query for IDirect3DDevice2");
       return E_NOINTERFACE;
     }
     // Some games, like Conquest: Frontier Wars, query for
     // IDirect3DDevice3, although that's not supported
     if (unlikely(riid == __uuidof(IDirect3DDevice3))) {
-      Logger::debug("D3D7Device::QueryInterface: Query for IDirect3DDevice3");
       return E_NOINTERFACE;
     }
 
@@ -141,8 +136,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::GetCaps(D3DDEVICEDESC7 *desc) {
-    Logger::debug(">>> D3D7Device::GetCaps");
-
     if (unlikely(desc == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -152,8 +145,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::EnumTextureFormats(LPD3DENUMPIXELFORMATSCALLBACK cb, void *ctx) {
-    Logger::debug(">>> D3D7Device::EnumTextureFormats");
-
     if (unlikely(cb == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -254,8 +245,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D7Device::BeginScene() {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D7Device::BeginScene");
-
     RefreshLastUsedDevice();
 
     if (unlikely(m_commonD3DDevice->IsInScene()))
@@ -273,8 +262,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D7Device::EndScene() {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D7Device::EndScene");
-
     RefreshLastUsedDevice();
 
     if (unlikely(!m_commonD3DDevice->IsInScene()))
@@ -290,8 +277,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::GetDirect3D(IDirect3D7 **d3d) {
-    Logger::debug(">>> D3D7Device::GetDirect3D");
-
     if (unlikely(d3d == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -310,12 +295,8 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D7Device::SetRenderTarget(IDirectDrawSurface7 *surface, DWORD flags) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D7Device::SetRenderTarget");
-
-    if (unlikely(surface == nullptr)) {
-      Logger::err("D3D7Device::SetRenderTarget: NULL render target");
+    if (unlikely(surface == nullptr))
       return DDERR_INVALIDPARAMS;
-    }
 
     if (unlikely(!DDrawCommonInterface::IsWrappedSurface(surface))) {
       Logger::err("D3D7Device::SetRenderTarget: Received an unwrapped RT");
@@ -346,8 +327,6 @@ namespace dxvk {
     m_ds = m_rt->GetAttachedDepthStencil();
 
     if (m_ds != nullptr) {
-      Logger::debug("D3D7Device::SetRenderTarget: Found an attached DS");
-
       hr = m_ds->InitializeD3D9DepthStencil();
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D7Device::SetRenderTarget: Failed to initialize/upload D3D9 DS");
@@ -360,8 +339,6 @@ namespace dxvk {
         return hr;
       }
     } else {
-      Logger::debug("D3D7Device::SetRenderTarget: RT has no depth stencil attached");
-
       hr = device9->SetDepthStencilSurface(nullptr);
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D7Device::SetRenderTarget: Failed to clear the D3D9 DS");
@@ -375,8 +352,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D7Device::GetRenderTarget(IDirectDrawSurface7 **surface) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D7Device::GetRenderTarget");
-
     if (unlikely(surface == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -388,8 +363,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D7Device::Clear(DWORD count, D3DRECT *rects, DWORD flags, D3DCOLOR color, D3DVALUE z, DWORD stencil) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D7Device::Clear");
-
     // D3D7 and later fast skip
     if (unlikely(!count && rects))
       return D3D_OK;
@@ -400,22 +373,27 @@ namespace dxvk {
     if (unlikely(clearRenderTarget && count)) {
       // If this isn't a full surface clear, we need to first upload the DDraw surface
       if (count > 1 || !m_rt->GetCommonSurface()->IsFullSurfaceLock(reinterpret_cast<RECT*>(rects), nullptr)) {
-        Logger::debug("D3D7Device::Clear: Partial render target clear");
+        //Logger::debug("D3D7Device::Clear: Partial render target clear");
         m_rt->InitializeOrUploadD3D9();
       }
     }
     if (unlikely(clearDepthStencil && count && m_ds != nullptr)) {
       // If this isn't a full surface clear, we need to first upload the DDraw surface
       if (count > 1 || !m_ds->GetCommonSurface()->IsFullSurfaceLock(reinterpret_cast<RECT*>(rects), nullptr)) {
-        Logger::debug("D3D7Device::Clear: Partial depth stencil clear");
+        //Logger::debug("D3D7Device::Clear: Partial depth stencil clear");
         m_ds->InitializeOrUploadD3D9();
       }
     }
 
-    HRESULT hr = m_commonD3DDevice->GetD3D9Device()->Clear(count, rects, flags, color, static_cast<float>(z), stencil);
+    HRESULT hr = m_commonD3DDevice->GetD3D9Device()->Clear(count, rects, flags, color, z, stencil);
+    // Can fail in D3D9 only in case of a missing depth stencil surface
     if (unlikely(FAILED(hr))) {
-      Logger::debug("D3D7Device::Clear: Failed D3D9 Clear call");
-      return hr;
+      // Fix up expected return codes
+      if (flags & D3DCLEAR_ZBUFFER) {
+        return D3DERR_ZBUFFER_NOTPRESENT;
+      } else {
+        return D3DERR_STENCILBUFFER_NOTPRESENT;
+      }
     }
 
     if (clearRenderTarget)
@@ -429,24 +407,19 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::SetTransform(D3DTRANSFORMSTATETYPE state, D3DMATRIX *matrix) {
-    Logger::debug(">>> D3D7Device::SetTransform");
     return m_commonD3DDevice->GetD3D9Device()->SetTransform(ConvertTransformState(state), matrix);
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::GetTransform(D3DTRANSFORMSTATETYPE state, D3DMATRIX *matrix) {
-    Logger::debug(">>> D3D7Device::GetTransform");
     return m_commonD3DDevice->GetD3D9Device()->GetTransform(ConvertTransformState(state), matrix);
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::MultiplyTransform(D3DTRANSFORMSTATETYPE state, D3DMATRIX *matrix) {
-    Logger::debug(">>> D3D7Device::MultiplyTransform");
     return m_commonD3DDevice->GetD3D9Device()->MultiplyTransform(ConvertTransformState(state), matrix);
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::SetViewport(D3DVIEWPORT7 *data) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D7Device::SetViewport");
 
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
@@ -479,8 +452,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D7Device::GetViewport(D3DVIEWPORT7 *data) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D7Device::GetViewport");
-
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -488,8 +459,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::SetMaterial(D3DMATERIAL7 *data) {
-    Logger::debug(">>> D3D7Device::SetMaterial");
-
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -497,8 +466,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::GetMaterial(D3DMATERIAL7 *data) {
-    Logger::debug(">>> D3D7Device::GetMaterial");
-
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -506,8 +473,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::SetLight(DWORD idx, D3DLIGHT7 *data) {
-    Logger::debug(">>> D3D7Device::SetLight");
-
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -536,8 +501,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::GetLight(DWORD idx, D3DLIGHT7 *data) {
-    Logger::debug(">>> D3D7Device::GetLight");
-
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -551,14 +514,10 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D7Device::SetRenderState(D3DRENDERSTATETYPE dwRenderStateType, DWORD dwRenderState) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(str::format(">>> D3D7Device::SetRenderState: ", dwRenderStateType));
-
     // As opposed to D3D8/9, D3D7 actually validates and
     // errors out in case of unknown/invalid render states
-    if (unlikely(!IsValidD3D7RenderStateType(dwRenderStateType))) {
-      Logger::debug(str::format("D3D7Device::SetRenderState: Invalid render state ", dwRenderStateType));
+    if (unlikely(!IsValidD3D7RenderStateType(dwRenderStateType)))
       return DDERR_INVALIDPARAMS;
-    }
 
     d3d9::D3DRENDERSTATETYPE State9 = d3d9::D3DRENDERSTATETYPE(dwRenderStateType);
 
@@ -606,14 +565,8 @@ namespace dxvk {
       case D3DRENDERSTATE_ZVISIBLE:
         return D3D_OK;
 
-      // Tests have shown age accurate GPUs didn't offer support for
-      // stippling at all, so this should be safe to ignore
+      // Tests have shown age accurate GPUs didn't offer support for stippling at all
       case D3DRENDERSTATE_STIPPLEDALPHA:
-        static bool s_stippledAlphaErrorShown;
-
-        if (dwRenderState && !std::exchange(s_stippledAlphaErrorShown, true))
-          Logger::warn("D3D7Device::SetRenderState: Unimplemented render state D3DRENDERSTATE_STIPPLEDALPHA");
-
         return D3D_OK;
 
       case D3DRENDERSTATE_EDGEANTIALIAS:
@@ -648,7 +601,8 @@ namespace dxvk {
 
         return D3D_OK;
 
-      // Used in conjunction with D3DRENDERSTATE_COLORKEYENABLE
+      // D3DPTEXTURECAPS_COLORKEYBLEND isn't advertised by any D3D7 capable
+      // or later GPUs, so this render state serves no practical purpose
       case D3DRENDERSTATE_COLORKEYBLENDENABLE:
         m_commonD3DDevice->SetColorKeyBlendEnable(dwRenderState);
         return D3D_OK;
@@ -661,18 +615,14 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D7Device::GetRenderState(D3DRENDERSTATETYPE dwRenderStateType, LPDWORD lpdwRenderState) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(str::format(">>> D3D7Device::GetRenderState: ", dwRenderStateType));
-
     if (unlikely(lpdwRenderState == nullptr))
       return DDERR_INVALIDPARAMS;
 
     // As opposed to D3D8/9, D3D7 actually validates and
     // errors out in case of unknown/invalid render states
     if (unlikely(!IsValidD3D7RenderStateType(dwRenderStateType)
-              && !m_commonIntf->GetOptions()->apitraceMode)) {
-      Logger::debug(str::format("D3D7Device::GetRenderState: Invalid render state ", dwRenderStateType));
+              && !m_commonIntf->GetOptions()->apitraceMode))
       return DDERR_INVALIDPARAMS;
-    }
 
     d3d9::D3DRENDERSTATETYPE State9 = d3d9::D3DRENDERSTATETYPE(dwRenderStateType);
 
@@ -736,8 +686,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D7Device::BeginStateBlock() {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D7Device::BeginStateBlock");
-
     if (unlikely(m_recorder != nullptr))
       return D3DERR_INBEGINSTATEBLOCK;
 
@@ -757,8 +705,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D7Device::EndStateBlock(LPDWORD lpdwBlockHandle) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D7Device::EndStateBlock");
 
     if (unlikely(lpdwBlockHandle == nullptr))
       return DDERR_INVALIDPARAMS;
@@ -784,8 +730,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D7Device::ApplyStateBlock(DWORD dwBlockHandle) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D7Device::ApplyStateBlock");
-
     // Applications cannot apply a state block while another is being recorded
     if (unlikely(ShouldRecord()))
       return D3DERR_INBEGINSTATEBLOCK;
@@ -803,8 +747,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D7Device::CaptureStateBlock(DWORD dwBlockHandle) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D7Device::CaptureStateBlock");
-
     // Applications cannot capture a state block while another is being recorded
     if (unlikely(ShouldRecord()))
       return D3DERR_INBEGINSTATEBLOCK;
@@ -821,8 +763,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D7Device::DeleteStateBlock(DWORD dwBlockHandle) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D7Device::DeleteStateBlock");
 
     // Applications cannot delete a state block while another is being recorded
     if (unlikely(ShouldRecord()))
@@ -848,8 +788,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D7Device::CreateStateBlock(D3DSTATEBLOCKTYPE d3dsbType, LPDWORD lpdwBlockHandle) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D7Device::CreateStateBlock");
 
     if (unlikely(lpdwBlockHandle == nullptr))
       return DDERR_INVALIDPARAMS;
@@ -880,8 +818,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::PreLoad(IDirectDrawSurface7 *surface) {
-    Logger::debug(">>> D3D7Device::PreLoad");
-
     if (unlikely(surface == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -910,8 +846,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D7Device::DrawPrimitive(D3DPRIMITIVETYPE d3dptPrimitiveType, DWORD dwVertexTypeDesc, LPVOID lpvVertices, DWORD dwVertexCount, DWORD dwFlags) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D7Device::DrawPrimitive");
 
     RefreshLastUsedDevice();
 
@@ -944,8 +878,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D7Device::DrawIndexedPrimitive(D3DPRIMITIVETYPE d3dptPrimitiveType, DWORD dwVertexTypeDesc, LPVOID lpvVertices, DWORD dwVertexCount, LPWORD lpwIndices, DWORD dwIndexCount, DWORD dwFlags) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D7Device::DrawIndexedPrimitive");
 
     RefreshLastUsedDevice();
 
@@ -981,8 +913,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::SetClipStatus(D3DCLIPSTATUS *clip_status) {
-    Logger::debug(">>> D3D7Device::SetClipStatus");
-
     if (unlikely(clip_status == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -990,8 +920,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::GetClipStatus(D3DCLIPSTATUS *clip_status) {
-    Logger::debug(">>> D3D7Device::GetClipStatus");
-
     if (unlikely(clip_status == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -1012,8 +940,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D7Device::DrawPrimitiveStrided(D3DPRIMITIVETYPE d3dptPrimitiveType, DWORD dwVertexTypeDesc, LPD3DDRAWPRIMITIVESTRIDEDDATA lpVertexArray, DWORD dwVertexCount, DWORD dwFlags) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D7Device::DrawPrimitiveStrided");
 
     RefreshLastUsedDevice();
 
@@ -1049,8 +975,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D7Device::DrawIndexedPrimitiveStrided(D3DPRIMITIVETYPE d3dptPrimitiveType, DWORD dwVertexTypeDesc, LPD3DDRAWPRIMITIVESTRIDEDDATA lpVertexArray, DWORD dwVertexCount, LPWORD lpwIndices, DWORD dwIndexCount, DWORD dwFlags) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D7Device::DrawIndexedPrimitiveStrided");
 
     RefreshLastUsedDevice();
 
@@ -1091,8 +1015,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D7Device::DrawPrimitiveVB(D3DPRIMITIVETYPE d3dptPrimitiveType, LPDIRECT3DVERTEXBUFFER7 lpd3dVertexBuffer, DWORD dwStartVertex, DWORD dwNumVertices, DWORD dwFlags) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D7Device::DrawPrimitiveVB");
-
     RefreshLastUsedDevice();
 
     if (unlikely(!dwNumVertices))
@@ -1131,8 +1053,6 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D7Device::DrawIndexedPrimitiveVB(D3DPRIMITIVETYPE d3dptPrimitiveType, LPDIRECT3DVERTEXBUFFER7 lpd3dVertexBuffer, DWORD dwStartVertex, DWORD dwNumVertices, LPWORD lpwIndices, DWORD dwIndexCount, DWORD dwFlags) {
     D3DDeviceLock lock = LockDevice();
-
-    Logger::debug(">>> D3D7Device::DrawIndexedPrimitiveVB");
 
     RefreshLastUsedDevice();
 
@@ -1189,8 +1109,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::ComputeSphereVisibility(D3DVECTOR *lpCenters, D3DVALUE *lpRadii, DWORD dwNumSpheres, DWORD dwFlags, DWORD *lpdwReturnValues) {
-    Logger::debug(">>> D3D7Device::ComputeSphereVisibility");
-
     if (unlikely(lpCenters == nullptr || lpRadii == nullptr || lpdwReturnValues == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -1211,15 +1129,11 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D7Device::GetTexture(DWORD stage, IDirectDrawSurface7 **surface) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D7Device::GetTexture");
-
     if (unlikely(surface == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    if (unlikely(stage >= ddrawCaps::TextureStageCount)) {
-      Logger::err(str::format("D3D7Device::GetTexture: Invalid texture stage: ", stage));
+    if (unlikely(stage >= ddrawCaps::TextureStageCount))
       return DDERR_INVALIDPARAMS;
-    }
 
     *surface = m_textures[stage].ref();
 
@@ -1229,12 +1143,8 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D7Device::SetTexture(DWORD stage, IDirectDrawSurface7 *surface) {
     D3DDeviceLock lock = LockDevice();
 
-    Logger::debug(">>> D3D7Device::SetTexture");
-
-    if (unlikely(stage >= ddrawCaps::TextureStageCount)) {
-      Logger::err(str::format("D3D7Device::SetTexture: Invalid texture stage: ", stage));
+    if (unlikely(stage >= ddrawCaps::TextureStageCount))
       return DDERR_INVALIDPARAMS;
-    }
 
     if (unlikely(ShouldRecord()))
       return m_recorder->SetTexture(stage, surface);
@@ -1245,8 +1155,6 @@ namespace dxvk {
 
     // Unbinding texture stages
     if (surface == nullptr) {
-      Logger::debug("D3D7Device::SetTexture: Unbiding D3D9 texture");
-
       hr = device9->SetTexture(stage, nullptr);
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D7Device::SetTexture: Failed to unbind D3D9 texture");
@@ -1254,7 +1162,6 @@ namespace dxvk {
       }
 
       if (likely(m_textures[stage] != nullptr)) {
-        Logger::debug("D3D7Device::SetTexture: Unbinding local texture");
         m_textures[stage] = nullptr;
 
         if (likely(stage == 0))
@@ -1269,8 +1176,6 @@ namespace dxvk {
       Logger::err("D3D7Device::SetTexture: Received an unwrapped texture");
       return DDERR_UNSUPPORTED;
     }
-
-    Logger::debug("D3D7Device::SetTexture: Binding D3D9 texture");
 
     DDraw7Surface* surface7 = static_cast<DDraw7Surface*>(surface);
 
@@ -1332,8 +1237,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::GetTextureStageState(DWORD dwStage, D3DTEXTURESTAGESTATETYPE d3dTexStageStateType, LPDWORD lpdwState) {
-    Logger::debug(">>> D3D7Device::GetTextureStageState");
-
     if (unlikely(lpdwState == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -1370,8 +1273,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::SetTextureStageState(DWORD dwStage, D3DTEXTURESTAGESTATETYPE d3dTexStageStateType, DWORD dwState) {
-    Logger::debug(">>> D3D7Device::SetTextureStageState");
-
     d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     // In the case of D3DTSS_ADDRESS, which is exclusive to D3D7
@@ -1399,8 +1300,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::ValidateDevice(LPDWORD lpdwPasses) {
-    Logger::debug(">>> D3D7Device::ValidateDevice");
-
     HRESULT hr = m_commonD3DDevice->GetD3D9Device()->ValidateDevice(lpdwPasses);
     if (unlikely(FAILED(hr)))
       return DDERR_INVALIDPARAMS;
@@ -1410,12 +1309,8 @@ namespace dxvk {
 
   // This is a precursor of our ol' D3D8 pal CopyRects
   HRESULT STDMETHODCALLTYPE D3D7Device::Load(IDirectDrawSurface7 *dst_surface, POINT *dst_point, IDirectDrawSurface7 *src_surface, RECT *src_rect, DWORD flags) {
-    Logger::debug("<<< D3D7Device::Load: Proxy");
-
-    if (dst_surface == nullptr || src_surface == nullptr) {
-      Logger::warn("D3D7Device::Load: null source or destination");
+    if (dst_surface == nullptr || src_surface == nullptr)
       return DDERR_INVALIDPARAMS;
-    }
 
     DDraw7Surface* ddraw7SurfaceSrc = nullptr;
     DDraw7Surface* ddraw7SurfaceDst = nullptr;
@@ -1445,10 +1340,8 @@ namespace dxvk {
 
     HRESULT hr = m_proxy->Load(ddraw7SurfaceDst->GetProxied(), dst_point,
                                ddraw7SurfaceSrc->GetProxied(), src_rect, flags);
-    if (unlikely(FAILED(hr))) {
-      Logger::warn("D3D7Device::Load: Failed to load surfaces");
+    if (unlikely(FAILED(hr)))
       return hr;
-    }
 
     DDrawCommonSurface* dstCommonSurf = ddraw7SurfaceDst->GetCommonSurface();
     hr = dstCommonSurf->RefreshSurfaceDescripton();
@@ -1463,8 +1356,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::LightEnable(DWORD dwLightIndex, BOOL bEnable) {
-    Logger::debug(">>> D3D7Device::LightEnable");
-
     HRESULT hr = m_commonD3DDevice->GetD3D9Device()->LightEnable(dwLightIndex, bEnable);
     if (unlikely(FAILED(hr)))
       return DDERR_INVALIDPARAMS;
@@ -1492,8 +1383,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::GetLightEnable(DWORD dwLightIndex, BOOL *pbEnable) {
-    Logger::debug(">>> D3D7Device::GetLightEnable");
-
     if (unlikely(pbEnable == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -1505,18 +1394,15 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::SetClipPlane(DWORD dwIndex, D3DVALUE *pPlaneEquation) {
-    Logger::debug(">>> D3D7Device::SetClipPlane");
     return m_commonD3DDevice->GetD3D9Device()->SetClipPlane(dwIndex, pPlaneEquation);
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::GetClipPlane(DWORD dwIndex, D3DVALUE *pPlaneEquation) {
-    Logger::debug(">>> D3D7Device::GetClipPlane");
     return m_commonD3DDevice->GetD3D9Device()->GetClipPlane(dwIndex, pPlaneEquation);
   }
 
   // Docs state: "This method returns S_FALSE on retail builds of DirectX."
   HRESULT STDMETHODCALLTYPE D3D7Device::GetInfo(DWORD info_id, void *info, DWORD info_size) {
-    Logger::debug(">>> D3D7Device::GetInfo");
     return S_FALSE;
   }
 
@@ -1528,16 +1414,12 @@ namespace dxvk {
     m_ds = m_rt->GetAttachedDepthStencil();
 
     if (m_ds != nullptr) {
-      Logger::debug("D3D7Device::InitializeDS: Found an attached DS");
-
       HRESULT hrDS = m_ds->InitializeD3D9DepthStencil();
       if (unlikely(FAILED(hrDS))) {
         Logger::err("D3D7Device::InitializeDS: Failed to initialize D3D9 DS");
       } else {
-        Logger::info("D3D7Device::InitializeDS: Got depth stencil from RT");
-
         const RECT* dsRect = m_ds->GetCommonSurface()->GetFullSurfaceRect();
-        Logger::debug(str::format("D3D7Device::InitializeDS: DepthStencil: ", dsRect->right, "x", dsRect->bottom));
+        Logger::info(str::format("D3D7Device::InitializeDS: Depth stencil: ", dsRect->right, "x", dsRect->bottom));
 
         HRESULT hrDS9 = device9->SetDepthStencilSurface(m_ds->GetCommonSurface()->GetD3D9Surface());
         if (unlikely(FAILED(hrDS9))) {
@@ -1548,7 +1430,6 @@ namespace dxvk {
         }
       }
     } else {
-      Logger::info("D3D7Device::InitializeDS: RT has no depth stencil attached");
       device9->SetDepthStencilSurface(nullptr);
       // Should be superfluous, but play it safe
       device9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_FALSE);
@@ -1580,8 +1461,6 @@ namespace dxvk {
       return hr;
     }
 
-    Logger::debug("D3D7Device::ResetD3D9Swapchain: Resetting the render target");
-
     m_rt->GetCommonSurface()->SetD3D9Surface(nullptr);
     m_rt->GetCommonSurface()->UnDirtyD3D9Surface();
 
@@ -1589,8 +1468,6 @@ namespace dxvk {
     DDraw7Surface* nextFlippable = m_rt->GetNextFlippable();
 
     while (nextFlippable != nullptr) {
-      Logger::debug("D3D7Device::ResetD3D9Swapchain: Resetting child surface");
-
       nextFlippable->GetCommonSurface()->SetD3D9Surface(nullptr);
       nextFlippable->GetCommonSurface()->UnDirtyD3D9Surface();
 
@@ -1601,8 +1478,6 @@ namespace dxvk {
     DDraw7Surface* parentSurf = m_rt->GetParentSurface();
 
     while (parentSurf != nullptr) {
-      Logger::debug("D3D7Device::ResetD3D9Swapchain: Resetting parent surface");
-
       parentSurf->GetCommonSurface()->SetD3D9Surface(nullptr);
       parentSurf->GetCommonSurface()->UnDirtyD3D9Surface();
 
@@ -1635,8 +1510,6 @@ namespace dxvk {
   }
 
   inline void D3D7Device::UploadIndices(d3d9::IDirect3DIndexBuffer9* ib9, WORD* indices, DWORD indexCount) {
-    Logger::debug(str::format("D3D7Device::UploadIndices: Uploading ", indexCount, " indices"));
-
     const size_t size = indexCount * sizeof(WORD);
     void* pData = nullptr;
 

--- a/src/ddraw/d3d7/d3d7_interface.cpp
+++ b/src/ddraw/d3d7/d3d7_interface.cpp
@@ -77,22 +77,18 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Interface::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> D3D7Interface::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
     InitReturnPtr(ppvObject);
 
     if (riid == __uuidof(IDirectDraw7)) {
-      Logger::debug("D3D7Interface::QueryInterface: Query for IDirectDraw7");
       return m_parent->QueryInterface(riid, ppvObject);
     }
     // Some games query for legacy ddraw interfaces
     if (unlikely(riid == __uuidof(IDirectDraw)
               || riid == __uuidof(IDirectDraw2)
               || riid == __uuidof(IDirectDraw4))) {
-      Logger::debug("D3D7Interface::QueryInterface: Query for legacy IDirectDraw");
       return m_parent->QueryInterface(riid, ppvObject);
     }
 
@@ -108,8 +104,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Interface::EnumDevices(LPD3DENUMDEVICESCALLBACK7 cb, void *ctx) {
-    Logger::debug(">>> D3D7Interface::EnumDevices");
-
     if (unlikely(cb == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -170,22 +164,19 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Interface::CreateDevice(REFCLSID rclsid, IDirectDrawSurface7 *surface, IDirect3DDevice7 **ppd3dDevice) {
-    Logger::debug(">>> D3D7Interface::CreateDevice");
-
     if (unlikely(ppd3dDevice == nullptr))
       return DDERR_INVALIDPARAMS;
 
     InitReturnPtr(ppd3dDevice);
 
-    if (unlikely(surface == nullptr)) {
-      Logger::err("D3D7Interface::CreateDevice: Null surface provided");
+    if (unlikely(surface == nullptr))
       return DDERR_INVALIDPARAMS;
-    }
 
     const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
 
     DWORD deviceCreationFlags9 = D3DCREATE_SOFTWARE_VERTEXPROCESSING;
     bool  isHALOrTNLHALDevice  = false;
+    bool  halFallback          = false;
     bool  rgbFallback          = false;
 
     if (likely(!d3dOptions->forceSWVP)) {
@@ -193,20 +184,32 @@ namespace dxvk {
         Logger::info("D3D7Interface::CreateDevice: Creating an IID_IDirect3DTnLHalDevice device");
         deviceCreationFlags9 = D3DCREATE_HARDWARE_VERTEXPROCESSING;
         isHALOrTNLHALDevice = true;
-      } else if (rclsid == IID_IDirect3DHALDevice || rclsid == IID_WineD3DDevice) {
+      } else if (rclsid == IID_IDirect3DHALDevice) {
         Logger::info("D3D7Interface::CreateDevice: Creating an IID_IDirect3DHALDevice device");
         deviceCreationFlags9 = D3DCREATE_MIXED_VERTEXPROCESSING;
         isHALOrTNLHALDevice = true;
       } else if (rclsid == IID_IDirect3DRGBDevice) {
         Logger::info("D3D7Interface::CreateDevice: Creating an IID_IDirect3DRGBDevice device");
-      } else {
-        Logger::warn("D3D7Interface::CreateDevice: Unsupported device type, falling back to RGB");
-        Logger::warn(str::format(rclsid));
+      } else if (rclsid == IID_IDirect3DMMXDevice) {
+        Logger::warn("D3D7Interface::CreateDevice: Unsupported MMX device, falling back to RGB");
         rgbFallback = true;
+      } else if (rclsid == IID_IDirect3DRampDevice) {
+        Logger::warn("D3D7Interface::CreateDevice: Unsupported Ramp device, falling back to RGB");
+        rgbFallback = true;
+      } else {
+        if (unlikely(rclsid != IID_WineD3DDevice)) {
+          Logger::warn("D3D7Interface::CreateDevice: Unknown device type, falling back to HAL");
+          Logger::warn(str::format(rclsid));
+        } else {
+          Logger::info("D3D7Interface::CreateDevice: Creating an IID_WineD3DDevice HAL device");
+        }
+        halFallback = true;
+        // Don't enforce isHALOrTNLHALDevice RT validations
       }
     }
 
-    const IID rclsidOverride = rgbFallback ? IID_IDirect3DRGBDevice : rclsid;
+    const IID rclsidOverride = halFallback ? IID_IDirect3DHALDevice :
+                               rgbFallback ? IID_IDirect3DRGBDevice : rclsid;
 
     HWND hWnd = m_commonIntf->GetHWND();
     // Needed to sometimes safely skip intro playback on legacy devices
@@ -250,7 +253,6 @@ namespace dxvk {
         if ((modeSize->width  && modeSize->width  < desc.dwWidth)
          || (modeSize->height && modeSize->height < desc.dwHeight)) {
           Logger::info("D3D7Interface::CreateDevice: Enforcing mode dimensions");
-
           backBufferWidth  = modeSize->width;
           BackBufferHeight = modeSize->height;
         }
@@ -339,8 +341,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Interface::CreateVertexBuffer(D3DVERTEXBUFFERDESC *desc, IDirect3DVertexBuffer7 **ppVertexBuffer, DWORD usage) {
-    Logger::debug(">>> D3D7Interface::CreateVertexBuffer");
-
     if (unlikely(desc == nullptr || ppVertexBuffer == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -352,8 +352,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Interface::EnumZBufferFormats(REFCLSID riidDevice, LPD3DENUMPIXELFORMATSCALLBACK lpEnumCallback, LPVOID lpContext) {
-    Logger::debug(">>> D3D7Interface::EnumZBufferFormats");
-
     if (unlikely(lpEnumCallback == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -398,8 +396,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Interface::EvictManagedTextures() {
-    Logger::debug(">>> D3D7Interface::EvictManagedTextures");
-
     HRESULT hr = m_proxy->EvictManagedTextures();
     if (unlikely(FAILED(hr)))
       return hr;

--- a/src/ddraw/d3d_light.cpp
+++ b/src/ddraw/d3d_light.cpp
@@ -20,8 +20,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3DLight::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">> D3DLight::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
@@ -41,13 +39,10 @@ namespace dxvk {
   // Docs state: "The method returns DDERR_ALREADYINITIALIZED because
   // the Direct3DLight object is initialized when it is created."
   HRESULT STDMETHODCALLTYPE D3DLight::Initialize(IDirect3D *d3d) {
-    Logger::debug(">>> D3DLight::Initialize");
     return DDERR_ALREADYINITIALIZED;
   }
 
   HRESULT STDMETHODCALLTYPE D3DLight::SetLight(D3DLIGHT *data) {
-    Logger::debug(">>> D3DLight::SetLight");
-
     static constexpr D3DCOLORVALUE noLight = {0.0f, 0.0f, 0.0f, 0.0f};
 
     if (unlikely(data == nullptr))
@@ -120,8 +115,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3DLight::GetLight(D3DLIGHT *data) {
-    Logger::debug(">>> D3DLight::GetLight");
-
     if (unlikely(data == nullptr))
       return DDERR_INVALIDPARAMS;
 

--- a/src/ddraw/d3d_process_vertices.h
+++ b/src/ddraw/d3d_process_vertices.h
@@ -30,16 +30,394 @@ namespace dxvk {
     std::vector<d3d9::D3DLIGHT9>* lights;
   };
 
+  struct PVLIGHT {
+    D3DLIGHTTYPE Type;
+    D3DCOLORVALUE Diffuse;
+    D3DCOLORVALUE Specular;
+    D3DCOLORVALUE Ambient;
+    float Range;
+    float Falloff;
+    float Attenuation0;
+    float Attenuation1;
+    float Attenuation2;
+    D3DVECTOR LightDirection;
+    D3DVECTOR LightPosition;
+    float cosHalfPhi;
+    float cosHalfTheta;
+  };
+
+  struct D3DVECTOR4 {
+    float x,y,z,w;
+  };
+
+  using PositionArray = std::array<FLOAT, 8>;
   using TexCoordArray = std::array<std::array<FLOAT, 4>, ddrawCaps::MaxSimultaneousTextures>;
+
+  struct alignas(16) SIMDRow {
+    __m128 lo; // Elements 0, 1, 2, 3
+    __m128 hi; // Elements 4, 5, 6, 7
+  };
+
+  inline void swap_rows_sse(SIMDRow& a, SIMDRow& b) {
+    __m128 temp_lo = a.lo;
+    __m128 temp_hi = a.hi;
+    a.lo = b.lo;
+    a.hi = b.hi;
+    b.lo = temp_lo;
+    b.hi = temp_hi;
+  }
+
+  inline void InvertMatrix_SSE2(D3DMATRIX *out, const D3DMATRIX *m) {
+    SIMDRow r[4];
+
+    auto get_val = [](const SIMDRow& row, int col) -> float {
+      if (col < 4) {
+        float f[4];
+        _mm_storeu_ps(f, row.lo);
+        return f[col];
+      } else {
+        float f[4];
+        _mm_storeu_ps(f, row.hi);
+        return f[col - 4];
+      }
+    };
+
+    r[0].lo = _mm_setr_ps(m->_11, m->_12, m->_13, m->_14);
+    r[0].hi = _mm_setr_ps(1.0f, 0.0f, 0.0f, 0.0f);
+    r[1].lo = _mm_setr_ps(m->_21, m->_22, m->_23, m->_24);
+    r[1].hi = _mm_setr_ps(0.0f, 1.0f, 0.0f, 0.0f);
+    r[2].lo = _mm_setr_ps(m->_31, m->_32, m->_33, m->_34);
+    r[2].hi = _mm_setr_ps(0.0f, 0.0f, 1.0f, 0.0f);
+    r[3].lo = _mm_setr_ps(m->_41, m->_42, m->_43, m->_44);
+    r[3].hi = _mm_setr_ps(0.0f, 0.0f, 0.0f, 1.0f);
+
+    if (std::abs(get_val(r[3], 0)) > std::abs(get_val(r[2], 0)))
+      swap_rows_sse(r[3], r[2]);
+    if (std::abs(get_val(r[2], 0)) > std::abs(get_val(r[1], 0)))
+      swap_rows_sse(r[2], r[1]);
+    if (std::abs(get_val(r[1], 0)) > std::abs(get_val(r[0], 0)))
+      swap_rows_sse(r[1], r[0]);
+
+    float pivot0 = get_val(r[0], 0);
+    if (pivot0 == 0.0f)
+      return;
+
+    auto eliminate_row = [&](SIMDRow& target, const SIMDRow& source, float factor) {
+      __m128 v_factor = _mm_set1_ps(factor);
+      target.lo = _mm_sub_ps(target.lo, _mm_mul_ps(v_factor, source.lo));
+      target.hi = _mm_sub_ps(target.hi, _mm_mul_ps(v_factor, source.hi));
+    };
+
+    eliminate_row(r[1], r[0], get_val(r[1], 0) / pivot0);
+    eliminate_row(r[2], r[0], get_val(r[2], 0) / pivot0);
+    eliminate_row(r[3], r[0], get_val(r[3], 0) / pivot0);
+
+    if (std::abs(get_val(r[3], 1)) > std::abs(get_val(r[2], 1)))
+      swap_rows_sse(r[3], r[2]);
+    if (std::abs(get_val(r[2], 1)) > std::abs(get_val(r[1], 1)))
+      swap_rows_sse(r[2], r[1]);
+
+    float pivot1 = get_val(r[1], 1);
+    if (pivot1 == 0.0f)
+      return;
+
+    eliminate_row(r[2], r[1], get_val(r[2], 1) / pivot1);
+    eliminate_row(r[3], r[1], get_val(r[3], 1) / pivot1);
+
+    if (std::abs(get_val(r[3], 2)) > std::abs(get_val(r[2], 2)))
+      swap_rows_sse(r[3], r[2]);
+    float pivot2 = get_val(r[2], 2);
+    if (pivot2 == 0.0f)
+      return;
+
+    eliminate_row(r[3], r[2], get_val(r[3], 2) / pivot2);
+
+    float pivot3 = get_val(r[3], 3);
+    if (pivot3 == 0.0f)
+      return;
+
+    __m128 v_inv_pivot3 = _mm_set1_ps(1.0f / pivot3);
+    r[3].lo = _mm_mul_ps(r[3].lo, v_inv_pivot3);
+    r[3].hi = _mm_mul_ps(r[3].hi, v_inv_pivot3);
+
+    float m2_3 = get_val(r[2], 3);
+    r[2].lo = _mm_sub_ps(r[2].lo, _mm_mul_ps(_mm_set1_ps(m2_3), r[3].lo));
+    r[2].hi = _mm_sub_ps(r[2].hi, _mm_mul_ps(_mm_set1_ps(m2_3), r[3].hi));
+
+    float s2 = get_val(r[2], 2);
+    r[2].lo = _mm_mul_ps(r[2].lo, _mm_set1_ps(1.0f / s2));
+    r[2].hi = _mm_mul_ps(r[2].hi, _mm_set1_ps(1.0f / s2));
+
+    float m1_3 = get_val(r[1], 3);
+    float m1_2 = get_val(r[1], 2);
+    r[1].lo = _mm_sub_ps(r[1].lo, _mm_mul_ps(_mm_set1_ps(m1_3), r[3].lo));
+    r[1].hi = _mm_sub_ps(r[1].hi, _mm_mul_ps(_mm_set1_ps(m1_3), r[3].hi));
+    r[1].lo = _mm_sub_ps(r[1].lo, _mm_mul_ps(_mm_set1_ps(m1_2), r[2].lo));
+    r[1].hi = _mm_sub_ps(r[1].hi, _mm_mul_ps(_mm_set1_ps(m1_2), r[2].hi));
+
+    float s1 = get_val(r[1], 1);
+    r[1].lo = _mm_mul_ps(r[1].lo, _mm_set1_ps(1.0f / s1));
+    r[1].hi = _mm_mul_ps(r[1].hi, _mm_set1_ps(1.0f / s1));
+
+    float m0_3 = get_val(r[0], 3);
+    float m0_2 = get_val(r[0], 2);
+    float m0_1 = get_val(r[0], 1);
+    r[0].lo = _mm_sub_ps(r[0].lo, _mm_mul_ps(_mm_set1_ps(m0_3), r[3].lo));
+    r[0].hi = _mm_sub_ps(r[0].hi, _mm_mul_ps(_mm_set1_ps(m0_3), r[3].hi));
+    r[0].lo = _mm_sub_ps(r[0].lo, _mm_mul_ps(_mm_set1_ps(m0_2), r[2].lo));
+    r[0].hi = _mm_sub_ps(r[0].hi, _mm_mul_ps(_mm_set1_ps(m0_2), r[2].hi));
+    r[0].lo = _mm_sub_ps(r[0].lo, _mm_mul_ps(_mm_set1_ps(m0_1), r[1].lo));
+    r[0].hi = _mm_sub_ps(r[0].hi, _mm_mul_ps(_mm_set1_ps(m0_1), r[1].hi));
+
+    float s0 = get_val(r[0], 0);
+    r[0].lo = _mm_mul_ps(r[0].lo, _mm_set1_ps(1.0f / s0));
+    r[0].hi = _mm_mul_ps(r[0].hi, _mm_set1_ps(1.0f / s0));
+
+    _mm_storeu_ps(&out->_11, r[0].hi); // This assumes _11 is the start of a float sequence
+    out->_11 = get_val(r[0], 4); out->_12 = get_val(r[0], 5); out->_13 = get_val(r[0], 6); out->_14 = get_val(r[0], 7);
+    out->_21 = get_val(r[1], 4); out->_22 = get_val(r[1], 5); out->_23 = get_val(r[1], 6); out->_24 = get_val(r[1], 7);
+    out->_31 = get_val(r[2], 4); out->_32 = get_val(r[2], 5); out->_33 = get_val(r[2], 6); out->_34 = get_val(r[2], 7);
+    out->_41 = get_val(r[3], 4); out->_42 = get_val(r[3], 5); out->_43 = get_val(r[3], 6); out->_44 = get_val(r[3], 7);
+  }
+
+  inline __m128 cross_product_sse2(__m128 a, __m128 b) {
+    __m128 a_yzx = _mm_shuffle_ps(a, a, _MM_SHUFFLE(3, 0, 2, 1));
+    __m128 b_zxy = _mm_shuffle_ps(b, b, _MM_SHUFFLE(3, 1, 0, 2));
+    __m128 a_zxy = _mm_shuffle_ps(a, a, _MM_SHUFFLE(3, 1, 0, 2));
+    __m128 b_yzx = _mm_shuffle_ps(b, b, _MM_SHUFFLE(3, 0, 2, 1));
+
+    return _mm_sub_ps(_mm_mul_ps(a_yzx, b_zxy), _mm_mul_ps(a_zxy, b_yzx));
+  }
+
+  inline void InvertMatrixLegacy_SSE2(D3DMATRIX *out, const D3DMATRIX *in) {
+    __m128 r1 = _mm_loadu_ps(&in->_11);
+    __m128 r2 = _mm_loadu_ps(&in->_21);
+    __m128 r3 = _mm_loadu_ps(&in->_31);
+
+    __m128 v_a = cross_product_sse2(r2, r3);
+    __m128 v_b = cross_product_sse2(r3, r1);
+    __m128 v_c = cross_product_sse2(r1, r2);
+
+    __m128 dot = _mm_mul_ps(r1, v_a);
+
+    float det;
+    float temp_det[4];
+    _mm_storeu_ps(temp_det, dot);
+    det = temp_det[0] + temp_det[1] + temp_det[2];
+
+    if (std::fabs(det) <= std::numeric_limits<float>::min() * 10)
+      return;
+
+    float inv_det = 1.0f / det;
+
+    v_a = _mm_mul_ps(v_a, _mm_set1_ps(inv_det));
+    v_b = _mm_mul_ps(v_b, _mm_set1_ps(inv_det));
+    v_c = _mm_mul_ps(v_c, _mm_set1_ps(inv_det));
+
+    float va[4], vb[4], vc[4];
+    _mm_storeu_ps(va, v_a);
+    _mm_storeu_ps(vb, v_b);
+    _mm_storeu_ps(vc, v_c);
+
+    out->_11 = va[0]; out->_12 = vb[0]; out->_13 = vc[0];
+    out->_21 = va[1]; out->_22 = vb[1]; out->_23 = vc[1];
+    out->_31 = va[2]; out->_32 = vb[2]; out->_33 = vc[2];
+  }
+
+  inline void ComputeNormalMatrix(D3DMATRIX &normal_matrix, bool isLegacy, const D3DMATRIX &wv) {
+    D3DMATRIX mv = wv;
+    if (isLegacy)
+      InvertMatrixLegacy_SSE2(&mv, &mv);
+    else
+      InvertMatrix_SSE2(&mv, &mv);
+
+    normal_matrix._11 = mv._11;
+    normal_matrix._12 = mv._21;
+    normal_matrix._13 = mv._31;
+    normal_matrix._21 = mv._12;
+    normal_matrix._22 = mv._22;
+    normal_matrix._23 = mv._32;
+    normal_matrix._31 = mv._13;
+    normal_matrix._32 = mv._23;
+    normal_matrix._33 = mv._33;
+  }
+
+  inline D3DMATRIX D3DMatrixMultiply4x4_SSE2(const D3DMATRIX& a, const D3DMATRIX& b) {
+    D3DMATRIX result;
+
+    const __m128 b0 = _mm_loadu_ps(&b._11);
+    const __m128 b1 = _mm_loadu_ps(&b._21);
+    const __m128 b2 = _mm_loadu_ps(&b._31);
+    const __m128 b3 = _mm_loadu_ps(&b._41);
+
+    #define MULROW(dst, src)                                            \
+    do {                                                                \
+        __m128 r = _mm_mul_ps(_mm_set1_ps((src)[0]), b0);               \
+        r = _mm_add_ps(r, _mm_mul_ps(_mm_set1_ps((src)[1]), b1));       \
+        r = _mm_add_ps(r, _mm_mul_ps(_mm_set1_ps((src)[2]), b2));       \
+        r = _mm_add_ps(r, _mm_mul_ps(_mm_set1_ps((src)[3]), b3));       \
+        _mm_storeu_ps((dst), r);                                        \
+    } while (0)
+
+    MULROW(&result._11, &a._11);
+    MULROW(&result._21, &a._21);
+    MULROW(&result._31, &a._31);
+    MULROW(&result._41, &a._41);
+    #undef MULROW
+
+    return result;
+  }
+
+  inline D3DVECTOR4 D3DVec4Transform_SSE2(const D3DMATRIX& m, const D3DVECTOR4& v)
+  {
+    D3DVECTOR4 result;
+
+    const __m128 r0 = _mm_loadu_ps(&m._11);
+    const __m128 r1 = _mm_loadu_ps(&m._21);
+    const __m128 r2 = _mm_loadu_ps(&m._31);
+    const __m128 r3 = _mm_loadu_ps(&m._41);
+
+    __m128 r = _mm_mul_ps(_mm_set1_ps(v.x), r0);
+    r = _mm_add_ps(r, _mm_mul_ps(_mm_set1_ps(v.y), r1));
+    r = _mm_add_ps(r, _mm_mul_ps(_mm_set1_ps(v.z), r2));
+    r = _mm_add_ps(r, _mm_mul_ps(_mm_set1_ps(v.w), r3));
+
+    _mm_storeu_ps(&result.x, r);
+
+    return result;
+  }
+
+  inline D3DVECTOR D3DVec3Transform_SSE2(const D3DMATRIX& m, const D3DVECTOR& v) {
+    const __m128 vx = _mm_set1_ps(v.x);
+    const __m128 vy = _mm_set1_ps(v.y);
+    const __m128 vz = _mm_set1_ps(v.z);
+
+    const __m128 rowX = _mm_setr_ps(m._11, m._12, m._13, 0.0f);
+    const __m128 rowY = _mm_setr_ps(m._21, m._22, m._23, 0.0f);
+    const __m128 rowZ = _mm_setr_ps(m._31, m._32, m._33, 0.0f);
+
+    __m128 r = _mm_mul_ps(vx, rowX);
+    r = _mm_add_ps(r, _mm_mul_ps(vy, rowY));
+    r = _mm_add_ps(r, _mm_mul_ps(vz, rowZ));
+
+    D3DVECTOR4 tmp;
+    _mm_storeu_ps(&tmp.x, r);
+
+    return D3DVECTOR{tmp.x, tmp.y, tmp.z};
+  }
+
+  inline D3DVECTOR D3DVec4to3Transform_SSE2(const D3DMATRIX& m, const D3DVECTOR4& v) {
+    const __m128 r0 = _mm_loadu_ps(&m._11);
+    const __m128 r1 = _mm_loadu_ps(&m._21);
+    const __m128 r2 = _mm_loadu_ps(&m._31);
+    const __m128 r3 = _mm_loadu_ps(&m._41);
+
+    __m128 r = _mm_mul_ps(_mm_set1_ps(v.x), r0);
+    r = _mm_add_ps(r, _mm_mul_ps(_mm_set1_ps(v.y), r1));
+    r = _mm_add_ps(r, _mm_mul_ps(_mm_set1_ps(v.z), r2));
+    r = _mm_add_ps(r, _mm_mul_ps(_mm_set1_ps(v.w), r3));
+
+    D3DVECTOR4 tmp;
+    _mm_storeu_ps(&tmp.x, r);
+
+    return D3DVECTOR{tmp.x, tmp.y, tmp.z};
+  }
+
+  inline float D3DVec3Dot_SSE2(const D3DVECTOR* a, const D3DVECTOR* b) {
+    if (a == nullptr || b == nullptr)
+      return 0.0f;
+
+    __m128 x = _mm_setr_ps(a->x, a->y, a->z, 0.0f);
+    __m128 y = _mm_setr_ps(b->x, b->y, b->z, 0.0f);
+    __m128 m = _mm_mul_ps(x, y);
+    __m128 t = _mm_add_ps(m, _mm_shuffle_ps(m, m, _MM_SHUFFLE(1,0,3,2)));
+
+    t = _mm_add_ss(t, _mm_shuffle_ps(t, t, _MM_SHUFFLE(2,3,0,1)));
+
+    return _mm_cvtss_f32(t);
+  }
+
+  inline __m128 D3DVec3Normalize_SSECore(__m128 v) {
+    __m128 mul = _mm_mul_ps(v, v);
+    __m128 sum = _mm_add_ps(mul, _mm_shuffle_ps(mul, mul, _MM_SHUFFLE(1,0,3,2)));
+    sum = _mm_add_ss(sum, _mm_shuffle_ps(sum, sum, _MM_SHUFFLE(2,3,0,1)));
+
+    __m128 inv = _mm_rsqrt_ss(sum);
+    __m128 half  = _mm_set_ss(0.5f);
+    __m128 three = _mm_set_ss(3.0f);
+
+    inv = _mm_mul_ss(inv, _mm_sub_ss(three, _mm_mul_ss(_mm_mul_ss(sum, inv), inv)));
+    inv = _mm_mul_ss(inv, half);
+
+    return _mm_shuffle_ps(inv, inv, 0x00);
+  }
+
+  inline D3DVECTOR D3DVec3Normalize(const D3DVECTOR& v) {
+    __m128 vec = _mm_setr_ps(v.x, v.y, v.z, 0.0f);
+    __m128 inv = D3DVec3Normalize_SSECore(vec);
+
+    vec = _mm_mul_ps(vec, inv);
+
+    D3DVECTOR out;
+    _mm_store_ss(&out.x, vec);
+    _mm_store_ss(&out.y, _mm_shuffle_ps(vec, vec, 1));
+    _mm_store_ss(&out.z, _mm_shuffle_ps(vec, vec, 2));
+
+    return out;
+  }
+
+  inline void D3DColorClamp_SSE2(D3DCOLORVALUE& color) {
+    __m128 c = _mm_loadu_ps(&color.r);
+
+    c = _mm_min_ps(c, _mm_set1_ps(1.0f));
+    c = _mm_max_ps(c, _mm_setzero_ps());
+
+    _mm_storeu_ps(&color.r, c);
+  }
+
+  inline void ColorVMultiplyAdd_SSE2(D3DCOLORVALUE& out, const D3DCOLORVALUE& color, float value) {
+    __m128 va = _mm_loadu_ps(&color.r);
+    __m128 vb = _mm_loadu_ps(&out.r);
+
+    __m128 vs = _mm_set1_ps(value);
+
+    __m128 r = _mm_add_ps(_mm_mul_ps(va, vs), vb);
+
+    float alpha = out.a;
+    _mm_storeu_ps(&out.r, r);
+    out.a = alpha;
+  }
+
+  inline float D3DSSE_Mad2_Add_Scalar_SSE2(float a1, float a2, float b1, float b2, float c) {
+    __m128 r = _mm_mul_ss(_mm_set_ss(a1), _mm_set_ss(a2));
+    r = _mm_add_ss(r, _mm_mul_ss(_mm_set_ss(b1), _mm_set_ss(b2)));
+    r = _mm_add_ss(r, _mm_set_ss(c));
+
+    return _mm_cvtss_f32(r);
+  }
+
+  inline void D3DColorMulRGB_SetAlpha_SSE2(D3DCOLORVALUE& a, const D3DCOLORVALUE& b, bool legacy) {
+    __m128 va = _mm_loadu_ps(&a.r);
+    __m128 vb = _mm_loadu_ps(&b.r);
+
+    __m128 r = _mm_mul_ps(va, vb);
+
+    _mm_storeu_ps(&a.r, r);
+
+    if (legacy)
+      a.a = 0.0f;
+    else
+      a.a = b.a;
+  }
 
   // D3DCOLOR is DWORD packed ARGB, uint8_t per component
   // D3DCOLORVALUE is struct with float per component normalized to 0.0f - 1.0f
   inline D3DCOLOR ColorVToColor(const D3DCOLORVALUE& c) {
     return D3DCOLOR_ARGB(
-      static_cast<int>(c.a * 255.0f),
-      static_cast<int>(c.r * 255.0f),
-      static_cast<int>(c.g * 255.0f),
-      static_cast<int>(c.b * 255.0f)
+      static_cast<int>(roundf(c.a * 255.0f)),
+      static_cast<int>(roundf(c.r * 255.0f)),
+      static_cast<int>(roundf(c.g * 255.0f)),
+      static_cast<int>(roundf(c.b * 255.0f))
     );
   }
 
@@ -65,12 +443,58 @@ namespace dxvk {
     return result;
   }
 
-  inline void ColorVMultiplyAdd(D3DCOLORVALUE& out, const D3DCOLORVALUE& color, float value, bool alpha = false) {
+  inline void ColorVMultiplyAdd(D3DCOLORVALUE& out, const D3DCOLORVALUE& color, float value) {
     out.r += color.r * value;
     out.g += color.g * value;
     out.b += color.b * value;
-    if (unlikely(alpha))
-      out.a += color.a * value;
+  }
+
+  inline void MaterialColorSource(
+        d3d9::IDirect3DDevice9* d3d9Device, DWORD inFVF, DWORD* diffuse,
+        DWORD* specular, DWORD* ambient, DWORD* emissive, bool isEnabledLighting) {
+    if (!isEnabledLighting) {
+      *diffuse = d3d9::D3DMCS_COLOR1;
+      *specular = d3d9::D3DMCS_COLOR2;
+      *ambient = *emissive = d3d9::D3DMCS_MATERIAL;
+      return;
+    }
+
+    DWORD state;
+    d3d9Device->GetRenderState(d3d9::D3DRS_COLORVERTEX, &state);
+    if (!state) {
+      *ambient = *diffuse = *emissive = *specular = d3d9::D3DMCS_MATERIAL;
+      return;
+    }
+
+    d3d9Device->GetRenderState(d3d9::D3DRS_DIFFUSEMATERIALSOURCE, diffuse);
+    d3d9Device->GetRenderState(d3d9::D3DRS_SPECULARMATERIALSOURCE, specular);
+    *emissive = *specular = d3d9::D3DMCS_MATERIAL;
+    if (*diffuse != d3d9::D3DMCS_COLOR1 || !(inFVF & D3DFVF_DIFFUSE))
+      *diffuse = d3d9::D3DMCS_MATERIAL;
+    if (*specular != d3d9::D3DMCS_COLOR2 || !(inFVF & D3DFVF_SPECULAR))
+      *specular = d3d9::D3DMCS_MATERIAL;
+  }
+
+  inline D3DCOLORVALUE ColorFromMaterialSource(
+        D3DCOLOR* diffuse, D3DCOLOR* specular, DWORD colorSource, D3DCOLORVALUE materialColor) {
+    switch (colorSource) {
+      case d3d9::D3DMCS_COLOR1:
+        if (diffuse != nullptr)
+          return ColorToColorV(*diffuse);
+        else
+          return D3DCOLORVALUE{1.0f, 1.0f, 1.0f, 1.0f};
+      case d3d9::D3DMCS_COLOR2:
+        if (specular != nullptr)
+          return ColorToColorV(*specular);
+        else
+          return D3DCOLORVALUE{0.0f, 0.0f, 0.0f, 0.0f};
+      case d3d9::D3DMCS_MATERIAL:
+        return materialColor;
+      default:
+        return D3DCOLORVALUE{0.0f, 0.0f, 0.0f, 0.0f};
+    }
+
+    return materialColor;
   }
 
   inline Vector4 NormalizeVec3(const Vector4& v) {
@@ -81,32 +505,31 @@ namespace dxvk {
   }
 
   inline void ApplyLight(
-        const d3d9::D3DLIGHT9* light9, bool localViewer, D3DCOLORVALUE& diffuse, D3DCOLORVALUE& specular,
-        const Vector4& normals, const Vector4& hitDirection, const Vector4& position,
+        const PVLIGHT* light9, bool localViewer, D3DCOLORVALUE& diffuse, D3DCOLORVALUE& specular,
+        const D3DVECTOR* normals, const D3DVECTOR* hitDirection, const D3DVECTOR* position,
         float attenuation, float materialPower, bool isLegacy) {
-    const float direction_dot = std::clamp(dot(hitDirection, normals), 0.0f, 1.0f);
-    ColorVMultiplyAdd(diffuse, light9->Diffuse, direction_dot * attenuation);
+    const float direction_dot = std::clamp(D3DVec3Dot_SSE2(hitDirection, normals), 0.0f, 1.0f);
+    ColorVMultiplyAdd_SSE2(diffuse, light9->Diffuse, direction_dot * attenuation);
 
-    Vector4 mid = hitDirection;
+    D3DVECTOR mid = *hitDirection;
     if (localViewer) {
-      mid.x -= position.x;
-      mid.y -= position.y;
-      mid.z -= position.z;
+      mid.x -= position->x;
+      mid.y -= position->y;
+      mid.z -= position->z;
     } else {
       mid.z -= 1.0f;
     }
 
-    mid = normalize(mid);
-    const float direction_transformed_dot = dot(Vector4(normals.x, normals.y, normals.z, 0.0f),
-                                                Vector4(mid.x, mid.y, mid.z, 0.0f));
+    mid = D3DVec3Normalize(mid);
+    const float direction_transformed_dot = D3DVec3Dot_SSE2(normals, &mid);
     if (direction_transformed_dot > 0.0f && (!isLegacy || materialPower > 0.0f) && direction_dot > 0.0f)
-      ColorVMultiplyAdd(specular, light9->Specular, powf(direction_transformed_dot, materialPower) * attenuation);
+      ColorVMultiplyAdd_SSE2(specular, light9->Specular, powf(direction_transformed_dot, materialPower) * attenuation);
   }
 
   inline void ApplyFog(
         float* specularAlpha, D3DFOGMODE vertexMode, float density,
-        float start, float end, bool useRange, const Vector4& position) {
-    const float coord = useRange ? sqrtf(dot(position, position)) : fabsf(position.z);
+        float start, float end, bool useRange, const D3DVECTOR& position) {
+    const float coord = useRange ? sqrtf(D3DVec3Dot_SSE2(&position, &position)) : fabsf(position.z);
 
     switch (vertexMode) {
       // (end - coord) / (end - start)
@@ -133,90 +556,44 @@ namespace dxvk {
   }
 
   inline void ProcessVerticesInput(
-        bool doNotCopyData, DWORD dwFVF, uint8_t *ptr, Vector4& position, Vector4& normals,
-        TexCoordArray& texCoords, D3DCOLOR& diffuse, D3DCOLOR& specular) {
+        bool doNotCopyData, DWORD dwFVF, uint8_t *ptr, PositionArray& position, D3DVECTOR** normals,
+        TexCoordArray& texCoords, D3DCOLOR** diffuse, D3DCOLOR** specular) {
     if (uint8_t type = (dwFVF & D3DFVF_POSITION_MASK)) {
       switch (type) {
         case D3DFVF_XYZ:
-          position.x = *reinterpret_cast<FLOAT*>(ptr);
-          ptr += sizeof(FLOAT);
-          position.y = *reinterpret_cast<FLOAT*>(ptr);
-          ptr += sizeof(FLOAT);
-          position.z = *reinterpret_cast<FLOAT*>(ptr);
-          ptr += sizeof(FLOAT);
-          position.w = 1.0f;
+          memcpy(position.data(), ptr, sizeof(FLOAT) * 3);
+          ptr += sizeof(FLOAT) * 3;
           break;
         case D3DFVF_XYZRHW:
-          position.x = *reinterpret_cast<FLOAT*>(ptr);
-          ptr += sizeof(FLOAT);
-          position.y = *reinterpret_cast<FLOAT*>(ptr);
-          ptr += sizeof(FLOAT);
-          position.z = *reinterpret_cast<FLOAT*>(ptr);
-          ptr += sizeof(FLOAT);
-          position.w = *reinterpret_cast<FLOAT*>(ptr);
-          ptr += sizeof(FLOAT);
+          memcpy(position.data(), ptr, sizeof(FLOAT) * 4);
+          ptr += sizeof(FLOAT) * 4;
           break;
         case D3DFVF_XYZB1:
-          position.x = *reinterpret_cast<FLOAT*>(ptr);
-          ptr += sizeof(FLOAT);
-          position.y = *reinterpret_cast<FLOAT*>(ptr);
-          ptr += sizeof(FLOAT);
-          position.z = *reinterpret_cast<FLOAT*>(ptr);
-          ptr += sizeof(FLOAT);
-          position.w = 1.0f;
-          ptr += sizeof(FLOAT);
+          memcpy(position.data(), ptr, sizeof(FLOAT) * 4);
+          ptr += sizeof(FLOAT) * 4;
           break;
         case D3DFVF_XYZB2:
-          position.x = *reinterpret_cast<FLOAT*>(ptr);
-          ptr += sizeof(FLOAT);
-          position.y = *reinterpret_cast<FLOAT*>(ptr);
-          ptr += sizeof(FLOAT);
-          position.z = *reinterpret_cast<FLOAT*>(ptr);
-          ptr += sizeof(FLOAT);
-          position.w = 1.0f;
-          ptr += 2 * sizeof(FLOAT);
+          memcpy(position.data(), ptr, sizeof(FLOAT) * 5);
+          ptr += sizeof(FLOAT) * 5;
           break;
         case D3DFVF_XYZB3:
-          position.x = *reinterpret_cast<FLOAT*>(ptr);
-          ptr += sizeof(FLOAT);
-          position.y = *reinterpret_cast<FLOAT*>(ptr);
-          ptr += sizeof(FLOAT);
-          position.z = *reinterpret_cast<FLOAT*>(ptr);
-          ptr += sizeof(FLOAT);
-          position.w = 1.0f;
-          ptr += 3 * sizeof(FLOAT);
+          memcpy(position.data(), ptr, sizeof(FLOAT) * 6);
+          ptr += sizeof(FLOAT) * 6;
           break;
         case D3DFVF_XYZB4:
-          position.x = *reinterpret_cast<FLOAT*>(ptr);
-          ptr += sizeof(FLOAT);
-          position.y = *reinterpret_cast<FLOAT*>(ptr);
-          ptr += sizeof(FLOAT);
-          position.z = *reinterpret_cast<FLOAT*>(ptr);
-          ptr += sizeof(FLOAT);
-          position.w = 1.0f;
-          ptr += 4 * sizeof(FLOAT);
+          memcpy(position.data(), ptr, sizeof(FLOAT) * 7);
+          ptr += sizeof(FLOAT) * 7;
           break;
         case D3DFVF_XYZB5:
-          position.x = *reinterpret_cast<FLOAT*>(ptr);
-          ptr += sizeof(FLOAT);
-          position.y = *reinterpret_cast<FLOAT*>(ptr);
-          ptr += sizeof(FLOAT);
-          position.z = *reinterpret_cast<FLOAT*>(ptr);
-          ptr += sizeof(FLOAT);
-          position.w = 1.0f;
-          ptr += 5 * sizeof(FLOAT);
+          memcpy(position.data(), ptr, sizeof(FLOAT) * 8);
+          ptr += sizeof(FLOAT) * 8;
           break;
       }
     }
 
     if (dwFVF & D3DFVF_NORMAL) {
-      normals.x = *reinterpret_cast<FLOAT*>(ptr);
-      ptr += sizeof(FLOAT);
-      normals.y = *reinterpret_cast<FLOAT*>(ptr);
-      ptr += sizeof(FLOAT);
-      normals.z = *reinterpret_cast<FLOAT*>(ptr);
-      ptr += sizeof(FLOAT);
-      normals.w = 0.0f;
+      *normals = reinterpret_cast<D3DVECTOR*>(ptr);
+      ptr += sizeof(D3DVECTOR);
     }
 
     if (dwFVF & D3DFVF_RESERVED1) {
@@ -224,38 +601,36 @@ namespace dxvk {
     }
 
     if (dwFVF & D3DFVF_DIFFUSE) {
-      diffuse = *reinterpret_cast<D3DCOLOR*>(ptr);
+      *diffuse = reinterpret_cast<D3DCOLOR*>(ptr);
       ptr += sizeof(D3DCOLOR);
     }
 
     if (dwFVF & D3DFVF_SPECULAR) {
-      specular = *reinterpret_cast<D3DCOLOR*>(ptr);
+      *specular = reinterpret_cast<D3DCOLOR*>(ptr);
       ptr += sizeof(D3DCOLOR);
     }
 
-    const DWORD dwNumTextures = (dwFVF & D3DFVF_TEXCOUNT_MASK) >> D3DFVF_TEXCOUNT_SHIFT;
+    if (unlikely(doNotCopyData))
+      return;
 
+    const DWORD dwNumTextures = (dwFVF & D3DFVF_TEXCOUNT_MASK) >> D3DFVF_TEXCOUNT_SHIFT;
     for (DWORD tex = 0; tex < dwNumTextures; tex++) {
       const DWORD texCoordSize = (dwFVF >> (tex * 2 + 16)) & 0x3;
       switch (texCoordSize) {
         case D3DFVF_TEXTUREFORMAT1:
-          if (likely(!doNotCopyData))
-            memcpy(texCoords[tex].data(), ptr, sizeof(FLOAT));
+          memcpy(texCoords[tex].data(), ptr, sizeof(FLOAT));
           ptr += sizeof(FLOAT);
           break;
         case D3DFVF_TEXTUREFORMAT2:
-          if (likely(!doNotCopyData))
-            memcpy(texCoords[tex].data(), ptr, sizeof(FLOAT) * 2);
+          memcpy(texCoords[tex].data(), ptr, sizeof(FLOAT) * 2);
           ptr += sizeof(FLOAT) * 2;
           break;
         case D3DFVF_TEXTUREFORMAT3:
-          if (likely(!doNotCopyData))
-            memcpy(texCoords[tex].data(), ptr, sizeof(FLOAT) * 3);
+          memcpy(texCoords[tex].data(), ptr, sizeof(FLOAT) * 3);
           ptr += sizeof(FLOAT) * 3;
           break;
         case D3DFVF_TEXTUREFORMAT4:
-          if (likely(!doNotCopyData))
-            memcpy(texCoords[tex].data(), ptr, sizeof(FLOAT) * 4);
+          memcpy(texCoords[tex].data(), ptr, sizeof(FLOAT) * 4);
           ptr += sizeof(FLOAT) * 4;
           break;
       }
@@ -263,88 +638,45 @@ namespace dxvk {
   }
 
   inline void ProcessVerticesOutput(
-        bool doNotCopyData, DWORD dwFVF, uint8_t* ptr, const Vector4& position, const Vector4& normals,
-        const TexCoordArray& texCoords, const D3DCOLOR& diffuse, const D3DCOLOR& specular) {
+        DWORD dwFVF, uint8_t* ptr, const PositionArray& position, const D3DVECTOR* normals,
+        TexCoordArray* texCoords, const D3DCOLOR* diffuse, const D3DCOLOR* specular) {
     if (uint8_t type = (dwFVF & D3DFVF_POSITION_MASK)) {
       switch (type) {
         case D3DFVF_XYZ:
-          memcpy(ptr, &position.x, sizeof(FLOAT));
-          ptr += sizeof(FLOAT);
-          memcpy(ptr, &position.y, sizeof(FLOAT));
-          ptr += sizeof(FLOAT);
-          memcpy(ptr, &position.z, sizeof(FLOAT));
-          ptr += sizeof(FLOAT);
+          memcpy(ptr, position.data(), sizeof(FLOAT) * 3);
+          ptr += sizeof(FLOAT) * 3;
           break;
         case D3DFVF_XYZRHW:
-          memcpy(ptr, &position.x, sizeof(FLOAT));
-          ptr += sizeof(FLOAT);
-          memcpy(ptr, &position.y, sizeof(FLOAT));
-          ptr += sizeof(FLOAT);
-          memcpy(ptr, &position.z, sizeof(FLOAT));
-          ptr += sizeof(FLOAT);
-          memcpy(ptr, &position.w, sizeof(FLOAT));
-          ptr += sizeof(FLOAT);
+          memcpy(ptr, position.data(), sizeof(FLOAT) * 4);
+          ptr += sizeof(FLOAT) * 4;
           break;
         case D3DFVF_XYZB1:
-          memcpy(ptr, &position.x, sizeof(FLOAT));
-          ptr += sizeof(FLOAT);
-          memcpy(ptr, &position.y, sizeof(FLOAT));
-          ptr += sizeof(FLOAT);
-          memcpy(ptr, &position.z, sizeof(FLOAT));
-          ptr += sizeof(FLOAT);
-          memset(ptr, 0x00, sizeof(FLOAT));
-          ptr += sizeof(FLOAT);
+          memcpy(ptr, position.data(), sizeof(FLOAT) * 4);
+          ptr += sizeof(FLOAT) * 4;
           break;
         case D3DFVF_XYZB2:
-          memcpy(ptr, &position.x, sizeof(FLOAT));
-          ptr += sizeof(FLOAT);
-          memcpy(ptr, &position.y, sizeof(FLOAT));
-          ptr += sizeof(FLOAT);
-          memcpy(ptr, &position.z, sizeof(FLOAT));
-          ptr += sizeof(FLOAT);
-          memset(ptr, 0x00, 2 * sizeof(FLOAT));
-          ptr += 2 * sizeof(FLOAT);
+          memcpy(ptr, position.data(), sizeof(FLOAT) * 5);
+          ptr += sizeof(FLOAT) * 5;
           break;
         case D3DFVF_XYZB3:
-          memcpy(ptr, &position.x, sizeof(FLOAT));
-          ptr += sizeof(FLOAT);
-          memcpy(ptr, &position.y, sizeof(FLOAT));
-          ptr += sizeof(FLOAT);
-          memcpy(ptr, &position.z, sizeof(FLOAT));
-          ptr += sizeof(FLOAT);
-          memset(ptr, 0x00, 3 * sizeof(FLOAT));
-          ptr += 3 * sizeof(FLOAT);
+          memcpy(ptr, position.data(), sizeof(FLOAT) * 6);
+          ptr += sizeof(FLOAT) * 6;
           break;
         case D3DFVF_XYZB4:
-          memcpy(ptr, &position.x, sizeof(FLOAT));
-          ptr += sizeof(FLOAT);
-          memcpy(ptr, &position.y, sizeof(FLOAT));
-          ptr += sizeof(FLOAT);
-          memcpy(ptr, &position.z, sizeof(FLOAT));
-          ptr += sizeof(FLOAT);
-          memset(ptr, 0x00, 4 * sizeof(FLOAT));
-          ptr += 4 * sizeof(FLOAT);
+          memcpy(ptr, position.data(), sizeof(FLOAT) * 7);
+          ptr += sizeof(FLOAT) * 7;
           break;
         case D3DFVF_XYZB5:
-          memcpy(ptr, &position.x, sizeof(FLOAT));
-          ptr += sizeof(FLOAT);
-          memcpy(ptr, &position.y, sizeof(FLOAT));
-          ptr += sizeof(FLOAT);
-          memcpy(ptr, &position.z, sizeof(FLOAT));
-          ptr += sizeof(FLOAT);
-          memset(ptr, 0x00, 5 * sizeof(FLOAT));
-          ptr += 5 * sizeof(FLOAT);
+          memcpy(ptr, position.data(), sizeof(FLOAT) * 8);
+          ptr += sizeof(FLOAT) * 8;
           break;
       }
     }
 
     if (dwFVF & D3DFVF_NORMAL) {
-      memcpy(ptr, &normals.x, sizeof(FLOAT));
-      ptr += sizeof(FLOAT);
-      memcpy(ptr, &normals.y, sizeof(FLOAT));
-      ptr += sizeof(FLOAT);
-      memcpy(ptr, &normals.z, sizeof(FLOAT));
-      ptr += sizeof(FLOAT);
+      if (likely(normals != nullptr))
+        memcpy(ptr, normals, sizeof(FLOAT) * 3);
+      ptr += sizeof(FLOAT) * 3;
     }
 
     if (dwFVF & D3DFVF_RESERVED1) {
@@ -352,40 +684,38 @@ namespace dxvk {
     }
 
     if (dwFVF & D3DFVF_DIFFUSE) {
-      if (likely(!doNotCopyData))
-        memcpy(ptr, &diffuse, sizeof(D3DCOLOR));
+      if (likely(diffuse != nullptr))
+        memcpy(ptr, diffuse, sizeof(D3DCOLOR));
       ptr += sizeof(D3DCOLOR);
     }
 
     if (dwFVF & D3DFVF_SPECULAR) {
-      if (likely(!doNotCopyData))
-        memcpy(ptr, &specular, sizeof(D3DCOLOR));
+      if (likely(specular != nullptr))
+        memcpy(ptr, specular, sizeof(D3DCOLOR));
       ptr += sizeof(D3DCOLOR);
     }
 
-    const DWORD dwNumTextures = (dwFVF & D3DFVF_TEXCOUNT_MASK) >> D3DFVF_TEXCOUNT_SHIFT;
+    if (unlikely(texCoords == nullptr))
+      return;
 
+    const DWORD dwNumTextures = (dwFVF & D3DFVF_TEXCOUNT_MASK) >> D3DFVF_TEXCOUNT_SHIFT;
     for (DWORD tex = 0; tex < dwNumTextures; tex++) {
       const DWORD texCoordSize = (dwFVF >> (tex * 2 + 16)) & 0x3;
       switch (texCoordSize) {
         case D3DFVF_TEXTUREFORMAT1:
-          if (likely(!doNotCopyData))
-            memcpy(ptr, texCoords[tex].data(), sizeof(FLOAT));
+          memcpy(ptr, texCoords[tex].data(), sizeof(FLOAT));
           ptr += sizeof(FLOAT);
           break;
         case D3DFVF_TEXTUREFORMAT2:
-          if (likely(!doNotCopyData))
-            memcpy(ptr, texCoords[tex].data(), sizeof(FLOAT) * 2);
+          memcpy(ptr, texCoords[tex].data(), sizeof(FLOAT) * 2);
           ptr += sizeof(FLOAT) * 2;
           break;
         case D3DFVF_TEXTUREFORMAT3:
-          if (likely(!doNotCopyData))
-            memcpy(ptr, texCoords[tex].data(), sizeof(FLOAT) * 3);
+          memcpy(ptr, texCoords[tex].data(), sizeof(FLOAT) * 3);
           ptr += sizeof(FLOAT) * 3;
           break;
         case D3DFVF_TEXTUREFORMAT4:
-          if (likely(!doNotCopyData))
-            memcpy(ptr, texCoords[tex].data(), sizeof(FLOAT) * 4);
+          memcpy(ptr, texCoords[tex].data(), sizeof(FLOAT) * 4);
           ptr += sizeof(FLOAT) * 4;
           break;
       }
@@ -394,7 +724,6 @@ namespace dxvk {
 
   inline void ProcessVerticesSW(
         d3d9::IDirect3DDevice9* d3d9Device, const D3DOptions* options, ProcessVerticesData* pvData) {
-    Logger::debug(">>> ProcessVerticesSW");
     if (unlikely(pvData == nullptr)) {
       Logger::err("ProcessVerticesSW: Missing processing data");
       return;
@@ -431,11 +760,24 @@ namespace dxvk {
     const DWORD viewport9Right      = viewport9.X + viewport9.Width;
     const DWORD viewport9Bottom     = viewport9.Y + viewport9.Height;
 
+    if (pvData->doClipping) {
+      if (pvData->dsStatus != nullptr && (pvData->dsStatus->dwFlags & D3DSETSTATUS_STATUS)) {
+        pvData->dsStatus->dwFlags = 0;
+        pvData->dsStatus->dwStatus = 0;
+        if (pvData->doExtents) {
+          pvData->dsStatus->dwFlags |= D3DSETSTATUS_EXTENTS;
+          pvData->dsStatus->drExtent.x1 = viewport9.X;
+          pvData->dsStatus->drExtent.y1 = viewport9.Y;
+          pvData->dsStatus->drExtent.x2 = viewport9Right;
+          pvData->dsStatus->drExtent.y2 = viewport9Bottom;
+        }
+      }
+    }
+
     const bool needsCorrection = pvData->isLegacy && pvData->correction != nullptr;
-    const Matrix4 view = MatrixD3DTo4(&view9);
-    const Matrix4 wv   = view * MatrixD3DTo4(&world9);
-    const Matrix4 wvp  = !needsCorrection ? MatrixD3DTo4(&projection9) * wv
-                                          : MatrixD3DTo4(pvData->correction) * MatrixD3DTo4(&projection9) * wv;
+    const D3DMATRIX wv         = D3DMatrixMultiply4x4_SSE2(world9, view9);
+    const D3DMATRIX wvp        = !needsCorrection ? D3DMatrixMultiply4x4_SSE2(wv, projection9)
+                                                  : D3DMatrixMultiply4x4_SSE2(D3DMatrixMultiply4x4_SSE2(wv, projection9), *pvData->correction);
 
     D3DFOGMODE fogVertexMode;
     float fogStart, fogEnd, fogDensity;
@@ -462,98 +804,133 @@ namespace dxvk {
       d3d9Device->GetRenderState(d3d9::D3DRS_SPECULARENABLE, reinterpret_cast<DWORD*>(&isEnabledSpecular));
       d3d9Device->GetRenderState(d3d9::D3DRS_NORMALIZENORMALS, reinterpret_cast<DWORD*>(&isEnabledNormalizeNormals));
       d3d9Device->GetRenderState(d3d9::D3DRS_LOCALVIEWER, reinterpret_cast<DWORD*>(&isEnabledLocalViewer));
-      d3d9Device->GetMaterial(&material9);
     }
-
-    static constexpr D3DCOLORVALUE defaultAmbientColorV  = {0.0f, 0.0f, 0.0f, 0.0f};
-    static constexpr D3DCOLORVALUE defaultDiffuseColorV  = {1.0f, 1.0f, 1.0f, 1.0f};
-    static constexpr D3DCOLORVALUE defaultSpecularColorV = {0.0f, 0.0f, 0.0f, 0.0f};
+    d3d9Device->GetMaterial(&material9);
 
     const float materialPower = useLighting && isEnabledSpecular ? material9.Power : 0.0f;
-    const D3DCOLORVALUE ambientStateColorV = useLighting ? ColorToColorV(ambientStateColor) : defaultAmbientColorV;
+
+    static constexpr D3DCOLORVALUE defaultAmbientColorValue = {0.0f, 0.0f, 0.0f, 0.0f};
+    const D3DCOLORVALUE ambientStateColorValue = useLighting ? ColorToColorV(ambientStateColor) : defaultAmbientColorValue;
+
+    DWORD sourceDiffuse, sourceSpecular, sourceAmbient, sourceEmissive;
+    MaterialColorSource(d3d9Device, pvData->inFVF, &sourceDiffuse, &sourceSpecular, &sourceAmbient, &sourceEmissive, useLighting);
+
+    std::vector<PVLIGHT> lights;
+    if (useLighting && (pvData->outFVF & (D3DFVF_DIFFUSE | D3DFVF_SPECULAR))) {
+      for (const d3d9::D3DLIGHT9& light : *pvData->lights) {
+        PVLIGHT* l = new PVLIGHT;
+
+        l->Type     = D3DLIGHTTYPE(light.Type);
+        l->Ambient  = light.Ambient;
+        l->Diffuse  = light.Diffuse;
+        l->Specular = light.Specular;
+
+        switch (l->Type) {
+            case D3DLIGHT_DIRECTIONAL:
+              l->LightDirection = D3DVec3Normalize(D3DVec4to3Transform_SSE2(view9, {-light.Direction.x, -light.Direction.y, -light.Direction.z, 0.0f}));
+              break;
+            case D3DLIGHT_POINT:
+              l->LightPosition = D3DVec4to3Transform_SSE2(view9, {light.Position.x, light.Position.y, light.Position.z, 1.0f});
+              l->Attenuation0 = light.Attenuation0;
+              l->Attenuation1 = light.Attenuation1;
+              l->Attenuation2 = light.Attenuation2;
+              l->Range = light.Range;
+              break;
+            case D3DLIGHT_SPOT:
+              l->LightDirection = D3DVec3Normalize(D3DVec4to3Transform_SSE2(view9, {light.Direction.x, light.Direction.y, light.Direction.z, 0.0f}));
+              l->LightPosition = D3DVec4to3Transform_SSE2(view9, {light.Position.x, light.Position.y, light.Position.z, 1.0f});
+              l->cosHalfPhi = cosf(light.Phi / 2.0f);
+              l->cosHalfTheta = cosf(light.Theta / 2.0f);
+              l->Attenuation0 = light.Attenuation0;
+              l->Attenuation1 = light.Attenuation1;
+              l->Attenuation2 = light.Attenuation2;
+              l->Range = light.Range;
+              l->Falloff = light.Falloff;
+              break;
+            default:
+              continue;
+        }
+        lights.push_back(*l);
+      }
+    }
 
     for (uint16_t t = 0; t < pvData->vertexCount; t++) {
       uint8_t* inPtr = pvData->inData + t * pvData->inStride;
       uint8_t* outPtr = pvData->outData + t * pvData->outStride;
 
-      Vector4 inPosition  = { };
-      Vector4 inNormals   = { };
-      D3DCOLOR inDiffuse  = 0;
-      D3DCOLOR inSpecular = 0;
+      PositionArray inPosition = { };
+      D3DVECTOR* inNormals = nullptr;
+      D3DCOLOR* inDiffuse  = nullptr;
+      D3DCOLOR* inSpecular = nullptr;
       TexCoordArray inTexCoords = { };
 
-      const bool hasDiffUse  = pvData->inFVF & D3DFVF_DIFFUSE;
-      const bool hasSpecular = pvData->inFVF & D3DFVF_SPECULAR;
-
       ProcessVerticesInput(pvData->doNotCopyData, pvData->inFVF, inPtr, inPosition,
-                           inNormals, inTexCoords, inDiffuse, inSpecular);
+                           &inNormals, inTexCoords, &inDiffuse, &inSpecular);
 
       // Transform vertices
-      Vector4 h = wvp * inPosition;
-      Vector4 outPosition;
+      PositionArray outPosition;
+      memcpy(outPosition.data(), inPosition.data(), sizeof(PositionArray));
+      if (likely(!(pvData->inFVF & D3DFVF_XYZRHW))) {
+        D3DVECTOR4 h = D3DVec4Transform_SSE2(wvp, D3DVECTOR4{inPosition[0], inPosition[1], inPosition[2], 1.0f});
 
-      // Hidden & Dangerous (D3D6) relies on division by zero and NAN/INF output
-      outPosition.w = 1.0f / h.w;
-      outPosition.x = viewport9.X + viewport9HalfWidth  * (h.x * outPosition.w + 1.0f);
-      outPosition.y = viewport9.Y + viewport9HalfHeight * (1.0f - h.y * outPosition.w);
-      outPosition.z = viewport9.MinZ + h.z * outPosition.w * viewport9ZDelta;
+        // Hidden & Dangerous (D3D6) relies on division by zero and NAN/INF output
+        const float rhw = 1.0f / h.w;
+        outPosition[0] = viewport9.X + viewport9HalfWidth  * (h.x * rhw + 1.0f);
+        outPosition[1] = viewport9.Y + viewport9HalfHeight * (1.0f - h.y * rhw);
+        outPosition[2] = viewport9.MinZ + h.z * rhw * viewport9ZDelta;
 
-      // Hack for Resident Evil quad alignment problem
-      if (unlikely(options->vertexOffset != 0.0f)) {
-        outPosition.x += options->vertexOffset;
-        outPosition.y += options->vertexOffset;
-      }
+        // Native supposedly always write rhw without checking output, be more sane until that become a real problem
+        if (likely(pvData->outFVF & D3DFVF_XYZRHW))
+          outPosition[3] = rhw;
 
-      if (pvData->doClipping) {
-        if (pvData->dsStatus != nullptr && (pvData->dsStatus->dwFlags & D3DSETSTATUS_STATUS)) {
-          pvData->dsStatus->dwFlags = 0;
-          pvData->dsStatus->dwStatus = 0;
-          if (pvData->doExtents) {
-            pvData->dsStatus->dwFlags |= D3DSETSTATUS_EXTENTS;
-            pvData->dsStatus->drExtent.x1 = viewport9.X;
-            pvData->dsStatus->drExtent.y1 = viewport9.Y;
-            pvData->dsStatus->drExtent.x2 = viewport9Right;
-            pvData->dsStatus->drExtent.y2 = viewport9Bottom;
-          }
+        // Hack for Resident Evil quad alignment problem
+        if (unlikely(options->vertexOffset != 0.0f)) {
+          outPosition[0] += options->vertexOffset;
+          outPosition[1] += options->vertexOffset;
         }
       }
 
       D3DCOLORVALUE diffuse  = {0.0f, 0.0f, 0.0f, 0.0f};
       D3DCOLORVALUE specular = {0.0f, 0.0f, 0.0f, 0.0f};
 
-      Vector4 VWPosition = wv * inPosition;
-      const float positionScale = 1.0f / VWPosition.w;
-      VWPosition.x *= positionScale;
-      VWPosition.y *= positionScale;
-      VWPosition.z *= positionScale;
+      D3DVECTOR4 WVPosition = D3DVec4Transform_SSE2(wv, D3DVECTOR4{inPosition[0], inPosition[1], inPosition[2], 1.0f});
+      const D3DVECTOR WVPosition3 = {WVPosition.x, WVPosition.y, WVPosition.z};
+      const float positionScale = 1.0f / WVPosition.w;
+      WVPosition.x *= positionScale;
+      WVPosition.y *= positionScale;
+      WVPosition.z *= positionScale;
+
+      D3DCOLORVALUE materialDiffuse  = ColorFromMaterialSource(inDiffuse, inSpecular, sourceDiffuse,  material9.Diffuse);
+      D3DCOLORVALUE materialSpecular = ColorFromMaterialSource(inDiffuse, inSpecular, sourceSpecular, material9.Specular);
 
       if (useLighting && (pvData->outFVF & (D3DFVF_DIFFUSE | D3DFVF_SPECULAR))) {
-        const Vector4 NVWPosition = NormalizeVec3(VWPosition);
-        const Vector4 normals = !isEnabledNormalizeNormals ? wv * inNormals : NormalizeVec3(wv * inNormals);
+        const D3DVECTOR NVWPosition = D3DVec3Normalize(WVPosition3);
+        D3DVECTOR normals;
+        if (inNormals != nullptr) {
+          D3DMATRIX normalMatrix{};
+          ComputeNormalMatrix(normalMatrix, pvData->isLegacy, wv);
+          normals = D3DVec3Transform_SSE2(normalMatrix, *inNormals);
+          if (isEnabledNormalizeNormals)
+            normals = D3DVec3Normalize(normals);
+        }
 
-        D3DCOLORVALUE ambient = ambientStateColorV;
+        D3DCOLORVALUE ambient = ambientStateColorValue;
 
-        for (const d3d9::D3DLIGHT9& light : *pvData->lights) {
-          Vector4 hitDirection;
+        for (const PVLIGHT& light : lights) {
+          D3DVECTOR hitDirection;
           float attenuation;
           const D3DLIGHTTYPE lightType = D3DLIGHTTYPE(light.Type);
           switch (lightType) {
             case D3DLIGHT_DIRECTIONAL: {
-              const Vector4 lightDirection = NormalizeVec3(view * Vector4(-light.Direction.x, -light.Direction.y,
-                                                                          -light.Direction.z, 0.0f));
-
-              hitDirection = Vector4(lightDirection.x, lightDirection.y, lightDirection.z, 0.0f);
+              hitDirection = light.LightDirection;
               attenuation = 1.0f;
               break;
             }
             case D3DLIGHT_POINT:
             case D3DLIGHT_SPOT: {
-              const Vector4 lightPosition = view * Vector4(light.Position.x, light.Position.y,
-                                                           light.Position.z, 1.0f);
-
-              hitDirection = Vector4(lightPosition.x - VWPosition.x, lightPosition.y - VWPosition.y,
-                                     lightPosition.z - VWPosition.z, 0.0f);
-              Vector4 destination(1.0f, 0.0f, dot(hitDirection, hitDirection), 0.0f);
+              hitDirection = D3DVECTOR{light.LightPosition.x - WVPosition.x, light.LightPosition.y - WVPosition.y,
+                                       light.LightPosition.z - WVPosition.z};
+              Vector4 destination(1.0f, 0.0f, D3DVec3Dot_SSE2(&hitDirection, &hitDirection), 0.0f);
               destination.y = sqrtf(destination.z);
               if (pvData->isLegacy) {
                 destination.y = (light.Range - destination.y) / light.Range;
@@ -565,66 +942,62 @@ namespace dxvk {
                   continue;
               }
 
-              hitDirection = NormalizeVec3(hitDirection);
+              hitDirection = D3DVec3Normalize(hitDirection);
               attenuation = destination.x * light.Attenuation0 + destination.y *
                             light.Attenuation1 + destination.z * light.Attenuation2;
+
               if (!pvData->isLegacy)
                 attenuation = 1.0f / attenuation;
 
               if (lightType == D3DLIGHT_SPOT) {
-                const Vector4 lightDirection = NormalizeVec3(view * Vector4(light.Direction.x, light.Direction.y,
-                                                                            light.Direction.z, 0.0f));
-                const float rho = dot(-hitDirection, lightDirection);
-                const float cosHalfPhi = cosf(light.Phi / 2.0f);
-                const float cosHalfTheta = cosf(light.Theta / 2.0f);
-                if (rho <= cosHalfPhi)
+                const D3DVECTOR revHit = {-hitDirection.x, -hitDirection.y, -hitDirection.z};
+                const float rho = D3DVec3Dot_SSE2(&revHit, &light.LightDirection);
+                if (rho <= light.cosHalfPhi)
                   attenuation = 0.0f;
-                else if (rho <= cosHalfTheta)
-                  attenuation *= powf((rho - cosHalfPhi) / (cosHalfTheta - cosHalfPhi), light.Falloff);
+                else if (rho <= light.cosHalfTheta)
+                  attenuation *= powf((rho - light.cosHalfPhi) / (light.cosHalfTheta - light.cosHalfPhi), light.Falloff);
               }
               break;
             }
-            // D3DLIGHT_PARALLELPOINT ligts are emulated with maximum range
-            // and no attentuation regular point lights, so this shouldn't be hit
             default:
               Logger::warn(str::format("ProcessVerticesSW: Invalid light type: ", lightType));
               continue;
           }
 
-          ColorVMultiplyAdd(ambient, light.Ambient, attenuation);
-          ApplyLight(&light, isEnabledLocalViewer, diffuse, specular, normals,
-                     hitDirection, NVWPosition, attenuation, materialPower, pvData->isLegacy);
+          ColorVMultiplyAdd_SSE2(ambient, light.Ambient, attenuation);
+          if (inNormals != nullptr)
+            ApplyLight(&light, isEnabledLocalViewer, diffuse, specular, &normals,
+                     &hitDirection, &NVWPosition, attenuation, materialPower, pvData->isLegacy);
         }
 
-        const D3DCOLORVALUE materialDiffuse  = hasDiffUse  ? ColorToColorV(inDiffuse)  : defaultDiffuseColorV;
-        const D3DCOLORVALUE materialSpecular = hasSpecular ? ColorToColorV(inSpecular) : defaultSpecularColorV;
+        D3DCOLORVALUE materialAmbient  = ColorFromMaterialSource(inDiffuse, inSpecular, sourceAmbient, material9.Ambient);
+        D3DCOLORVALUE materialEmissive = ColorFromMaterialSource(inDiffuse, inSpecular, sourceEmissive, material9.Emissive);
 
-        diffuse.r = ambient.r * material9.Ambient.r + diffuse.r * materialDiffuse.r + material9.Emissive.r;
-        diffuse.g = ambient.g * material9.Ambient.g + diffuse.g * materialDiffuse.g + material9.Emissive.g;
-        diffuse.b = ambient.b * material9.Ambient.b + diffuse.b * materialDiffuse.b + material9.Emissive.b;
-        diffuse.a = material9.Diffuse.a;
+        diffuse.r = D3DSSE_Mad2_Add_Scalar_SSE2(ambient.r, materialAmbient.r, diffuse.r, materialDiffuse.r, materialEmissive.r);
+        diffuse.g = D3DSSE_Mad2_Add_Scalar_SSE2(ambient.g, materialAmbient.g, diffuse.g, materialDiffuse.g, materialEmissive.g);
+        diffuse.b = D3DSSE_Mad2_Add_Scalar_SSE2(ambient.b, materialAmbient.b, diffuse.b, materialDiffuse.b, materialEmissive.b);
+        diffuse.a = materialDiffuse.a;
 
-        specular.r *= materialSpecular.r;
-        specular.g *= materialSpecular.g;
-        specular.b *= materialSpecular.b;
-        specular.a *= pvData->isLegacy ? 0.0f : materialSpecular.a;
+        D3DColorMulRGB_SetAlpha_SSE2(specular, materialSpecular, pvData->isLegacy);
       } else {
-        diffuse  = hasDiffUse  ? ColorToColorV(inDiffuse)  : defaultDiffuseColorV;
-        specular = hasSpecular ? ColorToColorV(inSpecular) : defaultSpecularColorV;
+        diffuse  = materialDiffuse;
+        specular = materialSpecular;
       }
 
       if (isEnabledFog)
-        ApplyFog(&specular.a, fogVertexMode, fogDensity, fogStart, fogEnd, isEnabledFogRange, VWPosition);
+        ApplyFog(&specular.a, fogVertexMode, fogDensity, fogStart, fogEnd, isEnabledFogRange, WVPosition3);
 
-      diffuse  = ColorVClamp(diffuse,  0.0f, 1.0f);
-      specular = ColorVClamp(specular, 0.0f, 1.0f);
+      D3DColorClamp_SSE2(diffuse);
+      D3DColorClamp_SSE2(specular);
 
-      static constexpr D3DCOLOR defaultColor = D3DCOLOR_ARGB(0, 0, 0, 0);
-      const D3DCOLOR outDiffuse  = !pvData->doNotCopyData ? ColorVToColor(diffuse)  : defaultColor;
-      const D3DCOLOR outSpecular = !pvData->doNotCopyData ? ColorVToColor(specular) : defaultColor;
+      const D3DCOLOR outDiffuse  = ColorVToColor(diffuse);
+      const D3DCOLOR outSpecular = ColorVToColor(specular);
 
-      ProcessVerticesOutput(pvData->doNotCopyData, pvData->outFVF, outPtr, outPosition,
-                            inNormals, inTexCoords, outDiffuse, outSpecular);
+      ProcessVerticesOutput(pvData->outFVF, outPtr, outPosition,
+                            (!pvData->doNotCopyData ? inNormals : nullptr),
+                            (!pvData->doNotCopyData ? &inTexCoords : nullptr),
+                            (!pvData->doNotCopyData ? &outDiffuse : nullptr),
+                            (!pvData->doNotCopyData ? &outSpecular : nullptr));
     }
   }
 

--- a/src/ddraw/ddraw/ddraw_interface.cpp
+++ b/src/ddraw/ddraw/ddraw_interface.cpp
@@ -57,8 +57,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawInterface::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> DDrawInterface::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
@@ -68,12 +66,8 @@ namespace dxvk {
     if (riid == __uuidof(IDirect3D3)) {
       // GTA 2 queries for IDirect3D3 on IDirectDraw, after creating a
       // IDirectDraw4 interface and a ton of surfaces... so forward the call
-      if (m_commonIntf->GetDD4Interface() != nullptr) {
-        Logger::debug("DDrawInterface::QueryInterface: Forwarded query for IDirect3D3");
+      if (m_commonIntf->GetDD4Interface() != nullptr)
         return m_commonIntf->GetDD4Interface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDrawInterface::QueryInterface: Query for IDirect3D3");
 
       Com<IDirect3D3> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -87,8 +81,6 @@ namespace dxvk {
     }
     // Standard way of retrieving a D3D5 interface
     if (unlikely(riid == __uuidof(IDirect3D2))) {
-      Logger::debug("DDrawInterface::QueryInterface: Query for IDirect3D2");
-
       // Initialize the IDirect3D2 interlocked object
       if (unlikely(m_d3d5Intf == nullptr))
         m_d3d5Intf = new D3D5Interface(nullptr, m_commonIntf.ptr(), this);
@@ -99,8 +91,6 @@ namespace dxvk {
     }
     // Standard way of retrieving a D3D3 interface
     if (unlikely(riid == __uuidof(IDirect3D))) {
-      Logger::debug("DDrawInterface::QueryInterface: Query for IDirect3D");
-
       // Initialize the IDirect3D interlocked object
       if (unlikely(m_d3d3Intf == nullptr)) {
         m_d3d3Intf = new D3D3Interface(nullptr, m_commonIntf.ptr(), this);
@@ -113,12 +103,8 @@ namespace dxvk {
     }
     // Standard way of getting a DDraw4 interface
     if (riid == __uuidof(IDirectDraw4)) {
-      if (m_commonIntf->GetDD4Interface() != nullptr) {
-        Logger::debug("DDrawInterface::QueryInterface: Query for existing IDirectDraw4");
+      if (m_commonIntf->GetDD4Interface() != nullptr)
         return m_commonIntf->GetDD4Interface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDrawInterface::QueryInterface: Query for IDirectDraw4");
 
       Com<IDirectDraw4> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -131,12 +117,8 @@ namespace dxvk {
     }
     // Standard way of getting a DDraw2 interface
     if (riid == __uuidof(IDirectDraw2)) {
-      if (m_commonIntf->GetDD2Interface() != nullptr) {
-        Logger::debug("DDrawInterface::QueryInterface: Query for existing IDirectDraw2");
+      if (m_commonIntf->GetDD2Interface() != nullptr)
         return m_commonIntf->GetDD2Interface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDrawInterface::QueryInterface: Query for IDirectDraw2");
 
       Com<IDirectDraw2> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -149,12 +131,8 @@ namespace dxvk {
     }
     // Legacy way of getting a DDraw7 interface
     if (unlikely(riid == __uuidof(IDirectDraw7))) {
-      if (m_commonIntf->GetDD7Interface() != nullptr) {
-        Logger::debug("DDrawInterface::QueryInterface: Query for existing IDirectDraw7");
+      if (m_commonIntf->GetDD7Interface() != nullptr)
         return m_commonIntf->GetDD7Interface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDrawInterface::QueryInterface: Query for IDirectDraw7");
 
       Com<IDirectDraw7> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -167,12 +145,10 @@ namespace dxvk {
     }
     // Quite a lot of games query for this IID during intro playback
     if (unlikely(riid == GUID_IAMMediaStream)) {
-      Logger::debug("DDrawInterface::QueryInterface: Query for IAMMediaStream");
       return m_proxy->QueryInterface(riid, ppvObject);
     }
     // Also seen queried by some games, such as V-Rally 2: Expert Edition
     if (unlikely(riid == GUID_IMediaStream)) {
-      Logger::debug("DDrawInterface::QueryInterface: Query for IMediaStream");
       return m_proxy->QueryInterface(riid, ppvObject);
     }
 
@@ -189,13 +165,10 @@ namespace dxvk {
 
   // The documentation states: "The IDirectDraw::Compact method is not currently implemented."
   HRESULT STDMETHODCALLTYPE DDrawInterface::Compact() {
-    Logger::debug(">>> DDrawInterface::Compact");
     return DDERR_UNSUPPORTED;
   }
 
   HRESULT STDMETHODCALLTYPE DDrawInterface::CreateClipper(DWORD dwFlags, LPDIRECTDRAWCLIPPER *lplpDDClipper, IUnknown *pUnkOuter) {
-    Logger::debug(">>> DDrawInterface::CreateClipper");
-
     if (unlikely(lplpDDClipper == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -203,10 +176,8 @@ namespace dxvk {
 
     Com<IDirectDrawClipper> lplpDDClipperProxy;
     HRESULT hr = m_proxy->CreateClipper(dwFlags, &lplpDDClipperProxy, pUnkOuter);
-    if (unlikely(FAILED(hr))) {
-      Logger::warn("DDrawInterface::CreateClipper: Failed to create proxy clipper");
+    if (unlikely(FAILED(hr)))
       return hr;
-    }
 
     *lplpDDClipper = ref(new DDrawClipper(m_commonIntf.ptr(), std::move(lplpDDClipperProxy), this));
 
@@ -214,8 +185,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawInterface::CreatePalette(DWORD dwFlags, LPPALETTEENTRY lpColorTable, LPDIRECTDRAWPALETTE *lplpDDPalette, IUnknown *pUnkOuter) {
-    Logger::debug(">>> DDrawInterface::CreatePalette");
-
     if (unlikely(lplpDDPalette == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -223,10 +192,8 @@ namespace dxvk {
 
     Com<IDirectDrawPalette> lplpDDPaletteProxy;
     HRESULT hr = m_proxy->CreatePalette(dwFlags, lpColorTable, &lplpDDPaletteProxy, pUnkOuter);
-    if (unlikely(FAILED(hr))) {
-      Logger::warn("DDrawInterface::CreatePalette: Failed to create proxy palette");
+    if (unlikely(FAILED(hr)))
       return hr;
-    }
 
     // Palettes created from IDirectDraw and IDirectDraw2 do not ref their parent interfaces
     *lplpDDPalette = ref(new DDrawPalette(std::move(lplpDDPaletteProxy), nullptr));
@@ -235,8 +202,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawInterface::CreateSurface(LPDDSURFACEDESC lpDDSurfaceDesc, LPDIRECTDRAWSURFACE *lplpDDSurface, IUnknown *pUnkOuter) {
-    Logger::debug(">>> DDrawInterface::CreateSurface");
-
     // The cooperative level is always checked first
     if (unlikely(!m_commonIntf->IsCooperativeLevelSet()))
       return DDERR_NOCOOPERATIVELEVELSET;
@@ -271,26 +236,35 @@ namespace dxvk {
       lpDDSurfaceDesc->ddsCaps.dwCaps |= DDSCAPS_SYSTEMMEMORY;
     }
 
-    if (unlikely((lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_ZBUFFER)
-              && (lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFFFF))) {
-      if (m_commonIntf->GetOptions()->useD24X8forD32) {
-        // In case of up-front unsupported and unadvertised D32 depth stencil use,
-        // replace it with D24X8, as some games, such as Sacrifice, rely on it
-        // to properly enable 32-bit display modes (and revert to 16-bit otherwise)
-        Logger::info("DDrawInterface::CreateSurface: Using D24X8 instead of D32");
-        lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFFFF;
-      } else {
-        Logger::warn("DDrawInterface::CreateSurface: Use of unsupported D32");
+    if (unlikely(lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_ZBUFFER)) {
+      if (unlikely(m_commonIntf->GetOptions()->useD16forD24X8
+                && lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFF
+                && lpDDSurfaceDesc->ddpfPixelFormat.dwStencilBitMask == 0x0)) {
+        // Games such as Need for Speed: Porsche are broken with 32-bit color
+        // on night tracks with "projected" lights, because they clearly were
+        // designed with 16-bit Z buffers in mind. Fix it up by silently swapping
+        // D16 for D24X8 on depth stencil creation.
+        Logger::info("DDrawInterface::CreateSurface: Using D16 instead of D24X8");
+        lpDDSurfaceDesc->ddpfPixelFormat.dwZBufferBitDepth = 16;
+        lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFF;
+      } else if (unlikely(lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFFFF)) {
+        if (m_commonIntf->GetOptions()->useD24X8forD32) {
+          // In case of up-front unsupported and unadvertised D32 depth stencil use,
+          // replace it with D24X8, as some games, such as Sacrifice, rely on it
+          // to properly enable 32-bit display modes (and revert to 16-bit otherwise)
+          Logger::info("DDrawInterface::CreateSurface: Using D24X8 instead of D32");
+          lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFFFF;
+        } else {
+          Logger::warn("DDrawInterface::CreateSurface: Use of unsupported D32");
+        }
       }
     }
 
     Com<IDirectDrawSurface> ddrawSurfaceProxied;
     hr = m_proxy->CreateSurface(lpDDSurfaceDesc, &ddrawSurfaceProxied, pUnkOuter);
     // Some games simply try creating surfaces with various formats until something works...
-    if (unlikely(FAILED(hr))) {
-      Logger::debug("DDrawInterface::CreateSurface: Failed to create proxy surface");
+    if (unlikely(FAILED(hr)))
       return hr;
-    }
 
     try{
       // Surfaces created from IDirectDraw and IDirectDraw2 do not ref their parent interfaces
@@ -339,8 +313,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawInterface::DuplicateSurface(LPDIRECTDRAWSURFACE lpDDSurface, LPDIRECTDRAWSURFACE *lplpDupDDSurface) {
-    Logger::debug("<<< DDrawInterface::DuplicateSurface: Proxy");
-
     if (unlikely(lpDDSurface == nullptr || lplpDupDDSurface == nullptr))
       return DDERR_CANTDUPLICATE;
 
@@ -369,13 +341,10 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawInterface::EnumDisplayModes(DWORD dwFlags, LPDDSURFACEDESC lpDDSurfaceDesc, LPVOID lpContext, LPDDENUMMODESCALLBACK lpEnumModesCallback) {
-    Logger::debug("<<< DDrawInterface::EnumDisplayModes: Proxy");
     return m_proxy->EnumDisplayModes(dwFlags, lpDDSurfaceDesc, lpContext, lpEnumModesCallback);
   }
 
   HRESULT STDMETHODCALLTYPE DDrawInterface::EnumSurfaces(DWORD dwFlags, LPDDSURFACEDESC lpDDSD, LPVOID lpContext, LPDDENUMSURFACESCALLBACK lpEnumSurfacesCallback) {
-    Logger::debug("<<< DDrawInterface::EnumSurfaces: Proxy");
-
     if (unlikely(lpEnumSurfacesCallback == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -406,8 +375,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawInterface::FlipToGDISurface() {
-    Logger::debug("*** DDrawInterface::FlipToGDISurface: Ignoring");
-
     DDrawCommonSurface* ps = m_commonIntf->GetPrimarySurface();
 
     // A primary surface must exist for a GDI flip to be possible
@@ -421,8 +388,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawInterface::GetCaps(LPDDCAPS lpDDDriverCaps, LPDDCAPS lpDDHELCaps) {
-    Logger::debug("<<< DDrawInterface::GetCaps: Proxy");
-
     if (unlikely(lpDDDriverCaps == nullptr && lpDDHELCaps == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -449,8 +414,6 @@ namespace dxvk {
 
     D3DCommonDevice* commonDevice = m_commonIntf->GetCommonD3DDevice();
     if (likely(commonDevice != nullptr)) {
-      Logger::debug("DDrawInterface::GetCaps: Getting memory stats from D3D9");
-
       d3d9::IDirect3DDevice9* d3d9Device = commonDevice->GetD3D9Device();
 
       total9 = static_cast<DWORD>(commonDevice->GetTotalTextureMemory());
@@ -462,16 +425,14 @@ namespace dxvk {
         free9 = free9 > delta + ReservedMemory ? free9 - (delta + ReservedMemory) : 0;
       }
 
-      Logger::debug(str::format("DDrawInterface::GetCaps: Total: ", total9));
-      Logger::debug(str::format("DDrawInterface::GetCaps: Free : ", free9));
+      //Logger::debug(str::format("DDrawInterface::GetCaps: Total: ", total9));
+      //Logger::debug(str::format("DDrawInterface::GetCaps: Free : ", free9));
     } else {
-      Logger::debug("DDrawInterface::GetCaps: Getting memory stats from DDraw");
-
       const DWORD total3 = lpDDDriverCaps != nullptr ? lpDDDriverCaps->dwVidMemTotal : 0;
       const DWORD free3  = lpDDDriverCaps != nullptr ? lpDDDriverCaps->dwVidMemFree  : 0;
 
-      Logger::debug(str::format("DDrawInterface::GetCaps: DDraw Total: ", total3));
-      Logger::debug(str::format("DDrawInterface::GetCaps: DDraw Free : ", free3));
+      //Logger::debug(str::format("DDrawInterface::GetCaps: DDraw Total: ", total3));
+      //Logger::debug(str::format("DDrawInterface::GetCaps: DDraw Free : ", free3));
 
       if (unlikely(total3 < MaxMemory)) {
         total9 = total3;
@@ -482,8 +443,8 @@ namespace dxvk {
         free9 = free3 > delta + ReservedMemory ? free3 - (delta + ReservedMemory) : 0;
       }
 
-      Logger::debug(str::format("DDrawInterface::GetCaps: Total: ", total9));
-      Logger::debug(str::format("DDrawInterface::GetCaps: Free : ", free9));
+      //Logger::debug(str::format("DDrawInterface::GetCaps: Total: ", total9));
+      //Logger::debug(str::format("DDrawInterface::GetCaps: Free : ", free9));
     }
 
     if (lpDDDriverCaps != nullptr) {
@@ -503,8 +464,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawInterface::GetDisplayMode(LPDDSURFACEDESC lpDDSurfaceDesc) {
-    Logger::debug("<<< DDrawInterface::GetDisplayMode: Proxy");
-
     if (unlikely(lpDDSurfaceDesc == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -521,8 +480,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawInterface::GetFourCCCodes(LPDWORD lpNumCodes, LPDWORD lpCodes) {
-    Logger::debug(">>> DDrawInterface::GetFourCCCodes");
-
     if (likely(lpNumCodes != nullptr && lpCodes != nullptr)) {
       const uint32_t copyNumCodes = std::min<uint32_t>(ddrawCaps::NumberOfFOURCCCodes, *lpNumCodes);
       for (uint32_t i = 0; i < copyNumCodes; i++) {
@@ -537,8 +494,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawInterface::GetGDISurface(LPDIRECTDRAWSURFACE *lplpGDIDDSurface) {
-    Logger::debug("<<< DDrawInterface::GetGDISurface: Proxy");
-
     if (unlikely(lplpGDIDDSurface == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -546,16 +501,12 @@ namespace dxvk {
 
     Com<IDirectDrawSurface> gdiSurface;
     HRESULT hr = m_proxy->GetGDISurface(&gdiSurface);
-
-    if (unlikely(FAILED(hr))) {
-      Logger::debug("DDrawInterface::GetGDISurface: Failed to retrieve GDI surface");
+    if (unlikely(FAILED(hr)))
       return hr;
-    }
 
     if (unlikely(DDrawCommonInterface::IsWrappedSurface(gdiSurface.ptr()))) {
       *lplpGDIDDSurface = gdiSurface.ref();
     } else {
-      Logger::debug("DDrawInterface::GetGDISurface: Received a non-wrapped GDI surface");
       try {
         *lplpGDIDDSurface = ref(new DDrawSurface(nullptr, std::move(gdiSurface), this, nullptr, false));
       } catch (const DxvkError& e) {
@@ -568,17 +519,14 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawInterface::GetMonitorFrequency(LPDWORD lpdwFrequency) {
-    Logger::debug("<<< DDrawInterface::GetMonitorFrequency: Proxy");
     return m_proxy->GetMonitorFrequency(lpdwFrequency);
   }
 
   HRESULT STDMETHODCALLTYPE DDrawInterface::GetScanLine(LPDWORD lpdwScanLine) {
-    Logger::debug("<<< DDrawInterface::GetScanLine: Proxy");
     return m_proxy->GetScanLine(lpdwScanLine);
   }
 
   HRESULT STDMETHODCALLTYPE DDrawInterface::GetVerticalBlankStatus(LPBOOL lpbIsInVB) {
-    Logger::debug("<<< DDrawInterface::GetVerticalBlankStatus: Proxy");
     return m_proxy->GetVerticalBlankStatus(lpbIsInVB);
   }
 
@@ -589,8 +537,6 @@ namespace dxvk {
   // On native DDraw the initial interface most likely gets reused. In practice,
   // applications that don't use IClassFactory won't call this, so keep it simple.
   HRESULT STDMETHODCALLTYPE DDrawInterface::Initialize(GUID* lpGUID) {
-    Logger::debug(">>> DDrawInterface::Initialize");
-
     if (unlikely(m_commonIntf->IsInitialized()))
       return DDERR_ALREADYINITIALIZED;
 
@@ -600,13 +546,10 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawInterface::RestoreDisplayMode() {
-    Logger::debug("<<< DDrawInterface::RestoreDisplayMode: Proxy");
     return m_proxy->RestoreDisplayMode();
   }
 
   HRESULT STDMETHODCALLTYPE DDrawInterface::SetCooperativeLevel(HWND hWnd, DWORD dwFlags) {
-    Logger::debug("<<< DDrawInterface::SetCooperativeLevel: Proxy");
-
     // DDSCL_CREATEDEVICEWINDOW doesn't appear to behave properly in
     // Wine, so use the cached hWnd to set the device window instead
     if (unlikely((dwFlags & DDSCL_CREATEDEVICEWINDOW) && hWnd == nullptr
@@ -626,8 +569,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawInterface::SetDisplayMode(DWORD dwWidth, DWORD dwHeight, DWORD dwBPP) {
-    Logger::debug("<<< DDrawInterface::SetDisplayMode: Proxy");
-
     Logger::debug(str::format("DDrawInterface::SetDisplayMode: ", dwWidth, "x", dwHeight, ":", dwBPP));
 
     HRESULT hr = m_proxy->SetDisplayMode(dwWidth, dwHeight, dwBPP);
@@ -660,8 +601,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawInterface::WaitForVerticalBlank(DWORD dwFlags, HANDLE hEvent) {
-    Logger::debug(">>> DDrawInterface::WaitForVerticalBlank");
-
     if (unlikely(dwFlags & DDWAITVB_BLOCKBEGINEVENT))
       return DDERR_UNSUPPORTED;
 

--- a/src/ddraw/ddraw/ddraw_surface.cpp
+++ b/src/ddraw/ddraw/ddraw_surface.cpp
@@ -94,13 +94,17 @@ namespace dxvk {
     // Clear the cached depth stencil on the parent if matched
     if (unlikely(m_parentSurf != nullptr && m_commonSurf->IsDepthStencil()
       && m_parentSurf->GetAttachedDepthStencil() == this)) {
-      m_parentSurf->ClearAttachedDepthStencil();
+      m_parentSurf->SetAttachedDepthStencil(nullptr);
     }
 
     DDrawCommonInterface::RemoveWrappedSurface(this);
 
+    if (m_depthStencil != nullptr)
+      m_depthStencil->SetParentSurface(nullptr);
+
     // Release all public references on all attached surfaces
     for (auto & attachedSurface : m_attachedSurfaces) {
+      attachedSurface.second->SetParentSurface(nullptr);
       uint32_t attachedRef;
       do {
         attachedRef = attachedSurface.second->Release();
@@ -116,16 +120,12 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> DDrawSurface::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
     InitReturnPtr(ppvObject);
 
     if (riid == __uuidof(IDirect3DTexture)) {
-      Logger::debug("DDrawSurface::QueryInterface: Query for IDirect3DTexture");
-
       if (unlikely(m_texture3 == nullptr)) {
         Com<IDirect3DTexture> ppvProxyObject;
         HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -141,8 +141,6 @@ namespace dxvk {
       return S_OK;
     }
     if (riid == __uuidof(IDirect3DTexture2)) {
-      Logger::debug("DDrawSurface::QueryInterface: Query for IDirect3DTexture2");
-
       if (unlikely(m_texture5 == nullptr)) {
         Com<IDirect3DTexture2> ppvProxyObject;
         HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -158,8 +156,6 @@ namespace dxvk {
         // it goes out of its way to release the originating IDirectDrawSurface4
         // object AFTER it queries for IDirect3DTexture2 from IDirectDrawSurface...
         if (unlikely(m_commonSurf->GetDD4Surface() == nullptr)) {
-          Logger::debug("DDrawSurface::QueryInterface: Query for IDirectDrawSurface4");
-
           Com<IDirectDrawSurface4> surface4ProxyObject;
           HRESULT hr = m_proxy->QueryInterface(__uuidof(IDirectDrawSurface4),
                                                reinterpret_cast<void**>(&surface4ProxyObject));
@@ -185,7 +181,6 @@ namespace dxvk {
     }
     // Wrap IDirectDrawGammaControl, to potentially ignore application set gamma ramps
     if (riid == __uuidof(IDirectDrawGammaControl)) {
-      Logger::debug("DDrawSurface::QueryInterface: Query for IDirectDrawGammaControl");
       void* gammaControlProxiedVoid = nullptr;
       // This can never reasonably fail
       m_proxy->QueryInterface(__uuidof(IDirectDrawGammaControl), &gammaControlProxiedVoid);
@@ -194,7 +189,6 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirectDrawColorControl))) {
-      Logger::debug("DDrawSurface::QueryInterface: Query for IDirectDrawColorControl");
       return E_NOINTERFACE;
     }
     // The standard way of creating a new D3D3 device. Outside of RAMP, MMX, RGB and HAL,
@@ -202,8 +196,6 @@ namespace dxvk {
     if (riid == IID_IDirect3DHALDevice  || riid == IID_IDirect3DRGBDevice  ||
         riid == IID_IDirect3DMMXDevice  || riid == IID_IDirect3DRampDevice ||
         riid == IID_WineD3DDevice) {
-      Logger::debug("DDrawSurface::QueryInterface: Query with an IDirect3DDevice IID");
-
       // Surfaces which have been queried from an IDirectDrawSurface7
       // object are unable to create a D3D3 device on this legacy path
       if (unlikely(m_commonSurf->GetDD7Surface() == m_commonSurf->GetOrigin()))
@@ -217,12 +209,8 @@ namespace dxvk {
     }
     // Some applications check the supported API level by querying the various newer surface GUIDs...
     if (unlikely(riid == __uuidof(IDirectDrawSurface2))) {
-      if (m_commonSurf->GetDD2Surface() != nullptr) {
-        Logger::debug("DDrawSurface::QueryInterface: Query for existing IDirectDrawSurface2");
+      if (m_commonSurf->GetDD2Surface() != nullptr)
         return m_commonSurf->GetDD2Surface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDrawSurface::QueryInterface: Query for IDirectDrawSurface2");
 
       Com<IDirectDrawSurface2> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -240,12 +228,8 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface3))) {
-      if (m_commonSurf->GetDD3Surface() != nullptr) {
-        Logger::debug("DDrawSurface::QueryInterface: Query for existing IDirectDrawSurface3");
+      if (m_commonSurf->GetDD3Surface() != nullptr)
         return m_commonSurf->GetDD3Surface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDrawSurface::QueryInterface: Query for IDirectDrawSurface3");
 
       Com<IDirectDrawSurface3> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -263,12 +247,8 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface4))) {
-      if (m_commonSurf->GetDD4Surface() != nullptr) {
-        Logger::debug("DDrawSurface::QueryInterface: Query for existing IDirectDrawSurface4");
+      if (m_commonSurf->GetDD4Surface() != nullptr)
         return m_commonSurf->GetDD4Surface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDrawSurface::QueryInterface: Query for IDirectDrawSurface4");
 
       Com<IDirectDrawSurface4> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -309,12 +289,8 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface7))) {
-      if (m_commonSurf->GetDD7Surface() != nullptr) {
-        Logger::debug("DDrawSurface::QueryInterface: Query for existing IDirectDrawSurface7");
+      if (m_commonSurf->GetDD7Surface() != nullptr)
         return m_commonSurf->GetDD7Surface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDrawSurface::QueryInterface: Query for IDirectDrawSurface7");
 
       Com<IDirectDrawSurface7> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -334,7 +310,6 @@ namespace dxvk {
     // Some games are known to query the clipper from the surface,
     // though that won't work and GetClipper exists anyway...
     if (unlikely(riid == __uuidof(IDirectDrawClipper))) {
-      Logger::debug("DDrawSurface::QueryInterface: Query for IDirectDrawClipper");
       return E_NOINTERFACE;
     }
 
@@ -350,8 +325,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::AddAttachedSurface(LPDIRECTDRAWSURFACE lpDDSAttachedSurface) {
-    Logger::debug("<<< DDrawSurface::AddAttachedSurface: Proxy");
-
     if (unlikely(lpDDSAttachedSurface == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -362,20 +335,18 @@ namespace dxvk {
 
     DDrawSurface* attachedSurf = static_cast<DDrawSurface*>(lpDDSAttachedSurface);
 
-    // Unsupported by Wine's DDraw implementation, so we'll do our own handling
-    if (unlikely(attachedSurf->GetCommonSurface()->IsBackBufferOrFlippable())) {
-      Logger::debug("DDrawSurface::AddAttachedSurface: Caching surface as DDraw RT");
-      m_commonIntf->SetDDrawRenderTarget(attachedSurf->GetCommonSurface());
-      return DD_OK;
-    }
-
     HRESULT hr = m_proxy->AddAttachedSurface(attachedSurf->GetProxied());
     if (unlikely(FAILED(hr)))
       return hr;
 
     attachedSurf->SetParentSurface(this);
-    if (likely(attachedSurf->GetCommonSurface()->IsDepthStencil()))
+
+    if (likely(attachedSurf->GetCommonSurface()->IsDepthStencil())) {
       m_depthStencil = attachedSurf;
+    // If a flippable surface is attached, mark it as the next flippable surface
+    } else if (unlikely(attachedSurf->GetCommonSurface()->IsBackBufferOrFlippable())) {
+      m_nextFlippable = attachedSurf;
+    }
 
     return DD_OK;
   }
@@ -383,17 +354,12 @@ namespace dxvk {
   // Docs: "This method is used for the software implementation.
   // It is not needed if the overlay support is provided by the hardware."
   HRESULT STDMETHODCALLTYPE DDrawSurface::AddOverlayDirtyRect(LPRECT lpRect) {
-    Logger::debug(">>> DDrawSurface::AddOverlayDirtyRect");
     return DDERR_UNSUPPORTED;
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::Blt(LPRECT lpDestRect, LPDIRECTDRAWSURFACE lpDDSrcSurface, LPRECT lpSrcRect, DWORD dwFlags, LPDDBLTFX lpDDBltFx) {
-    Logger::debug("<<< DDrawSurface::Blt: Proxy");
-
-    const bool sourceIsWrappedSurface = lpDDSrcSurface == nullptr ||
-                                        DDrawCommonInterface::IsWrappedSurface(lpDDSrcSurface);
-
-    if (unlikely(!sourceIsWrappedSurface)) {
+    if (unlikely(lpDDSrcSurface != nullptr
+             && !DDrawCommonInterface::IsWrappedSurface(lpDDSrcSurface))) {
       Logger::err("DDrawSurface::Blt: Received an unwrapped source surface");
       return DDERR_UNSUPPORTED;
     }
@@ -458,17 +424,12 @@ namespace dxvk {
 
   // Docs: "The IDirectDrawSurface::BltBatch method is not currently implemented."
   HRESULT STDMETHODCALLTYPE DDrawSurface::BltBatch(LPDDBLTBATCH lpDDBltBatch, DWORD dwCount, DWORD dwFlags) {
-    Logger::debug("<<< DDrawSurface::BltBatch: Proxy");
     return DDERR_UNSUPPORTED;
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::BltFast(DWORD dwX, DWORD dwY, LPDIRECTDRAWSURFACE lpDDSrcSurface, LPRECT lpSrcRect, DWORD dwTrans) {
-    Logger::debug("<<< DDrawSurface::BltFast: Proxy");
-
-    const bool sourceIsWrappedSurface = lpDDSrcSurface == nullptr ||
-                                        DDrawCommonInterface::IsWrappedSurface(lpDDSrcSurface);
-
-    if (unlikely(!sourceIsWrappedSurface)) {
+    if (unlikely(lpDDSrcSurface != nullptr
+             && !DDrawCommonInterface::IsWrappedSurface(lpDDSrcSurface))) {
       Logger::err("DDrawSurface::BltFast: Received an unwrapped source surface");
       return DDERR_UNSUPPORTED;
     }
@@ -534,12 +495,8 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::DeleteAttachedSurface(DWORD dwFlags, LPDIRECTDRAWSURFACE lpDDSAttachedSurface) {
-    Logger::debug("<<< DDrawSurface::DeleteAttachedSurface: Proxy");
-
-    const bool attachedSurfaceIsWrappedSurface = lpDDSAttachedSurface == nullptr ||
-                                                 DDrawCommonInterface::IsWrappedSurface(lpDDSAttachedSurface);
-
-    if (unlikely(!attachedSurfaceIsWrappedSurface)) {
+    if (unlikely(lpDDSAttachedSurface != nullptr
+             && !DDrawCommonInterface::IsWrappedSurface(lpDDSAttachedSurface))) {
       Logger::err("DDrawSurface::DeleteAttachedSurface: Received an unwrapped surface");
       return DDERR_UNSUPPORTED;
     }
@@ -557,28 +514,24 @@ namespace dxvk {
 
     DDrawSurface* attachedSurf = static_cast<DDrawSurface*>(lpDDSAttachedSurface);
 
-    if (unlikely(attachedSurf->GetCommonSurface()->IsBackBufferOrFlippable() &&
-                 attachedSurf->GetCommonSurface() == m_commonIntf->GetDDrawRenderTarget())) {
-      Logger::debug("DDrawSurface::DeleteAttachedSurface: Removing cached DDraw RT surface");
-      m_commonIntf->SetDDrawRenderTarget(nullptr);
-      return DD_OK;
-    }
-
     HRESULT hr = m_proxy->DeleteAttachedSurface(dwFlags, attachedSurf->GetProxied());
     if (unlikely(FAILED(hr)))
       return hr;
 
+    attachedSurf->SetParentSurface(nullptr);
+
     if (likely(m_depthStencil == attachedSurf)) {
-      attachedSurf->ClearParentSurface();
       m_depthStencil = nullptr;
+    // Clear the next flippable surface or flippable surface detachment
+    } else if (unlikely(attachedSurf->GetCommonSurface()->IsBackBufferOrFlippable() &&
+                        attachedSurf == m_nextFlippable)) {
+      m_nextFlippable = nullptr;
     }
 
     return DD_OK;
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::EnumAttachedSurfaces(LPVOID lpContext, LPDDENUMSURFACESCALLBACK lpEnumSurfacesCallback) {
-    Logger::debug(">>> DDrawSurface::EnumAttachedSurfaces");
-
     if (unlikely(lpEnumSurfacesCallback == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -623,15 +576,12 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::EnumOverlayZOrders(DWORD dwFlags, LPVOID lpContext, LPDDENUMSURFACESCALLBACK lpfnCallback) {
-    Logger::debug("<<< DDrawSurface::EnumOverlayZOrders: Proxy");
     return m_proxy->EnumOverlayZOrders(dwFlags, lpContext, lpfnCallback);
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::Flip(LPDIRECTDRAWSURFACE lpDDSurfaceTargetOverride, DWORD dwFlags) {
-    const bool overrideIsWrappedSurface = lpDDSurfaceTargetOverride == nullptr ||
-                                          DDrawCommonInterface::IsWrappedSurface(lpDDSurfaceTargetOverride);
-
-    if (unlikely(!overrideIsWrappedSurface)) {
+    if (unlikely(lpDDSurfaceTargetOverride != nullptr
+             && !DDrawCommonInterface::IsWrappedSurface(lpDDSurfaceTargetOverride))) {
       Logger::err("DDrawSurface::Flip: Received an unwrapped override surface");
       return DDERR_UNSUPPORTED;
     }
@@ -639,60 +589,40 @@ namespace dxvk {
     Com<DDrawSurface> overrideSurf = static_cast<DDrawSurface*>(lpDDSurfaceTargetOverride);
 
     d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
-    if (likely(d3d9Device != nullptr)) {
-      Logger::debug("*** DDrawSurface::Flip: Presenting");
-
+    // Overlays can have odd video formats which DXVK doesn't support for RT
+    // use, so let DDraw present in case the flipped surface is an overlay
+    if (likely(d3d9Device != nullptr && !m_commonSurf->IsOverlay())) {
       // Lost surfaces are not flippable
       HRESULT hr = m_proxy->IsLost();
-      if (unlikely(FAILED(hr))) {
-        Logger::debug("DDrawSurface::Flip: Lost surface");
+      if (unlikely(FAILED(hr)))
         return hr;
-      }
 
-      if (unlikely(!(m_commonSurf->IsFrontBuffer() || m_commonSurf->IsBackBufferOrFlippable()))) {
-        Logger::debug("DDrawSurface::Flip: Unflippable surface");
+      if (unlikely(!(m_commonSurf->IsFrontBuffer() || m_commonSurf->IsBackBufferOrFlippable())))
         return DDERR_NOTFLIPPABLE;
-      }
 
       const bool exclusiveMode = m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE;
 
       // Non-exclusive mode validations
-      if (unlikely(m_commonSurf->IsPrimarySurface() && !exclusiveMode)) {
-        Logger::debug("DDrawSurface::Flip: Primary surface flip in non-exclusive mode");
+      if (unlikely(m_commonSurf->IsPrimarySurface() && !exclusiveMode))
         return DDERR_NOEXCLUSIVEMODE;
-      }
 
       // Exclusive mode validations
-      if (unlikely(m_commonSurf->IsBackBufferOrFlippable() && exclusiveMode)) {
-        Logger::debug("DDrawSurface::Flip: Back buffer flip in exclusive mode");
+      if (unlikely(m_commonSurf->IsBackBufferOrFlippable() && exclusiveMode))
         return DDERR_NOTFLIPPABLE;
-      }
 
-      if (unlikely(overrideSurf != nullptr && !overrideSurf->GetCommonSurface()->IsBackBufferOrFlippable())) {
-        Logger::debug("DDrawSurface::Flip: Unflippable override surface");
+      if (unlikely(overrideSurf != nullptr && !overrideSurf->GetCommonSurface()->IsBackBufferOrFlippable()))
         return DDERR_NOTFLIPPABLE;
-      }
 
-      if (m_commonSurf->IsPrimarySurface()) {
-        DDrawSurface* rt = m_commonIntf->GetDDrawRenderTarget() != nullptr ?
-                           m_commonIntf->GetDDrawRenderTarget()->GetDDSurface() : nullptr;
-
-        if (unlikely(rt != nullptr)) {
-          Logger::debug("DDrawSurface::Flip: Presenting from DDraw RT");
-          if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer)) {
-            InitializeOrUploadD3D9();
-            if (m_shadowSurf != nullptr && rt->GetCommonSurface()->IsDDrawSurfaceDirty())
-              GetShadowOrProxied()->BltFast(0, 0, rt->GetShadowOrProxied(), nullptr, DDBLTFAST_NOCOLORKEY);
-          }
-          rt->InitializeOrUploadD3D9();
-          d3d9Device->Present(NULL, NULL, NULL, NULL);
-          return DD_OK;
-        }
+      // Workaround for The Sims/other games flipping a different
+      // swapchain than the one set on the current D3D device
+      if (unlikely(m_commonIntf->GetOptions()->forceRTFlip && m_commonSurf->IsPrimarySurface())) {
+        m_nextFlippable = m_commonSurf->GetCommonD3DDevice()->GetCurrentRenderTarget();
       }
 
       if (likely(m_nextFlippable != nullptr)) {
-        if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer)) {
+        if (m_commonIntf->GetOptions()->emulateFrontBuffer) {
           InitializeOrUploadD3D9();
+          // Workaround for front buffer image retention issues
           if (m_shadowSurf != nullptr && m_nextFlippable->GetCommonSurface()->IsDDrawSurfaceDirty())
             GetShadowOrProxied()->BltFast(0, 0, m_nextFlippable->GetShadowOrProxied(), nullptr, DDBLTFAST_NOCOLORKEY);
         }
@@ -704,19 +634,6 @@ namespace dxvk {
       d3d9Device->Present(NULL, NULL, NULL, NULL);
 
     } else {
-      Logger::debug("<<< DDrawSurface::Flip: Proxy");
-
-      if (m_commonSurf->IsPrimarySurface()) {
-        DDrawSurface* rt = m_commonIntf->GetDDrawRenderTarget() != nullptr ?
-                            m_commonIntf->GetDDrawRenderTarget()->GetDDSurface() : nullptr;
-
-        if (unlikely(rt != nullptr)) {
-          Logger::debug("DDrawSurface::Flip: Blitting DDraw RT");
-          m_proxy->Blt(nullptr, rt->GetShadowOrProxied(), nullptr, DDBLT_WAIT, nullptr);
-          return DD_OK;
-        }
-      }
-
       if (overrideSurf == nullptr) {
         return m_proxy->Flip(lpDDSurfaceTargetOverride, dwFlags);
       } else {
@@ -728,8 +645,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::GetAttachedSurface(LPDDSCAPS lpDDSCaps, LPDIRECTDRAWSURFACE *lplpDDAttachedSurface) {
-    Logger::debug("<<< DDrawSurface::GetAttachedSurface: Proxy");
-
     if (unlikely(lpDDSCaps == nullptr || lplpDDAttachedSurface == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -757,7 +672,6 @@ namespace dxvk {
     // These are rather common, as some games query expecting to get nothing in return, for
     // example it's a common use case to query the mip attach chain until nothing is returned
     if (FAILED(hr)) {
-      Logger::debug("DDrawSurface::GetAttachedSurface: Failed to find the requested surface");
       *lplpDDAttachedSurface = surface.ptr();
       return hr;
     }
@@ -789,8 +703,6 @@ namespace dxvk {
 
   // Blitting can be done at any time and completes within its call frame
   HRESULT STDMETHODCALLTYPE DDrawSurface::GetBltStatus(DWORD dwFlags) {
-    Logger::debug(">>> DDrawSurface::GetBltStatus");
-
     if (likely(dwFlags == DDGBS_CANBLT || dwFlags == DDGBS_ISBLTDONE))
       return DD_OK;
 
@@ -798,8 +710,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::GetCaps(LPDDSCAPS lpDDSCaps) {
-    Logger::debug(">>> DDrawSurface::GetCaps");
-
     if (unlikely(lpDDSCaps == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -809,8 +719,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::GetClipper(LPDIRECTDRAWCLIPPER *lplpDDClipper) {
-    Logger::debug(">>> DDrawSurface::GetClipper");
-
     if (unlikely(lplpDDClipper == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -827,12 +735,20 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::GetColorKey(DWORD dwFlags, LPDDCOLORKEY lpDDColorKey) {
-    Logger::debug("<<< DDrawSurface::GetColorKey: Proxy");
     return m_proxy->GetColorKey(dwFlags, lpDDColorKey);
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::GetDC(HDC *lphDC) {
-    Logger::debug("<<< DDrawSurface::GetDC: Proxy");
+    // Direct D3D9 path which can sometimes be faster (and other times slower)
+    if (unlikely(m_commonIntf->GetOptions()->forceDCForwarding && m_commonSurf->IsInitialized())) {
+      InitializeOrUploadD3D9();
+
+      HRESULT hr = m_commonSurf->GetD3D9Surface()->GetDC(lphDC);
+      if (unlikely(FAILED(hr)))
+        return DDERR_INVALIDPARAMS;
+
+      return DD_OK;
+    }
 
     // Write back any dirty surface data from bound D3D9 back buffers or depth stencils
     DownloadSurfaceData();
@@ -842,8 +758,6 @@ namespace dxvk {
 
   // Flipping can be done at any time and completes within its call frame
   HRESULT STDMETHODCALLTYPE DDrawSurface::GetFlipStatus(DWORD dwFlags) {
-    Logger::debug(">>> DDrawSurface::GetFlipStatus");
-
     if (likely(dwFlags == DDGFS_CANFLIP || dwFlags == DDGFS_ISFLIPDONE))
       return DD_OK;
 
@@ -851,13 +765,10 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::GetOverlayPosition(LPLONG lplX, LPLONG lplY) {
-    Logger::debug("<<< DDrawSurface::GetOverlayPosition: Proxy");
     return m_proxy->GetOverlayPosition(lplX, lplY);
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::GetPalette(LPDIRECTDRAWPALETTE *lplpDDPalette) {
-    Logger::debug(">>> DDrawSurface::GetPalette");
-
     if (unlikely(lplpDDPalette == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -874,8 +785,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::GetPixelFormat(LPDDPIXELFORMAT lpDDPixelFormat) {
-    Logger::debug(">>> DDrawSurface::GetPixelFormat");
-
     if (unlikely(lpDDPixelFormat == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -885,8 +794,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::GetSurfaceDesc(LPDDSURFACEDESC lpDDSurfaceDesc) {
-    Logger::debug(">>> DDrawSurface::GetSurfaceDesc");
-
     if (unlikely(lpDDSurfaceDesc == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -901,18 +808,14 @@ namespace dxvk {
   // According to the docs: "Because the DirectDrawSurface object is initialized
   // when it's created, this method always returns DDERR_ALREADYINITIALIZED."
   HRESULT STDMETHODCALLTYPE DDrawSurface::Initialize(LPDIRECTDRAW lpDD, LPDDSURFACEDESC lpDDSurfaceDesc) {
-    Logger::debug(">>> DDrawSurface::Initialize");
     return DDERR_ALREADYINITIALIZED;
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::IsLost() {
-    Logger::debug("<<< DDrawSurface::IsLost: Proxy");
     return m_proxy->IsLost();
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::Lock(LPRECT lpDestRect, LPDDSURFACEDESC lpDDSurfaceDesc, DWORD dwFlags, HANDLE hEvent) {
-    Logger::debug("<<< DDrawSurface::Lock: Proxy");
-
     // Write back any dirty surface data from bound D3D9 back buffers or depth stencils
     DownloadSurfaceData();
 
@@ -920,7 +823,16 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::ReleaseDC(HDC hDC) {
-    Logger::debug("<<< DDrawSurface::ReleaseDC: Proxy");
+    // Direct D3D9 path which can sometimes be faster (and other times slower)
+    if (unlikely(m_commonIntf->GetOptions()->forceDCForwarding && m_commonSurf->IsInitialized())) {
+      HRESULT hr = m_commonSurf->GetD3D9Surface()->ReleaseDC(hDC);
+      if (unlikely(FAILED(hr)))
+        return DDERR_INVALIDPARAMS;
+
+      m_commonSurf->DirtyD3D9Surface();
+
+      return DD_OK;
+    }
 
     HRESULT hr = GetShadowOrProxied()->ReleaseDC(hDC);
     if (unlikely(FAILED(hr)))
@@ -944,13 +856,10 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::Restore() {
-    Logger::debug("<<< DDrawSurface::Restore: Proxy");
     return m_proxy->Restore();
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::SetClipper(LPDIRECTDRAWCLIPPER lpDDClipper) {
-    Logger::debug("<<< DDrawSurface::SetClipper: Proxy");
-
     // A nullptr lpDDClipper gets the current clipper detached
     if (lpDDClipper == nullptr) {
       HRESULT hr = m_proxy->SetClipper(lpDDClipper);
@@ -970,19 +879,16 @@ namespace dxvk {
       // Retrieve a hWnd, if needed, during clipper attachment
       HWND hWnd = nullptr;
       hr = ddrawClipper->GetProxied()->GetHWnd(&hWnd);
-      if (unlikely(FAILED(hr))) {
-        Logger::debug("DDrawSurface::SetClipper: Failed to retrieve hWnd");
-      } else {
-        m_commonIntf->SetHWND(hWnd);
-      }
+      if (unlikely(FAILED(hr)))
+        return DD_OK;
+
+      m_commonIntf->SetHWND(hWnd);
     }
 
     return DD_OK;
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::SetColorKey(DWORD dwFlags, LPDDCOLORKEY lpDDColorKey) {
-    Logger::debug("<<< DDrawSurface::SetColorKey: Proxy");
-
     // The Combat Mission series of games set a color key which is
     // outside the color range of the surface they are setting it on...
     // clamp it to the surface color depth in that case. This doesn't
@@ -1018,13 +924,10 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::SetOverlayPosition(LONG lX, LONG lY) {
-    Logger::debug("<<< DDrawSurface::SetOverlayPosition: Proxy");
     return m_proxy->SetOverlayPosition(lX, lY);
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::SetPalette(LPDIRECTDRAWPALETTE lpDDPalette) {
-    Logger::debug("<<< DDrawSurface::SetPalette: Proxy");
-
     // A nullptr lpDDPalette gets the current palette detached
     if (lpDDPalette == nullptr) {
       HRESULT hr = GetShadowOrProxied()->SetPalette(lpDDPalette);
@@ -1046,8 +949,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::Unlock(LPVOID lpSurfaceData) {
-    Logger::debug("<<< DDrawSurface::Unlock: Proxy");
-
     HRESULT hr = GetShadowOrProxied()->Unlock(lpSurfaceData);
     if (unlikely(FAILED(hr)))
       return hr;
@@ -1070,8 +971,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::UpdateOverlay(LPRECT lpSrcRect, LPDIRECTDRAWSURFACE lpDDDestSurface, LPRECT lpDestRect, DWORD dwFlags, LPDDOVERLAYFX lpDDOverlayFx) {
-    Logger::debug("<<< DDrawSurface::UpdateOverlay: Proxy");
-
     if (unlikely(lpDDDestSurface == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -1086,17 +985,12 @@ namespace dxvk {
 
   // Docs: "This method is for software emulation only; it does nothing if the hardware supports overlays."
   HRESULT STDMETHODCALLTYPE DDrawSurface::UpdateOverlayDisplay(DWORD dwFlags) {
-    Logger::debug(">>> DDrawSurface::UpdateOverlayDisplay");
     return DDERR_UNSUPPORTED;
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::UpdateOverlayZOrder(DWORD dwFlags, LPDIRECTDRAWSURFACE lpDDSReference) {
-    Logger::debug("<<< DDrawSurface::UpdateOverlayZOrder: Proxy");
-
-    const bool referenceIsWrappedSurface = lpDDSReference == nullptr ||
-                                           DDrawCommonInterface::IsWrappedSurface(lpDDSReference);
-
-    if (unlikely(!referenceIsWrappedSurface)) {
+    if (unlikely(lpDDSReference != nullptr
+              && !DDrawCommonInterface::IsWrappedSurface(lpDDSReference))) {
       Logger::err("DDrawSurface::UpdateOverlayZOrder: Received an unwrapped surface");
       return DDERR_UNSUPPORTED;
     }
@@ -1161,10 +1055,8 @@ namespace dxvk {
     d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
 
     // Fast skip
-    if (unlikely(d3d9Device == nullptr)) {
-      Logger::debug("DDrawSurface::InitializeOrUploadD3D9: Null device, can't initialize right now");
+    if (unlikely(d3d9Device == nullptr))
       return DD_OK;
-    }
 
     if (unlikely(!m_commonSurf->IsInitialized())) {
       if (m_commonSurf->IsTexture())
@@ -1195,19 +1087,15 @@ namespace dxvk {
       m_commonSurf->RefreshD3D9Device();
 
     if (unlikely(m_commonSurf->IsD3D9BackBuffer())) {
-      Logger::debug("DDrawSurface::DownloadSurfaceData: Surface is a bound swapchain surface");
-
       if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
-        Logger::debug(str::format("DDrawSurface::DownloadSurfaceData: Downloading nr. [[1-", m_surfCount, "]]"));
+        //Logger::debug(str::format("DDrawSurface::DownloadSurfaceData: Downloading nr. [[1-", m_surfCount, "]]"));
         BlitToDDrawSurface<IDirectDrawSurface, DDSURFACEDESC>(GetShadowOrProxied(), m_commonSurf->GetD3D9Surface(),
                                                               m_commonSurf->IsDXTFormat());
         m_commonSurf->UnDirtyD3D9Surface();
       }
     } else if (unlikely(m_commonSurf->IsD3D9DepthStencil())) {
-      Logger::debug("DDrawSurface::DownloadSurfaceData: Surface is a bound depth stencil");
-
       if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
-        Logger::debug(str::format("DDrawSurface::DownloadSurfaceData: Downloading nr. [[1-", m_surfCount, "]]"));
+        //Logger::debug(str::format("DDrawSurface::DownloadSurfaceData: Downloading nr. [[1-", m_surfCount, "]]"));
         BlitToDDrawSurface<IDirectDrawSurface, DDSURFACEDESC>(m_proxy.ptr(), m_commonSurf->GetD3D9Surface(),
                                                               m_commonSurf->IsDXTFormat());
         m_commonSurf->UnDirtyD3D9Surface();
@@ -1251,10 +1139,8 @@ namespace dxvk {
         Logger::debug(str::format("DDrawSurface::InitializeD3D9: Mismatch with declared ", desc->dwMipMapCount, " mip levels"));
     }
 
-    if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps)) {
-      Logger::debug("DDrawSurface::InitializeD3D9: Using auto mip map generation");
+    if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps))
       mipCount = 0;
-    }
 
     m_commonSurf->SetMipCount(mipCount);
   }
@@ -1264,16 +1150,13 @@ namespace dxvk {
     if (!m_commonSurf->IsDDrawSurfaceDirty())
       return DD_OK;
 
-    Logger::debug(str::format("DDrawSurface::UploadSurfaceData: Uploading nr. [[1-", m_surfCount, "]]"));
+    //Logger::debug(str::format("DDrawSurface::UploadSurfaceData: Uploading nr. [[1-", m_surfCount, "]]"));
 
     if (m_commonSurf->IsTexture()) {
       BlitToD3D9Texture<IDirectDrawSurface, DDSURFACEDESC>(m_commonSurf->GetD3D9Texture(), m_proxy.ptr(),
                                                            m_commonSurf->GetMipCount(), m_commonSurf->IsDXTFormat());
     // Blit surfaces directly
     } else {
-      if (unlikely(m_commonSurf->IsDepthStencil()))
-        Logger::debug("DDrawSurface::UploadSurfaceData: Uploading depth stencil");
-
       BlitToD3D9Surface<IDirectDrawSurface, DDSURFACEDESC>(m_commonSurf->GetD3D9Surface(), GetShadowOrProxied(),
                                                            m_commonSurf->IsDXTFormat());
     }
@@ -1288,10 +1171,11 @@ namespace dxvk {
 
     DWORD deviceCreationFlags9 = D3DCREATE_SOFTWARE_VERTEXPROCESSING;
     bool  isHALDevice          = false;
+    bool  halFallback          = false;
     bool  rgbFallback          = false;
 
     if (likely(!d3dOptions->forceSWVP)) {
-      if (riid == IID_IDirect3DHALDevice || riid == IID_WineD3DDevice) {
+      if (riid == IID_IDirect3DHALDevice) {
         Logger::info("DDrawSurface::CreateDeviceInternal: Creating an IID_IDirect3DHALDevice device");
         deviceCreationFlags9 = D3DCREATE_MIXED_VERTEXPROCESSING;
         isHALDevice = true;
@@ -1304,13 +1188,19 @@ namespace dxvk {
         Logger::warn("DDrawSurface::CreateDeviceInternal: Unsupported Ramp device, falling back to RGB");
         rgbFallback = true;
       } else {
-        Logger::warn("DDrawSurface::CreateDeviceInternal: Unknown device identifier, falling back to RGB");
-        Logger::warn(str::format(riid));
-        rgbFallback = true;
+        if (unlikely(riid != IID_WineD3DDevice)) {
+          Logger::warn("DDrawSurface::CreateDeviceInternal: Unknown device type, falling back to HAL");
+          Logger::warn(str::format(riid));
+        } else {
+          Logger::info("DDrawSurface::CreateDeviceInternal: Creating an IID_WineD3DDevice HAL device");
+        }
+        halFallback = true;
+        // Don't enforce isHALDevice RT validations
       }
     }
 
-    const IID rclsidOverride = rgbFallback ? IID_IDirect3DRGBDevice : riid;
+    const IID rclsidOverride = halFallback ? IID_IDirect3DHALDevice :
+                               rgbFallback ? IID_IDirect3DRGBDevice : riid;
 
     HWND hWnd = m_commonIntf->GetHWND();
     // Needed to sometimes safely skip intro playback on legacy devices
@@ -1322,8 +1212,10 @@ namespace dxvk {
     if (unlikely(FAILED(hrRT)))
       return hrRT;
 
-    DWORD backBufferWidth  = m_commonSurf->GetDesc()->dwWidth;
-    DWORD BackBufferHeight = m_commonSurf->GetDesc()->dwHeight;
+    const DDSURFACEDESC* desc = m_commonSurf->GetDesc();
+
+    DWORD backBufferWidth  = desc->dwWidth;
+    DWORD BackBufferHeight = desc->dwHeight;
 
     if (likely(d3dOptions->backBufferResize)) {
       const bool exclusiveMode = m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE;
@@ -1332,10 +1224,9 @@ namespace dxvk {
       if (exclusiveMode) {
         DDrawModeSize* modeSize = m_commonIntf->GetModeSize();
         // Wayland apparently needs this for somewhat proper back buffer sizing
-        if ((modeSize->width  && modeSize->width  < m_commonSurf->GetDesc()->dwWidth)
-          || (modeSize->height && modeSize->height < m_commonSurf->GetDesc()->dwHeight)) {
+        if ((modeSize->width  && modeSize->width  < desc->dwWidth)
+         || (modeSize->height && modeSize->height < desc->dwHeight)) {
           Logger::info("DDrawSurface::CreateDeviceInternal: Enforcing mode dimensions");
-
           backBufferWidth  = modeSize->width;
           BackBufferHeight = modeSize->height;
         }
@@ -1357,7 +1248,7 @@ namespace dxvk {
     if (cooperativeLevel & DDSCL_NOWINDOWCHANGES)
       deviceCreationFlags9 |= D3DCREATE_NOWINDOWCHANGES;
 
-    Logger::info(str::format("DDrawSurface::CreateDeviceInternal: Back buffer size: ", backBufferWidth, "x", BackBufferHeight));
+    Logger::info(str::format("DDrawSurface::CreateDeviceInternal: Back buffer size: ", desc->dwWidth, "x", desc->dwHeight));
 
     const DWORD backBufferCount = DetermineBackBufferCount(m_proxy.ptr());
     Logger::info(str::format("DDrawSurface::CreateDeviceInternal: Back buffer count: ", backBufferCount));

--- a/src/ddraw/ddraw/ddraw_surface.h
+++ b/src/ddraw/ddraw/ddraw_surface.h
@@ -129,6 +129,10 @@ namespace dxvk {
       return m_commonIntf;
     }
 
+    void SetNextFlippable(DDrawSurface* nextFlippable) {
+      m_nextFlippable = nextFlippable;
+    }
+
     DDrawSurface* GetNextFlippable() const {
       return m_nextFlippable;
     }
@@ -170,18 +174,17 @@ namespace dxvk {
       return m_depthStencil.ptr();
     }
 
-    void ClearAttachedDepthStencil() {
-      m_depthStencil = nullptr;
-    }
-
     void SetParentSurface(DDrawSurface* surface) {
       m_parentSurf = surface;
-      m_commonSurf->SetIsAttached(true);
+
+      if (m_parentSurf != nullptr)
+        m_commonSurf->SetIsAttached(true);
+      else
+        m_commonSurf->SetIsAttached(false);
     }
 
-    void ClearParentSurface() {
-      m_parentSurf = nullptr;
-      m_commonSurf->SetIsAttached(false);
+    DDrawSurface* GetParentSurface() const {
+      return m_parentSurf;
     }
 
     void SetParentSurface4(DDraw4Surface* surface4) {

--- a/src/ddraw/ddraw2/ddraw2_interface.cpp
+++ b/src/ddraw/ddraw2/ddraw2_interface.cpp
@@ -53,8 +53,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Interface::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> DDraw2Interface::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
@@ -62,22 +60,15 @@ namespace dxvk {
 
     // Standard way of retrieving a D3D5 interface
     if (riid == __uuidof(IDirect3D2)) {
-      if (m_commonIntf->GetDDInterface() != nullptr) {
-        Logger::debug("DDraw2Interface::QueryInterface: Query for IDirect3D2");
+      if (m_commonIntf->GetDDInterface() != nullptr)
         return m_commonIntf->GetDDInterface()->QueryInterface(riid, ppvObject);
-      }
 
-      Logger::warn("DDraw2Interface::QueryInterface: Query for IDirect3D2");
       return m_proxy->QueryInterface(riid, ppvObject);
     }
     // Some games query for legacy DDraw interfaces
     if (unlikely(riid == __uuidof(IDirectDraw))) {
-      if (m_commonIntf->GetDDInterface() != nullptr) {
-        Logger::debug("DDraw2Interface::QueryInterface: Query for existing IDirectDraw");
+      if (m_commonIntf->GetDDInterface() != nullptr)
         return m_commonIntf->GetDDInterface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw2Interface::QueryInterface: Query for IDirectDraw");
 
       Com<IDirectDraw> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -90,12 +81,8 @@ namespace dxvk {
     }
     // Legacy way of getting a DDraw4 interface
     if (riid == __uuidof(IDirectDraw4)) {
-      if (m_commonIntf->GetDD4Interface() != nullptr) {
-        Logger::debug("DDraw2Interface::QueryInterface: Query for existing IDirectDraw4");
+      if (m_commonIntf->GetDD4Interface() != nullptr)
         return m_commonIntf->GetDD4Interface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw2Interface::QueryInterface: Query for IDirectDraw4");
 
       Com<IDirectDraw4> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -108,12 +95,8 @@ namespace dxvk {
     }
     // Legacy way of getting a DDraw7 interface
     if (unlikely(riid == __uuidof(IDirectDraw7))) {
-      if (m_commonIntf->GetDD7Interface() != nullptr) {
-        Logger::debug("DDraw2Interface::QueryInterface: Query for existing IDirectDraw7");
+      if (m_commonIntf->GetDD7Interface() != nullptr)
         return m_commonIntf->GetDD7Interface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw2Interface::QueryInterface: Query for IDirectDraw7");
 
       Com<IDirectDraw7> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -126,12 +109,8 @@ namespace dxvk {
     }
     // Standard way of retrieving a D3D3 interface
     if (unlikely(riid == __uuidof(IDirect3D))) {
-      if (m_commonIntf->GetDDInterface() != nullptr) {
-        Logger::debug("DDraw2Interface::QueryInterface: Query for IDirect3D");
+      if (m_commonIntf->GetDDInterface() != nullptr)
         return m_commonIntf->GetDDInterface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw2Interface::QueryInterface: Query for IDirect3D");
 
       Com<D3D3Interface> d3d3Intf = new D3D3Interface(nullptr, m_commonIntf.ptr(), this);
       m_commonIntf->SetD3D3Interface(d3d3Intf.ptr());
@@ -141,12 +120,8 @@ namespace dxvk {
     }
     // Standard way of retrieving a D3D5 interface
     if (unlikely(riid == __uuidof(IDirect3D2))) {
-      if (m_commonIntf->GetDDInterface() != nullptr) {
-        Logger::debug("DDraw2Interface::QueryInterface: Forwarded query for IDirect3D2");
+      if (m_commonIntf->GetDDInterface() != nullptr)
         return m_commonIntf->GetDDInterface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw2Interface::QueryInterface: Query for IDirect3D2");
 
       Com<D3D5Interface> d3d5Intf = new D3D5Interface(nullptr, m_commonIntf.ptr(), this);
       *ppvObject = d3d5Intf.ref();
@@ -155,8 +130,6 @@ namespace dxvk {
     }
     // Standard way of retrieving a D3D6 interface
     if (unlikely(riid == __uuidof(IDirect3D3))) {
-      Logger::debug("DDraw2Interface::QueryInterface: Query for IDirect3D3");
-
       Com<IDirect3D3> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
       if (unlikely(FAILED(hr)))
@@ -169,12 +142,10 @@ namespace dxvk {
     }
     // Quite a lot of games query for this IID during intro playback
     if (unlikely(riid == GUID_IAMMediaStream)) {
-      Logger::debug("DDraw2Interface::QueryInterface: Query for IAMMediaStream");
       return m_proxy->QueryInterface(riid, ppvObject);
     }
     // Also seen queried by some games, such as V-Rally 2: Expert Edition
     if (unlikely(riid == GUID_IMediaStream)) {
-      Logger::debug("DDraw2Interface::QueryInterface: Query for IMediaStream");
       return m_proxy->QueryInterface(riid, ppvObject);
     }
 
@@ -191,13 +162,10 @@ namespace dxvk {
 
   // The documentation states: "The IDirectDraw2::Compact method is not currently implemented."
   HRESULT STDMETHODCALLTYPE DDraw2Interface::Compact() {
-    Logger::debug(">>> DDraw2Interface::Compact");
-    return DD_OK;
+    return DDERR_UNSUPPORTED;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Interface::CreateClipper(DWORD dwFlags, LPDIRECTDRAWCLIPPER *lplpDDClipper, IUnknown *pUnkOuter) {
-    Logger::debug(">>> DDraw2Interface::CreateClipper");
-
     if (unlikely(lplpDDClipper == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -205,10 +173,8 @@ namespace dxvk {
 
     Com<IDirectDrawClipper> lplpDDClipperProxy;
     HRESULT hr = m_proxy->CreateClipper(dwFlags, &lplpDDClipperProxy, pUnkOuter);
-    if (unlikely(FAILED(hr))) {
-      Logger::warn("DDraw2Interface::CreateClipper: Failed to create proxy clipper");
+    if (unlikely(FAILED(hr)))
       return hr;
-    }
 
     *lplpDDClipper = ref(new DDrawClipper(m_commonIntf.ptr(), std::move(lplpDDClipperProxy), this));
 
@@ -216,8 +182,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Interface::CreatePalette(DWORD dwFlags, LPPALETTEENTRY lpColorTable, LPDIRECTDRAWPALETTE *lplpDDPalette, IUnknown *pUnkOuter) {
-    Logger::debug(">>> DDraw2Interface::CreatePalette");
-
     if (unlikely(lplpDDPalette == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -225,10 +189,8 @@ namespace dxvk {
 
     Com<IDirectDrawPalette> lplpDDPaletteProxy;
     HRESULT hr = m_proxy->CreatePalette(dwFlags, lpColorTable, &lplpDDPaletteProxy, pUnkOuter);
-    if (unlikely(FAILED(hr))) {
-      Logger::warn("DDraw2Interface::CreatePalette: Failed to create proxy palette");
+    if (unlikely(FAILED(hr)))
       return hr;
-    }
 
     // Palettes created from IDirectDraw and IDirectDraw2 do not ref their parent interfaces
     *lplpDDPalette = ref(new DDrawPalette(std::move(lplpDDPaletteProxy), nullptr));
@@ -237,8 +199,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Interface::CreateSurface(LPDDSURFACEDESC lpDDSurfaceDesc, LPDIRECTDRAWSURFACE *lplpDDSurface, IUnknown *pUnkOuter) {
-    Logger::debug(">>> DDraw2Interface::CreateSurface");
-
     // The cooperative level is always checked first
     if (unlikely(!m_commonIntf->IsCooperativeLevelSet()))
       return DDERR_NOCOOPERATIVELEVELSET;
@@ -273,26 +233,35 @@ namespace dxvk {
       lpDDSurfaceDesc->ddsCaps.dwCaps |= DDSCAPS_SYSTEMMEMORY;
     }
 
-    if (unlikely((lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_ZBUFFER)
-              && (lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFFFF))) {
-      if (m_commonIntf->GetOptions()->useD24X8forD32) {
-        // In case of up-front unsupported and unadvertised D32 depth stencil use,
-        // replace it with D24X8, as some games, such as Sacrifice, rely on it
-        // to properly enable 32-bit display modes (and revert to 16-bit otherwise)
-        Logger::info("DDraw2Interface::CreateSurface: Using D24X8 instead of D32");
-        lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFFFF;
-      } else {
-        Logger::warn("DDraw2Interface::CreateSurface: Use of unsupported D32");
+    if (unlikely(lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_ZBUFFER)) {
+      if (unlikely(m_commonIntf->GetOptions()->useD16forD24X8
+                && lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFF
+                && lpDDSurfaceDesc->ddpfPixelFormat.dwStencilBitMask == 0x0)) {
+        // Games such as Need for Speed: Porsche are broken with 32-bit color
+        // on night tracks with "projected" lights, because they clearly were
+        // designed with 16-bit Z buffers in mind. Fix it up by silently swapping
+        // D16 for D24X8 on depth stencil creation.
+        Logger::info("DDraw2Interface::CreateSurface: Using D16 instead of D24X8");
+        lpDDSurfaceDesc->ddpfPixelFormat.dwZBufferBitDepth = 16;
+        lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFF;
+      } else if (unlikely(lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFFFF)) {
+        if (m_commonIntf->GetOptions()->useD24X8forD32) {
+          // In case of up-front unsupported and unadvertised D32 depth stencil use,
+          // replace it with D24X8, as some games, such as Sacrifice, rely on it
+          // to properly enable 32-bit display modes (and revert to 16-bit otherwise)
+          Logger::info("DDraw2Interface::CreateSurface: Using D24X8 instead of D32");
+          lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFFFF;
+        } else {
+          Logger::warn("DDraw2Interface::CreateSurface: Use of unsupported D32");
+        }
       }
     }
 
     Com<IDirectDrawSurface> ddrawSurfaceProxied;
     hr = m_proxy->CreateSurface(lpDDSurfaceDesc, &ddrawSurfaceProxied, pUnkOuter);
     // Some games simply try creating surfaces with various formats until something works...
-    if (unlikely(FAILED(hr))) {
-      Logger::debug("DDraw2Interface::CreateSurface: Failed to create proxy surface");
+    if (unlikely(FAILED(hr)))
       return hr;
-    }
 
     try{
       // Surfaces created from IDirectDraw and IDirectDraw2 do not ref their parent interfaces
@@ -342,8 +311,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Interface::DuplicateSurface(LPDIRECTDRAWSURFACE lpDDSurface, LPDIRECTDRAWSURFACE *lplpDupDDSurface) {
-    Logger::debug("<<< DDraw2Interface::DuplicateSurface: Proxy");
-
     if (unlikely(lpDDSurface == nullptr || lplpDupDDSurface == nullptr))
       return DDERR_CANTDUPLICATE;
 
@@ -373,23 +340,19 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Interface::EnumDisplayModes(DWORD dwFlags, LPDDSURFACEDESC lpDDSurfaceDesc, LPVOID lpContext, LPDDENUMMODESCALLBACK lpEnumModesCallback) {
-    Logger::debug("<<< DDraw2Interface::EnumDisplayModes: Proxy");
     return m_proxy->EnumDisplayModes(dwFlags, lpDDSurfaceDesc, lpContext, lpEnumModesCallback);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Interface::EnumSurfaces(DWORD dwFlags, LPDDSURFACEDESC lpDDSD, LPVOID lpContext, LPDDENUMSURFACESCALLBACK lpEnumSurfacesCallback) {
     if (unlikely(m_commonIntf->GetDDInterface() == nullptr)) {
-      Logger::warn("!!! DDraw2Interface::EnumSurfaces: Stub");
+      Logger::err("DDraw2Interface::EnumSurfaces: Found no valid parent interface");
       return DDERR_UNSUPPORTED;
     }
 
-    Logger::warn(">>> DDraw2Interface::EnumSurfaces");
     return m_commonIntf->GetDDInterface()->EnumSurfaces(dwFlags, lpDDSD, lpContext, lpEnumSurfacesCallback);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Interface::FlipToGDISurface() {
-    Logger::debug("*** DDraw2Interface::FlipToGDISurface: Ignoring");
-
     DDrawCommonSurface* ps = m_commonIntf->GetPrimarySurface();
 
     // A primary surface must exist for a GDI flip to be possible
@@ -403,8 +366,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Interface::GetCaps(LPDDCAPS lpDDDriverCaps, LPDDCAPS lpDDHELCaps) {
-    Logger::debug("<<< DDraw2Interface::GetCaps: Proxy");
-
     if (unlikely(lpDDDriverCaps == nullptr && lpDDHELCaps == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -431,8 +392,6 @@ namespace dxvk {
 
     D3DCommonDevice* commonDevice = m_commonIntf->GetCommonD3DDevice();
     if (likely(commonDevice != nullptr)) {
-      Logger::debug("DDraw2Interface::GetCaps: Getting memory stats from D3D9");
-
       d3d9::IDirect3DDevice9* d3d9Device = commonDevice->GetD3D9Device();
 
       total9 = static_cast<DWORD>(commonDevice->GetTotalTextureMemory());
@@ -444,16 +403,14 @@ namespace dxvk {
         free9 = free9 > delta + ReservedMemory ? free9 - (delta + ReservedMemory) : 0;
       }
 
-      Logger::debug(str::format("DDraw2Interface::GetCaps: Total: ", total9));
-      Logger::debug(str::format("DDraw2Interface::GetCaps: Free : ", free9));
+      //Logger::debug(str::format("DDraw2Interface::GetCaps: Total: ", total9));
+      //Logger::debug(str::format("DDraw2Interface::GetCaps: Free : ", free9));
     } else {
-      Logger::debug("DDraw2Interface::GetCaps: Getting memory stats from DDraw");
-
       const DWORD total5 = lpDDDriverCaps != nullptr ? lpDDDriverCaps->dwVidMemTotal : 0;
       const DWORD free5  = lpDDDriverCaps != nullptr ? lpDDDriverCaps->dwVidMemFree  : 0;
 
-      Logger::debug(str::format("DDraw2Interface::GetCaps: DDraw Total: ", total5));
-      Logger::debug(str::format("DDraw2Interface::GetCaps: DDraw Free : ", free5));
+      //Logger::debug(str::format("DDraw2Interface::GetCaps: DDraw Total: ", total5));
+      //Logger::debug(str::format("DDraw2Interface::GetCaps: DDraw Free : ", free5));
 
       if (unlikely(total5 < MaxMemory)) {
         total9 = total5;
@@ -464,8 +421,8 @@ namespace dxvk {
         free9 = free5 > delta + ReservedMemory ? free5 - (delta + ReservedMemory) : 0;
       }
 
-      Logger::debug(str::format("DDraw2Interface::GetCaps: Total: ", total9));
-      Logger::debug(str::format("DDraw2Interface::GetCaps: Free : ", free9));
+      //Logger::debug(str::format("DDraw2Interface::GetCaps: Total: ", total9));
+      //Logger::debug(str::format("DDraw2Interface::GetCaps: Free : ", free9));
     }
 
     if (lpDDDriverCaps != nullptr) {
@@ -485,8 +442,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Interface::GetDisplayMode(LPDDSURFACEDESC lpDDSurfaceDesc) {
-    Logger::debug("<<< DDraw2Interface::GetDisplayMode: Proxy");
-
     if (unlikely(lpDDSurfaceDesc == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -503,8 +458,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Interface::GetFourCCCodes(LPDWORD lpNumCodes, LPDWORD lpCodes) {
-    Logger::debug(">>> DDraw2Interface::GetFourCCCodes");
-
     if (likely(lpNumCodes != nullptr && lpCodes != nullptr)) {
       const uint32_t copyNumCodes = std::min<uint32_t>(ddrawCaps::NumberOfFOURCCCodes, *lpNumCodes);
       for (uint32_t i = 0; i < copyNumCodes; i++) {
@@ -519,8 +472,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Interface::GetGDISurface(LPDIRECTDRAWSURFACE *lplpGDIDDSurface) {
-    Logger::debug("<<< DDraw2Interface::GetGDISurface: Proxy");
-
     if (unlikely(lplpGDIDDSurface == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -528,16 +479,12 @@ namespace dxvk {
 
     Com<IDirectDrawSurface> gdiSurface;
     HRESULT hr = m_proxy->GetGDISurface(&gdiSurface);
-
-    if (unlikely(FAILED(hr))) {
-      Logger::debug("DDraw2Interface::GetGDISurface: Failed to retrieve GDI surface");
+    if (unlikely(FAILED(hr)))
       return hr;
-    }
 
     if (unlikely(DDrawCommonInterface::IsWrappedSurface(gdiSurface.ptr()))) {
       *lplpGDIDDSurface = gdiSurface.ref();
     } else {
-      Logger::debug("DDraw2Interface::GetGDISurface: Received a non-wrapped GDI surface");
       try {
         *lplpGDIDDSurface = ref(new DDrawSurface(nullptr, std::move(gdiSurface),
                                                  m_commonIntf->GetDDInterface(), nullptr, false));
@@ -551,17 +498,14 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Interface::GetMonitorFrequency(LPDWORD lpdwFrequency) {
-    Logger::debug("<<< DDraw2Interface::GetMonitorFrequency: Proxy");
     return m_proxy->GetMonitorFrequency(lpdwFrequency);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Interface::GetScanLine(LPDWORD lpdwScanLine) {
-    Logger::debug("<<< DDraw2Interface::GetScanLine: Proxy");
     return m_proxy->GetScanLine(lpdwScanLine);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Interface::GetVerticalBlankStatus(LPBOOL lpbIsInVB) {
-    Logger::debug("<<< DDraw2Interface::GetVerticalBlankStatus: Proxy");
     return m_proxy->GetVerticalBlankStatus(lpbIsInVB);
   }
 
@@ -572,8 +516,6 @@ namespace dxvk {
   // On native DDraw the initial interface most likely gets reused. In practice,
   // applications that don't use IClassFactory won't call this, so keep it simple.
   HRESULT STDMETHODCALLTYPE DDraw2Interface::Initialize(GUID* lpGUID) {
-    Logger::debug(">>> DDraw2Interface::Initialize");
-
     if (unlikely(m_commonIntf->IsInitialized()))
       return DDERR_ALREADYINITIALIZED;
 
@@ -583,13 +525,10 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Interface::RestoreDisplayMode() {
-    Logger::debug("<<< DDraw2Interface::RestoreDisplayMode: Proxy");
     return m_proxy->RestoreDisplayMode();
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Interface::SetCooperativeLevel(HWND hWnd, DWORD dwFlags) {
-    Logger::debug("<<< DDraw2Interface::SetCooperativeLevel: Proxy");
-
     // DDSCL_CREATEDEVICEWINDOW doesn't appear to behave properly in
     // Wine, so use the cached hWnd to set the device window instead
     if (unlikely((dwFlags & DDSCL_CREATEDEVICEWINDOW) && hWnd == nullptr
@@ -609,8 +548,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Interface::SetDisplayMode(DWORD dwWidth, DWORD dwHeight, DWORD dwBPP, DWORD dwRefreshRate, DWORD dwFlags) {
-    Logger::debug("<<< DDraw2Interface::SetDisplayMode: Proxy");
-
     Logger::debug(str::format("DDraw2Interface::SetDisplayMode: ", dwWidth, "x", dwHeight, ":", dwBPP, "@", dwRefreshRate));
 
     HRESULT hr = m_proxy->SetDisplayMode(dwWidth, dwHeight, dwBPP, dwRefreshRate, dwFlags);
@@ -643,8 +580,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Interface::WaitForVerticalBlank(DWORD dwFlags, HANDLE hEvent) {
-    Logger::debug(">>> DDraw2Interface::WaitForVerticalBlank");
-
     if (unlikely(dwFlags & DDWAITVB_BLOCKBEGINEVENT))
       return DDERR_UNSUPPORTED;
 
@@ -665,8 +600,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Interface::GetAvailableVidMem(LPDDSCAPS lpDDCaps, LPDWORD lpdwTotal, LPDWORD lpdwFree) {
-    Logger::debug(">>> DDraw2Interface::GetAvailableVidMem");
-
     if (unlikely(lpdwTotal == nullptr && lpdwFree == nullptr))
       return DD_OK;
 
@@ -676,8 +609,6 @@ namespace dxvk {
 
     D3DCommonDevice* commonDevice = m_commonIntf->GetCommonD3DDevice();
     if (likely(commonDevice != nullptr)) {
-      Logger::debug("DDraw2Interface::GetAvailableVidMem: Getting memory stats from D3D9");
-
       d3d9::IDirect3DDevice9* d3d9Device = commonDevice->GetD3D9Device();
 
       DWORD total9 = static_cast<DWORD>(commonDevice->GetTotalTextureMemory());
@@ -689,8 +620,8 @@ namespace dxvk {
         free9 = free9 > delta + ReservedMemory ? free9 - (delta + ReservedMemory) : 0;
       }
 
-      Logger::debug(str::format("DDraw2Interface::GetAvailableVidMem: Total: ", total9));
-      Logger::debug(str::format("DDraw2Interface::GetAvailableVidMem: Free : ", free9));
+      //Logger::debug(str::format("DDraw2Interface::GetAvailableVidMem: Total: ", total9));
+      //Logger::debug(str::format("DDraw2Interface::GetAvailableVidMem: Free : ", free9));
 
       if (lpdwTotal != nullptr)
         *lpdwTotal = total9;
@@ -698,8 +629,6 @@ namespace dxvk {
         *lpdwFree  = free9;
 
     } else {
-      Logger::debug("DDraw2Interface::GetAvailableVidMem: Getting memory stats from DDraw");
-
       DWORD total5 = 0;
       DWORD free5  = 0;
 
@@ -713,8 +642,8 @@ namespace dxvk {
         return hr;
       }
 
-      Logger::debug(str::format("DDraw2Interface::GetAvailableVidMem: DDraw Total: ", total5));
-      Logger::debug(str::format("DDraw2Interface::GetAvailableVidMem: DDraw Free : ", free5));
+      //Logger::debug(str::format("DDraw2Interface::GetAvailableVidMem: DDraw Total: ", total5));
+      //Logger::debug(str::format("DDraw2Interface::GetAvailableVidMem: DDraw Free : ", free5));
 
       DWORD total9 = 0;
       DWORD free9  = 0;
@@ -728,8 +657,8 @@ namespace dxvk {
         free9 = free5 > delta + ReservedMemory ? free5 - (delta + ReservedMemory) : 0;
       }
 
-      Logger::debug(str::format("DDraw2Interface::GetAvailableVidMem: Total: ", total9));
-      Logger::debug(str::format("DDraw2Interface::GetAvailableVidMem: Free : ", free9));
+      //Logger::debug(str::format("DDraw2Interface::GetAvailableVidMem: Total: ", total9));
+      //Logger::debug(str::format("DDraw2Interface::GetAvailableVidMem: Free : ", free9));
 
       if (lpdwTotal != nullptr)
         *lpdwTotal = total9;

--- a/src/ddraw/ddraw2/ddraw2_surface.cpp
+++ b/src/ddraw/ddraw2/ddraw2_surface.cpp
@@ -69,8 +69,6 @@ namespace dxvk {
     if (likely(m_shadowSurf == nullptr)) {
       IUnknown* shadowSurfaceProxiedOrigin = m_commonSurf->GetShadowSurfaceProxied();
       if (likely(shadowSurfaceProxiedOrigin != nullptr)) {
-        Logger::debug("DDraw2Surface: Retrieving shadow surface from origin");
-
         Com<IDirectDrawSurface2> shadowSurfProxy;
         HRESULT hr = shadowSurfaceProxiedOrigin->QueryInterface(__uuidof(IDirectDrawSurface2),
                                                                 reinterpret_cast<void**>(&shadowSurfProxy));
@@ -105,10 +103,22 @@ namespace dxvk {
     // Clear the cached depth stencil on the parent if matched
     if (unlikely(m_parentSurf != nullptr && m_commonSurf->IsDepthStencil()
       && m_parentSurf->GetAttachedDepthStencil() == this)) {
-      m_parentSurf->ClearAttachedDepthStencil();
+      m_parentSurf->SetAttachedDepthStencil(nullptr);
     }
 
     DDrawCommonInterface::RemoveWrappedSurface(this);
+
+    if (m_depthStencil != nullptr)
+      m_depthStencil->SetParentSurface(nullptr);
+
+    // Release all public references on all attached surfaces
+    for (auto & attachedSurface : m_attachedSurfaces) {
+      attachedSurface.second->SetParentSurface(nullptr);
+      uint32_t attachedRef;
+      do {
+        attachedRef = attachedSurface.second->Release();
+      } while (attachedRef > 0);
+    }
 
     m_commonSurf->SetDD2Surface(nullptr);
 
@@ -116,16 +126,12 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> DDraw2Surface::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
     InitReturnPtr(ppvObject);
 
     if (riid == __uuidof(IDirect3DTexture)) {
-      Logger::debug("DDraw2Surface::QueryInterface: Query for IDirect3DTexture");
-
       IDirect3DTexture* texture3 = m_parent->GetD3D3Texture();
 
       if (unlikely(texture3 == nullptr))
@@ -136,8 +142,6 @@ namespace dxvk {
       return S_OK;
     }
     if (riid == __uuidof(IDirect3DTexture2)) {
-      Logger::debug("DDraw2Surface::QueryInterface: Query for IDirect3DTexture2");
-
       IDirect3DTexture2* texture5 = m_parent->GetD3D5Texture();
 
       if (unlikely(texture5 == nullptr))
@@ -148,7 +152,6 @@ namespace dxvk {
       return S_OK;
     }
     if (riid == __uuidof(IDirectDrawGammaControl)) {
-      Logger::debug("DDraw2Surface::QueryInterface: Query for IDirectDrawGammaControl");
       void* gammaControlProxiedVoid = nullptr;
       // This can never reasonably fail
       m_proxy->QueryInterface(__uuidof(IDirectDrawGammaControl), &gammaControlProxiedVoid);
@@ -157,17 +160,12 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirectDrawColorControl))) {
-      Logger::debug("DDraw2Surface::QueryInterface: Query for IDirectDrawColorControl");
       return E_NOINTERFACE;
     }
     if (unlikely(riid == __uuidof(IUnknown)
               || riid == __uuidof(IDirectDrawSurface))) {
-      if (m_commonSurf->GetDDSurface() != nullptr) {
-        Logger::debug("DDraw2Surface::QueryInterface: Query for existing IDirectDrawSurface");
+      if (m_commonSurf->GetDDSurface() != nullptr)
         return m_commonSurf->GetDDSurface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw2Surface::QueryInterface: Query for IDirectDrawSurface");
 
       Com<IDirectDrawSurface> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -185,12 +183,8 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface3))) {
-      if (m_commonSurf->GetDD3Surface() != nullptr) {
-        Logger::debug("DDraw2Surface::QueryInterface: Query for existing IDirectDrawSurface3");
+      if (m_commonSurf->GetDD3Surface() != nullptr)
         return m_commonSurf->GetDD3Surface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw2Surface::QueryInterface: Query for IDirectDrawSurface3");
 
       Com<IDirectDrawSurface3> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -208,12 +202,8 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface4))) {
-      if (m_commonSurf->GetDD4Surface() != nullptr) {
-        Logger::debug("DDraw2Surface::QueryInterface: Query for existing IDirectDrawSurface4");
+      if (m_commonSurf->GetDD4Surface() != nullptr)
         return m_commonSurf->GetDD4Surface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw2Surface::QueryInterface: Query for IDirectDrawSurface4");
 
       Com<IDirectDrawSurface4> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -231,12 +221,8 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface7))) {
-      if (m_commonSurf->GetDD7Surface() != nullptr) {
-        Logger::debug("DDraw2Surface::QueryInterface: Query for existing IDirectDrawSurface7");
+      if (m_commonSurf->GetDD7Surface() != nullptr)
         return m_commonSurf->GetDD7Surface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw2Surface::QueryInterface: Query for IDirectDrawSurface7");
 
       Com<IDirectDrawSurface7> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -265,17 +251,13 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::AddAttachedSurface(LPDIRECTDRAWSURFACE2 lpDDSAttachedSurface) {
-    Logger::debug("<<< DDraw2Surface::AddAttachedSurface: Proxy");
-
     if (unlikely(lpDDSAttachedSurface == nullptr))
       return DDERR_INVALIDPARAMS;
 
     if (unlikely(!DDrawCommonInterface::IsWrappedSurface(lpDDSAttachedSurface))) {
       // Some games, like Nightmare Creatures, try to attach an IDirectDrawSurface depth stencil directly...
-      if (likely(DDrawCommonInterface::IsWrappedSurface(reinterpret_cast<IDirectDrawSurface*>(lpDDSAttachedSurface)))) {
-        Logger::debug("DDraw2Surface::AddAttachedSurface: Attaching IDirectDrawSurface surface");
+      if (likely(DDrawCommonInterface::IsWrappedSurface(reinterpret_cast<IDirectDrawSurface*>(lpDDSAttachedSurface))))
         return m_parent->AddAttachedSurface(reinterpret_cast<IDirectDrawSurface*>(lpDDSAttachedSurface));
-      }
 
       Logger::err("DDraw2Surface::AddAttachedSurface: Received an unwrapped surface");
       return DDERR_CANNOTATTACHSURFACE;
@@ -283,20 +265,19 @@ namespace dxvk {
 
     DDraw2Surface* attachedSurf = static_cast<DDraw2Surface*>(lpDDSAttachedSurface);
 
-    // Unsupported by Wine's DDraw implementation, so we'll do our own handling
-    if (unlikely(attachedSurf->GetCommonSurface()->IsBackBufferOrFlippable())) {
-      Logger::debug("DDraw2Surface::AddAttachedSurface: Caching surface as DDraw RT");
-      m_commonIntf->SetDDrawRenderTarget(attachedSurf->GetCommonSurface());
-      return DD_OK;
-    }
-
     HRESULT hr = m_proxy->AddAttachedSurface(attachedSurf->GetProxied());
     if (unlikely(FAILED(hr)))
       return hr;
 
     attachedSurf->SetParentSurface(this);
-    if (likely(attachedSurf->GetCommonSurface()->IsDepthStencil()))
+
+    if (likely(attachedSurf->GetCommonSurface()->IsDepthStencil())) {
       m_depthStencil = attachedSurf;
+    // If a flippable surface is attached, mark it as the next flippable surface
+    } else if (unlikely(attachedSurf->GetCommonSurface()->IsBackBufferOrFlippable())) {
+      DDrawSurface* attachedSurfParent = attachedSurf->GetCommonSurface()->GetDDSurface();
+      m_parent->SetNextFlippable(attachedSurfParent);
+    }
 
     return DD_OK;
   }
@@ -304,21 +285,14 @@ namespace dxvk {
   // Docs: "This method is used for the software implementation.
   // It is not needed if the overlay support is provided by the hardware."
   HRESULT STDMETHODCALLTYPE DDraw2Surface::AddOverlayDirtyRect(LPRECT lpRect) {
-    Logger::debug(">>> DDraw2Surface::AddOverlayDirtyRect");
     return DDERR_UNSUPPORTED;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::Blt(LPRECT lpDestRect, LPDIRECTDRAWSURFACE2 lpDDSrcSurface, LPRECT lpSrcRect, DWORD dwFlags, LPDDBLTFX lpDDBltFx) {
-    Logger::debug("<<< DDraw2Surface::Blt: Proxy");
-
-    const bool sourceIsWrappedSurface = lpDDSrcSurface == nullptr ||
-                                        DDrawCommonInterface::IsWrappedSurface(lpDDSrcSurface);
-
-    if (unlikely(!sourceIsWrappedSurface)) {
-      if (likely(DDrawCommonInterface::IsWrappedSurface(reinterpret_cast<IDirectDrawSurface*>(lpDDSrcSurface)))) {
-        Logger::debug("DDraw2Surface::Blt: Blitting IDirectDrawSurface surface");
+    if (unlikely(lpDDSrcSurface != nullptr
+             && !DDrawCommonInterface::IsWrappedSurface(lpDDSrcSurface))) {
+      if (likely(DDrawCommonInterface::IsWrappedSurface(reinterpret_cast<IDirectDrawSurface*>(lpDDSrcSurface))))
         return m_parent->Blt(lpDestRect, reinterpret_cast<IDirectDrawSurface*>(lpDDSrcSurface), lpSrcRect, dwFlags, lpDDBltFx);
-      }
 
       Logger::err("DDraw2Surface::Blt: Received an unwrapped source surface");
       return DDERR_UNSUPPORTED;
@@ -385,21 +359,14 @@ namespace dxvk {
 
   // Docs: "The IDirectDrawSurface2::BltBatch method is not currently implemented."
   HRESULT STDMETHODCALLTYPE DDraw2Surface::BltBatch(LPDDBLTBATCH lpDDBltBatch, DWORD dwCount, DWORD dwFlags) {
-    Logger::debug(">>> DDraw2Surface::BltBatch");
     return DDERR_UNSUPPORTED;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::BltFast(DWORD dwX, DWORD dwY, LPDIRECTDRAWSURFACE2 lpDDSrcSurface, LPRECT lpSrcRect, DWORD dwTrans) {
-    Logger::debug("<<< DDraw2Surface::BltFast: Proxy");
-
-    const bool sourceIsWrappedSurface = lpDDSrcSurface == nullptr ||
-                                        DDrawCommonInterface::IsWrappedSurface(lpDDSrcSurface);
-
-    if (unlikely(!sourceIsWrappedSurface)) {
-      if (likely(DDrawCommonInterface::IsWrappedSurface(reinterpret_cast<IDirectDrawSurface*>(lpDDSrcSurface)))) {
-        Logger::debug("DDraw2Surface::BltFast: Blitting IDirectDrawSurface surface");
+    if (unlikely(lpDDSrcSurface != nullptr
+             && !DDrawCommonInterface::IsWrappedSurface(lpDDSrcSurface))) {
+      if (likely(DDrawCommonInterface::IsWrappedSurface(reinterpret_cast<IDirectDrawSurface*>(lpDDSrcSurface))))
         return m_parent->BltFast(dwX, dwY, reinterpret_cast<IDirectDrawSurface*>(lpDDSrcSurface), lpSrcRect, dwTrans);
-      }
 
       Logger::err("DDraw2Surface::BltFast: Received an unwrapped source surface");
       return DDERR_UNSUPPORTED;
@@ -467,17 +434,11 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::DeleteAttachedSurface(DWORD dwFlags, LPDIRECTDRAWSURFACE2 lpDDSAttachedSurface) {
-    Logger::debug("<<< DDraw2Surface::DeleteAttachedSurface: Proxy");
-
-    const bool attachedSurfaceIsWrappedSurface = lpDDSAttachedSurface == nullptr ||
-                                                 DDrawCommonInterface::IsWrappedSurface(lpDDSAttachedSurface);
-
-    if (unlikely(!attachedSurfaceIsWrappedSurface)) {
+    if (unlikely(lpDDSAttachedSurface != nullptr
+             && !DDrawCommonInterface::IsWrappedSurface(lpDDSAttachedSurface))) {
       // Some games, like Nightmare Creatures, try to attach an IDirectDrawSurface depth stencil directly...
-      if (likely(DDrawCommonInterface::IsWrappedSurface(reinterpret_cast<IDirectDrawSurface*>(lpDDSAttachedSurface)))) {
-        Logger::debug("DDraw2Surface::DeleteAttachedSurface: Detaching IDirectDrawSurface surface");
+      if (likely(DDrawCommonInterface::IsWrappedSurface(reinterpret_cast<IDirectDrawSurface*>(lpDDSAttachedSurface))))
         return m_parent->DeleteAttachedSurface(dwFlags, reinterpret_cast<IDirectDrawSurface*>(lpDDSAttachedSurface));
-      }
 
       Logger::err("DDraw2Surface::DeleteAttachedSurface: Received an unwrapped surface");
       return DDERR_UNSUPPORTED;
@@ -496,40 +457,34 @@ namespace dxvk {
 
     DDraw2Surface* attachedSurf = static_cast<DDraw2Surface*>(lpDDSAttachedSurface);
 
-    if (unlikely(attachedSurf->GetCommonSurface()->IsBackBufferOrFlippable() &&
-                 attachedSurf->GetCommonSurface() == m_commonIntf->GetDDrawRenderTarget())) {
-      Logger::debug("DDraw2Surface::DeleteAttachedSurface: Removing cached DDraw RT surface");
-      m_commonIntf->SetDDrawRenderTarget(nullptr);
-      return DD_OK;
-    }
-
     HRESULT hr = m_proxy->DeleteAttachedSurface(dwFlags, attachedSurf->GetProxied());
     if (unlikely(FAILED(hr)))
       return hr;
 
+    attachedSurf->SetParentSurface(nullptr);
+
     if (likely(m_depthStencil == attachedSurf)) {
-      attachedSurf->ClearParentSurface();
       m_depthStencil = nullptr;
+    // Clear the next flippable surface or flippable surface detachment
+    } else if (unlikely(attachedSurf->GetCommonSurface()->IsBackBufferOrFlippable() &&
+                        attachedSurf->GetCommonSurface()->GetDDSurface() == m_parent->GetNextFlippable())) {
+      m_parent->SetNextFlippable(nullptr);
     }
 
     return DD_OK;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::EnumAttachedSurfaces(LPVOID lpContext, LPDDENUMSURFACESCALLBACK lpEnumSurfacesCallback) {
-    Logger::warn(">>> DDraw2Surface::EnumAttachedSurfaces");
     return m_parent->EnumAttachedSurfaces(lpContext, lpEnumSurfacesCallback);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::EnumOverlayZOrders(DWORD dwFlags, LPVOID lpContext, LPDDENUMSURFACESCALLBACK lpfnCallback) {
-    Logger::debug("<<< DDraw2Surface::EnumOverlayZOrders: Proxy");
     return m_proxy->EnumOverlayZOrders(dwFlags, lpContext, lpfnCallback);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::Flip(LPDIRECTDRAWSURFACE2 lpDDSurfaceTargetOverride, DWORD dwFlags) {
-    const bool overrideIsWrappedSurface = lpDDSurfaceTargetOverride == nullptr ||
-                                          DDrawCommonInterface::IsWrappedSurface(lpDDSurfaceTargetOverride);
-
-    if (unlikely(!overrideIsWrappedSurface)) {
+    if (unlikely(lpDDSurfaceTargetOverride != nullptr
+             && !DDrawCommonInterface::IsWrappedSurface(lpDDSurfaceTargetOverride))) {
       Logger::err("DDraw2Surface::Flip: Received an unwrapped override surface");
       return DDERR_UNSUPPORTED;
     }
@@ -537,62 +492,43 @@ namespace dxvk {
     Com<DDraw2Surface> overrideSurf = static_cast<DDraw2Surface*>(lpDDSurfaceTargetOverride);
 
     d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
-    if (likely(d3d9Device != nullptr)) {
-      Logger::debug("*** DDraw2Surface::Flip: Presenting");
-
+    // Overlays can have odd video formats which DXVK doesn't support for RT
+    // use, so let DDraw present in case the flipped surface is an overlay
+    if (likely(d3d9Device != nullptr && !m_commonSurf->IsOverlay())) {
       // Lost surfaces are not flippable
       HRESULT hr = m_proxy->IsLost();
-      if (unlikely(FAILED(hr))) {
-        Logger::debug("DDraw2Surface::Flip: Lost surface");
+      if (unlikely(FAILED(hr)))
         return hr;
-      }
 
-      if (unlikely(!(m_commonSurf->IsFrontBuffer() || m_commonSurf->IsBackBufferOrFlippable()))) {
-        Logger::debug("DDraw2Surface::Flip: Unflippable surface");
+      if (unlikely(!(m_commonSurf->IsFrontBuffer() || m_commonSurf->IsBackBufferOrFlippable())))
         return DDERR_NOTFLIPPABLE;
-      }
 
       const bool exclusiveMode = m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE;
 
       // Non-exclusive mode validations
-      if (unlikely(m_commonSurf->IsPrimarySurface() && !exclusiveMode)) {
-        Logger::debug("DDraw2Surface::Flip: Primary surface flip in non-exclusive mode");
+      if (unlikely(m_commonSurf->IsPrimarySurface() && !exclusiveMode))
         return DDERR_NOEXCLUSIVEMODE;
-      }
 
       // Exclusive mode validations
-      if (unlikely(m_commonSurf->IsBackBufferOrFlippable() && exclusiveMode)) {
-        Logger::debug("DDraw2Surface::Flip: Back buffer flip in exclusive mode");
+      if (unlikely(m_commonSurf->IsBackBufferOrFlippable() && exclusiveMode))
         return DDERR_NOTFLIPPABLE;
-      }
 
-      if (unlikely(overrideSurf != nullptr && !overrideSurf->GetParent()->GetCommonSurface()->IsBackBufferOrFlippable())) {
-        Logger::debug("DDraw2Surface::Flip: Unflippable override surface");
+      if (unlikely(overrideSurf != nullptr && !overrideSurf->GetParent()->GetCommonSurface()->IsBackBufferOrFlippable()))
         return DDERR_NOTFLIPPABLE;
+
+      DDrawSurface* nextFlippable;
+      // Workaround for The Sims/other games flipping a different
+      // swapchain than the one set on the current D3D device
+      if (unlikely(m_commonIntf->GetOptions()->forceRTFlip && m_commonSurf->IsPrimarySurface())) {
+        nextFlippable = m_commonSurf->GetCommonD3DDevice()->GetCurrentRenderTarget();
+      } else {
+        nextFlippable = m_parent->GetNextFlippable();
       }
-
-      if (m_commonSurf->IsPrimarySurface()) {
-        DDraw2Surface* rt = m_commonIntf->GetDDrawRenderTarget() != nullptr ?
-                            m_commonIntf->GetDDrawRenderTarget()->GetDD2Surface() : nullptr;
-
-        if (unlikely(rt != nullptr)) {
-          Logger::debug("DDraw2Surface::Flip: Presenting from DDraw RT");
-          if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer)) {
-            InitializeOrUploadD3D9();
-            if (m_shadowSurf != nullptr && rt->GetCommonSurface()->IsDDrawSurfaceDirty())
-              GetShadowOrProxied()->BltFast(0, 0, rt->GetShadowOrProxied(), nullptr, DDBLTFAST_NOCOLORKEY);
-          }
-          rt->InitializeOrUploadD3D9();
-          d3d9Device->Present(NULL, NULL, NULL, NULL);
-          return DD_OK;
-        }
-      }
-
-      DDrawSurface* nextFlippable = m_parent->GetNextFlippable();
 
       if (likely(nextFlippable != nullptr)) {
-        if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer)) {
+        if (m_commonIntf->GetOptions()->emulateFrontBuffer) {
           InitializeOrUploadD3D9();
+          // Workaround for front buffer image retention issues
           if (m_shadowSurf != nullptr && nextFlippable->GetCommonSurface()->IsDDrawSurfaceDirty())
             m_parent->GetShadowOrProxied()->BltFast(0, 0, nextFlippable->GetShadowOrProxied(), nullptr, DDBLTFAST_NOCOLORKEY);
         }
@@ -604,19 +540,6 @@ namespace dxvk {
       d3d9Device->Present(NULL, NULL, NULL, NULL);
 
     } else {
-      Logger::debug("<<< DDraw2Surface::Flip: Proxy");
-
-      if (m_commonSurf->IsPrimarySurface()) {
-        DDraw2Surface* rt = m_commonIntf->GetDDrawRenderTarget() != nullptr ?
-                            m_commonIntf->GetDDrawRenderTarget()->GetDD2Surface() : nullptr;
-
-        if (unlikely(rt != nullptr)) {
-          Logger::debug("DDraw2Surface::Flip: Blitting DDraw RT");
-          m_proxy->Blt(nullptr, rt->GetShadowOrProxied(), nullptr, DDBLT_WAIT, nullptr);
-          return DD_OK;
-        }
-      }
-
       if (overrideSurf == nullptr) {
         return m_proxy->Flip(lpDDSurfaceTargetOverride, dwFlags);
       } else {
@@ -628,8 +551,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::GetAttachedSurface(LPDDSCAPS lpDDSCaps, LPDIRECTDRAWSURFACE2 *lplpDDAttachedSurface) {
-    Logger::debug("<<< DDraw2Surface::GetAttachedSurface: Proxy");
-
     if (unlikely(lpDDSCaps == nullptr || lplpDDAttachedSurface == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -657,7 +578,6 @@ namespace dxvk {
     // These are rather common, as some games query expecting to get nothing in return, for
     // example it's a common use case to query the mip attach chain until nothing is returned
     if (FAILED(hr)) {
-      Logger::debug("DDraw2Surface::GetAttachedSurface: Failed to find the requested surface");
       *lplpDDAttachedSurface = surface.ptr();
       return hr;
     }
@@ -689,8 +609,6 @@ namespace dxvk {
 
   // Blitting can be done at any time and completes within its call frame
   HRESULT STDMETHODCALLTYPE DDraw2Surface::GetBltStatus(DWORD dwFlags) {
-    Logger::debug(">>> DDraw2Surface::GetBltStatus");
-
     if (likely(dwFlags == DDGBS_CANBLT || dwFlags == DDGBS_ISBLTDONE))
       return DD_OK;
 
@@ -698,8 +616,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::GetCaps(LPDDSCAPS lpDDSCaps) {
-    Logger::debug(">>> DDraw2Surface::GetCaps");
-
     if (unlikely(lpDDSCaps == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -709,8 +625,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::GetClipper(LPDIRECTDRAWCLIPPER *lplpDDClipper) {
-    Logger::debug(">>> DDraw2Surface::GetClipper");
-
     if (unlikely(lplpDDClipper == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -727,12 +641,20 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::GetColorKey(DWORD dwFlags, LPDDCOLORKEY lpDDColorKey) {
-    Logger::debug("<<< DDraw2Surface::GetColorKey: Proxy");
     return m_proxy->GetColorKey(dwFlags, lpDDColorKey);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::GetDC(HDC *lphDC) {
-    Logger::debug("<<< DDraw2Surface::GetDC: Proxy");
+    // Direct D3D9 path which can sometimes be faster (and other times slower)
+    if (unlikely(m_commonIntf->GetOptions()->forceDCForwarding && m_commonSurf->IsInitialized())) {
+      InitializeOrUploadD3D9();
+
+      HRESULT hr = m_commonSurf->GetD3D9Surface()->GetDC(lphDC);
+      if (unlikely(FAILED(hr)))
+        return DDERR_INVALIDPARAMS;
+
+      return DD_OK;
+    }
 
     // Write back any dirty surface data from bound D3D9 back buffers or depth stencils
     DownloadSurfaceData();
@@ -742,8 +664,6 @@ namespace dxvk {
 
   // Flipping can be done at any time and completes within its call frame
   HRESULT STDMETHODCALLTYPE DDraw2Surface::GetFlipStatus(DWORD dwFlags) {
-    Logger::debug(">>> DDraw2Surface::GetFlipStatus");
-
     if (likely(dwFlags == DDGFS_CANFLIP || dwFlags == DDGFS_ISFLIPDONE))
       return DD_OK;
 
@@ -751,13 +671,10 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::GetOverlayPosition(LPLONG lplX, LPLONG lplY) {
-    Logger::debug("<<< DDraw2Surface::GetOverlayPosition: Proxy");
     return m_proxy->GetOverlayPosition(lplX, lplY);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::GetPalette(LPDIRECTDRAWPALETTE *lplpDDPalette) {
-    Logger::debug(">>> DDraw2Surface::GetPalette");
-
     if (unlikely(lplpDDPalette == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -774,8 +691,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::GetPixelFormat(LPDDPIXELFORMAT lpDDPixelFormat) {
-    Logger::debug(">>> DDraw2Surface::GetPixelFormat");
-
     if (unlikely(lpDDPixelFormat == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -785,8 +700,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::GetSurfaceDesc(LPDDSURFACEDESC lpDDSurfaceDesc) {
-    Logger::debug(">>> DDraw2Surface::GetSurfaceDesc");
-
     if (unlikely(lpDDSurfaceDesc == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -801,18 +714,14 @@ namespace dxvk {
   // According to the docs: "Because the DirectDrawSurface object is initialized
   // when it's created, this method always returns DDERR_ALREADYINITIALIZED."
   HRESULT STDMETHODCALLTYPE DDraw2Surface::Initialize(LPDIRECTDRAW lpDD, LPDDSURFACEDESC lpDDSurfaceDesc) {
-    Logger::debug(">>> DDraw2Surface::Initialize");
     return DDERR_ALREADYINITIALIZED;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::IsLost() {
-    Logger::debug("<<< DDraw2Surface::IsLost: Proxy");
     return m_proxy->IsLost();
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::Lock(LPRECT lpDestRect, LPDDSURFACEDESC lpDDSurfaceDesc, DWORD dwFlags, HANDLE hEvent) {
-    Logger::debug("<<< DDraw2Surface::Lock: Proxy");
-
     // Write back any dirty surface data from bound D3D9 back buffers or depth stencils
     DownloadSurfaceData();
 
@@ -820,7 +729,16 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::ReleaseDC(HDC hDC) {
-    Logger::debug("<<< DDraw2Surface::ReleaseDC: Proxy");
+    // Direct D3D9 path which can sometimes be faster (and other times slower)
+    if (unlikely(m_commonIntf->GetOptions()->forceDCForwarding && m_commonSurf->IsInitialized())) {
+      HRESULT hr = m_commonSurf->GetD3D9Surface()->ReleaseDC(hDC);
+      if (unlikely(FAILED(hr)))
+        return DDERR_INVALIDPARAMS;
+
+      m_commonSurf->DirtyD3D9Surface();
+
+      return DD_OK;
+    }
 
     HRESULT hr = GetShadowOrProxied()->ReleaseDC(hDC);
     if (unlikely(FAILED(hr)))
@@ -844,13 +762,10 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::Restore() {
-    Logger::debug("<<< DDraw2Surface::Restore: Proxy");
     return m_proxy->Restore();
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::SetClipper(LPDIRECTDRAWCLIPPER lpDDClipper) {
-    Logger::debug("<<< DDraw2Surface::SetClipper: Proxy");
-
     // A nullptr lpDDClipper gets the current clipper detached
     if (lpDDClipper == nullptr) {
       HRESULT hr = m_proxy->SetClipper(lpDDClipper);
@@ -870,19 +785,16 @@ namespace dxvk {
       // Retrieve a hWnd, if needed, during clipper attachment
       HWND hWnd = nullptr;
       hr = ddrawClipper->GetProxied()->GetHWnd(&hWnd);
-      if (unlikely(FAILED(hr))) {
-        Logger::debug("DDraw2Surface::SetClipper: Failed to retrieve hWnd");
-      } else {
-        m_commonIntf->SetHWND(hWnd);
-      }
+      if (unlikely(FAILED(hr)))
+        return DD_OK;
+
+      m_commonIntf->SetHWND(hWnd);
     }
 
     return DD_OK;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::SetColorKey(DWORD dwFlags, LPDDCOLORKEY lpDDColorKey) {
-    Logger::debug("<<< DDraw2Surface::SetColorKey: Proxy");
-
     // The Combat Mission series of games set a color key which is
     // outside the color range of the surface they are setting it on...
     // clamp it to the surface color depth in that case. This doesn't
@@ -918,13 +830,10 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::SetOverlayPosition(LONG lX, LONG lY) {
-    Logger::debug("<<< DDraw2Surface::SetOverlayPosition: Proxy");
     return m_proxy->SetOverlayPosition(lX, lY);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::SetPalette(LPDIRECTDRAWPALETTE lpDDPalette) {
-    Logger::debug("<<< DDraw2Surface::SetPalette: Proxy");
-
     // A nullptr lpDDPalette gets the current palette detached
     if (lpDDPalette == nullptr) {
       HRESULT hr = GetShadowOrProxied()->SetPalette(lpDDPalette);
@@ -946,8 +855,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::Unlock(LPVOID lpSurfaceData) {
-    Logger::debug("<<< DDraw2Surface::Unlock: Proxy");
-
     HRESULT hr = GetShadowOrProxied()->Unlock(lpSurfaceData);
     if (unlikely(FAILED(hr)))
       return hr;
@@ -970,8 +877,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::UpdateOverlay(LPRECT lpSrcRect, LPDIRECTDRAWSURFACE2 lpDDDestSurface, LPRECT lpDestRect, DWORD dwFlags, LPDDOVERLAYFX lpDDOverlayFx) {
-    Logger::debug("<<< DDraw2Surface::UpdateOverlay: Proxy");
-
     if (unlikely(lpDDDestSurface == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -986,17 +891,12 @@ namespace dxvk {
 
   // Docs: "This method is for software emulation only; it does nothing if the hardware supports overlays."
   HRESULT STDMETHODCALLTYPE DDraw2Surface::UpdateOverlayDisplay(DWORD dwFlags) {
-    Logger::debug(">>> DDraw2Surface::UpdateOverlayDisplay");
     return DDERR_UNSUPPORTED;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::UpdateOverlayZOrder(DWORD dwFlags, LPDIRECTDRAWSURFACE2 lpDDSReference) {
-    Logger::debug("<<< DDraw2Surface::UpdateOverlayZOrder: Proxy");
-
-    const bool referenceIsWrappedSurface = lpDDSReference == nullptr ||
-                                           DDrawCommonInterface::IsWrappedSurface(lpDDSReference);
-
-    if (unlikely(!referenceIsWrappedSurface)) {
+    if (unlikely(lpDDSReference != nullptr
+              && !DDrawCommonInterface::IsWrappedSurface(lpDDSReference))) {
       Logger::err("DDraw2Surface::UpdateOverlayZOrder: Received an unwrapped surface");
       return DDERR_UNSUPPORTED;
     }
@@ -1010,29 +910,26 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::GetDDInterface(LPVOID *lplpDD) {
-    if (unlikely(m_commonIntf->GetDDInterface() == nullptr)) {
-      Logger::warn("<<< DDraw2Surface::GetDDInterface: Proxy");
-      return m_proxy->GetDDInterface(lplpDD);
-    }
-
-    Logger::debug(">>> DDraw2Surface::GetDDInterface");
-
     if (unlikely(lplpDD == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    // Was an easy footgun to return a proxied interface
+    InitReturnPtr(lplpDD);
+
+    if (unlikely(m_commonIntf->GetDDInterface() == nullptr)) {
+      Logger::err("DDraw2Surface::GetDDInterface: Found no valid parent interface");
+      return DDERR_NOTFOUND;
+    }
+
     *lplpDD = ref(m_commonIntf->GetDDInterface());
 
     return DD_OK;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::PageLock(DWORD dwFlags) {
-    Logger::debug("<<< DDraw2Surface::PageLock: Proxy");
     return m_proxy->PageLock(dwFlags);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::PageUnlock(DWORD dwFlags) {
-    Logger::debug("<<< DDraw2Surface::PageUnlock: Proxy");
     return m_proxy->PageUnlock(dwFlags);
   }
 
@@ -1049,10 +946,8 @@ namespace dxvk {
     d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
 
     // Fast skip
-    if (unlikely(d3d9Device == nullptr)) {
-      Logger::debug("DDraw2Surface::InitializeOrUploadD3D9: Null device, can't initialize right now");
+    if (unlikely(d3d9Device == nullptr))
       return DD_OK;
-    }
 
     if (unlikely(!m_commonSurf->IsInitialized())) {
       if (m_commonSurf->IsTexture())
@@ -1083,19 +978,15 @@ namespace dxvk {
       m_commonSurf->RefreshD3D9Device();
 
     if (unlikely(m_commonSurf->IsD3D9BackBuffer())) {
-      Logger::debug("DDraw2Surface::DownloadSurfaceData: Surface is a bound swapchain surface");
-
       if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
-        Logger::debug(str::format("DDraw2Surface::DownloadSurfaceData: Downloading nr. [[2-", m_surfCount, "]]"));
+        //Logger::debug(str::format("DDraw2Surface::DownloadSurfaceData: Downloading nr. [[2-", m_surfCount, "]]"));
         BlitToDDrawSurface<IDirectDrawSurface2, DDSURFACEDESC>(GetShadowOrProxied(), m_commonSurf->GetD3D9Surface(),
                                                                m_commonSurf->IsDXTFormat());
         m_commonSurf->UnDirtyD3D9Surface();
       }
     } else if (unlikely(m_commonSurf->IsD3D9DepthStencil())) {
-      Logger::debug("DDraw2Surface::DownloadSurfaceData: Surface is a bound depth stencil");
-
       if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
-        Logger::debug(str::format("DDraw2Surface::DownloadSurfaceData: Downloading nr. [[2-", m_surfCount, "]]"));
+        //Logger::debug(str::format("DDraw2Surface::DownloadSurfaceData: Downloading nr. [[2-", m_surfCount, "]]"));
         BlitToDDrawSurface<IDirectDrawSurface2, DDSURFACEDESC>(m_proxy.ptr(), m_commonSurf->GetD3D9Surface(),
                                                                m_commonSurf->IsDXTFormat());
         m_commonSurf->UnDirtyD3D9Surface();
@@ -1108,16 +999,13 @@ namespace dxvk {
     if (!m_commonSurf->IsDDrawSurfaceDirty())
       return DD_OK;
 
-    Logger::debug(str::format("DDraw2Surface::UploadSurfaceData: Uploading nr. [[2-", m_surfCount, "]]"));
+    //Logger::debug(str::format("DDraw2Surface::UploadSurfaceData: Uploading nr. [[2-", m_surfCount, "]]"));
 
     if (m_commonSurf->IsTexture()) {
       BlitToD3D9Texture<IDirectDrawSurface2, DDSURFACEDESC>(m_commonSurf->GetD3D9Texture(), m_proxy.ptr(),
                                                             m_commonSurf->GetMipCount(), m_commonSurf->IsDXTFormat());
     // Blit surfaces directly
     } else {
-      if (unlikely(m_commonSurf->IsDepthStencil()))
-        Logger::debug("DDraw2Surface::UploadSurfaceData: Uploading depth stencil");
-
       BlitToD3D9Surface<IDirectDrawSurface2, DDSURFACEDESC>(m_commonSurf->GetD3D9Surface(), GetShadowOrProxied(),
                                                             m_commonSurf->IsDXTFormat());
     }

--- a/src/ddraw/ddraw2/ddraw2_surface.h
+++ b/src/ddraw/ddraw2/ddraw2_surface.h
@@ -147,18 +147,17 @@ namespace dxvk {
       return m_depthStencil.ptr();
     }
 
-    void ClearAttachedDepthStencil() {
-      m_depthStencil = nullptr;
-    }
-
     void SetParentSurface(DDraw2Surface* surface) {
       m_parentSurf = surface;
-      m_commonSurf->SetIsAttached(true);
+
+      if (m_parentSurf != nullptr)
+        m_commonSurf->SetIsAttached(true);
+      else
+        m_commonSurf->SetIsAttached(false);
     }
 
-    void ClearParentSurface() {
-      m_parentSurf = nullptr;
-      m_commonSurf->SetIsAttached(false);
+    DDraw2Surface* GetParentSurface() const {
+      return m_parentSurf;
     }
 
   private:

--- a/src/ddraw/ddraw2/ddraw3_surface.cpp
+++ b/src/ddraw/ddraw2/ddraw3_surface.cpp
@@ -69,8 +69,6 @@ namespace dxvk {
     if (likely(m_shadowSurf == nullptr)) {
       IUnknown* shadowSurfaceProxiedOrigin = m_commonSurf->GetShadowSurfaceProxied();
       if (likely(shadowSurfaceProxiedOrigin != nullptr)) {
-        Logger::debug("DDraw3Surface: Retrieving shadow surface from origin");
-
         Com<IDirectDrawSurface3> shadowSurfProxy;
         HRESULT hr = shadowSurfaceProxiedOrigin->QueryInterface(__uuidof(IDirectDrawSurface3),
                                                                 reinterpret_cast<void**>(&shadowSurfProxy));
@@ -105,10 +103,22 @@ namespace dxvk {
     // Clear the cached depth stencil on the parent if matched
     if (unlikely(m_parentSurf != nullptr && m_commonSurf->IsDepthStencil()
       && m_parentSurf->GetAttachedDepthStencil() == this)) {
-      m_parentSurf->ClearAttachedDepthStencil();
+      m_parentSurf->SetAttachedDepthStencil(nullptr);
     }
 
     DDrawCommonInterface::RemoveWrappedSurface(this);
+
+    if (m_depthStencil != nullptr)
+      m_depthStencil->SetParentSurface(nullptr);
+
+    // Release all public references on all attached surfaces
+    for (auto & attachedSurface : m_attachedSurfaces) {
+      attachedSurface.second->SetParentSurface(nullptr);
+      uint32_t attachedRef;
+      do {
+        attachedRef = attachedSurface.second->Release();
+      } while (attachedRef > 0);
+    }
 
     m_commonSurf->SetDD3Surface(nullptr);
 
@@ -116,16 +126,12 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> DDraw3Surface::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
     InitReturnPtr(ppvObject);
 
     if (riid == __uuidof(IDirect3DTexture)) {
-      Logger::debug("DDraw3Surface::QueryInterface: Query for IDirect3DTexture");
-
       IDirect3DTexture* texture3 = m_parent->GetD3D3Texture();
 
       if (unlikely(texture3 == nullptr))
@@ -136,8 +142,6 @@ namespace dxvk {
       return S_OK;
     }
     if (riid == __uuidof(IDirect3DTexture2)) {
-      Logger::debug("DDraw3Surface::QueryInterface: Query for IDirect3DTexture2");
-
       IDirect3DTexture2* texture5 = m_parent->GetD3D5Texture();
 
       if (unlikely(texture5 == nullptr))
@@ -148,7 +152,6 @@ namespace dxvk {
       return S_OK;
     }
     if (riid == __uuidof(IDirectDrawGammaControl)) {
-      Logger::debug("DDraw3Surface::QueryInterface: Query for IDirectDrawGammaControl");
       void* gammaControlProxiedVoid = nullptr;
       // This can never reasonably fail
       m_proxy->QueryInterface(__uuidof(IDirectDrawGammaControl), &gammaControlProxiedVoid);
@@ -157,17 +160,12 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirectDrawColorControl))) {
-      Logger::debug("DDraw3Surface::QueryInterface: Query for IDirectDrawColorControl");
       return E_NOINTERFACE;
     }
     if (unlikely(riid == __uuidof(IUnknown)
               || riid == __uuidof(IDirectDrawSurface))) {
-      if (m_commonSurf->GetDDSurface() != nullptr) {
-        Logger::debug("DDraw3Surface::QueryInterface: Query for existing IDirectDrawSurface");
+      if (m_commonSurf->GetDDSurface() != nullptr)
         return m_commonSurf->GetDDSurface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw3Surface::QueryInterface: Query for IDirectDrawSurface");
 
       Com<IDirectDrawSurface> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -185,12 +183,8 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface2))) {
-      if (m_commonSurf->GetDD2Surface() != nullptr) {
-        Logger::debug("DDraw3Surface::QueryInterface: Query for existing IDirectDrawSurface2");
+      if (m_commonSurf->GetDD2Surface() != nullptr)
         return m_commonSurf->GetDD2Surface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw3Surface::QueryInterface: Query for IDirectDrawSurface3");
 
       Com<IDirectDrawSurface2> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -208,12 +202,8 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface4))) {
-      if (m_commonSurf->GetDD4Surface() != nullptr) {
-        Logger::debug("DDraw3Surface::QueryInterface: Query for existing IDirectDrawSurface4");
+      if (m_commonSurf->GetDD4Surface() != nullptr)
         return m_commonSurf->GetDD4Surface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw3Surface::QueryInterface: Query for IDirectDrawSurface4");
 
       Com<IDirectDrawSurface4> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -231,12 +221,8 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface7))) {
-      if (m_commonSurf->GetDD7Surface() != nullptr) {
-        Logger::debug("DDraw3Surface::QueryInterface: Query for existing IDirectDrawSurface7");
+      if (m_commonSurf->GetDD7Surface() != nullptr)
         return m_commonSurf->GetDD7Surface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw3Surface::QueryInterface: Query for IDirectDrawSurface7");
 
       Com<IDirectDrawSurface7> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -265,17 +251,13 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::AddAttachedSurface(LPDIRECTDRAWSURFACE3 lpDDSAttachedSurface) {
-    Logger::debug("<<< DDraw3Surface::AddAttachedSurface: Proxy");
-
     if (unlikely(lpDDSAttachedSurface == nullptr))
       return DDERR_INVALIDPARAMS;
 
     if (unlikely(!DDrawCommonInterface::IsWrappedSurface(lpDDSAttachedSurface))) {
       // Some games, like Nightmare Creatures, try to attach an IDirectDrawSurface depth stencil directly...
-      if (likely(DDrawCommonInterface::IsWrappedSurface(reinterpret_cast<IDirectDrawSurface*>(lpDDSAttachedSurface)))) {
-        Logger::debug("DDraw3Surface::AddAttachedSurface: Attaching IDirectDrawSurface surface");
+      if (likely(DDrawCommonInterface::IsWrappedSurface(reinterpret_cast<IDirectDrawSurface*>(lpDDSAttachedSurface))))
         return m_parent->AddAttachedSurface(reinterpret_cast<IDirectDrawSurface*>(lpDDSAttachedSurface));
-      }
 
       Logger::warn("DDraw3Surface::AddAttachedSurface: Received an unwrapped surface");
       return DDERR_CANNOTATTACHSURFACE;
@@ -283,20 +265,19 @@ namespace dxvk {
 
     DDraw3Surface* attachedSurf = static_cast<DDraw3Surface*>(lpDDSAttachedSurface);
 
-    // Unsupported by Wine's DDraw implementation, so we'll do our own handling
-    if (unlikely(attachedSurf->GetCommonSurface()->IsBackBufferOrFlippable())) {
-      Logger::debug("DDraw3Surface::AddAttachedSurface: Caching surface as DDraw RT");
-      m_commonIntf->SetDDrawRenderTarget(attachedSurf->GetCommonSurface());
-      return DD_OK;
-    }
-
     HRESULT hr = m_proxy->AddAttachedSurface(attachedSurf->GetProxied());
     if (unlikely(FAILED(hr)))
       return hr;
 
     attachedSurf->SetParentSurface(this);
-    if (likely(attachedSurf->GetCommonSurface()->IsDepthStencil()))
+
+    if (likely(attachedSurf->GetCommonSurface()->IsDepthStencil())) {
       m_depthStencil = attachedSurf;
+    // If a flippable surface is attached, mark it as the next flippable surface
+    } else if (unlikely(attachedSurf->GetCommonSurface()->IsBackBufferOrFlippable())) {
+      DDrawSurface* attachedSurfParent = attachedSurf->GetCommonSurface()->GetDDSurface();
+      m_parent->SetNextFlippable(attachedSurfParent);
+    }
 
     return DD_OK;
   }
@@ -304,22 +285,15 @@ namespace dxvk {
   // Docs: "This method is used for the software implementation.
   // It is not needed if the overlay support is provided by the hardware."
   HRESULT STDMETHODCALLTYPE DDraw3Surface::AddOverlayDirtyRect(LPRECT lpRect) {
-    Logger::debug(">>> DDraw3Surface::AddOverlayDirtyRect");
     return DDERR_UNSUPPORTED;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::Blt(LPRECT lpDestRect, LPDIRECTDRAWSURFACE3 lpDDSrcSurface, LPRECT lpSrcRect, DWORD dwFlags, LPDDBLTFX lpDDBltFx) {
-    Logger::debug("<<< DDraw3Surface::Blt: Proxy");
-
-    const bool sourceIsWrappedSurface = lpDDSrcSurface == nullptr ||
-                                        DDrawCommonInterface::IsWrappedSurface(lpDDSrcSurface);
-
-    if (unlikely(!sourceIsWrappedSurface)) {
+    if (unlikely(lpDDSrcSurface != nullptr
+             && !DDrawCommonInterface::IsWrappedSurface(lpDDSrcSurface))) {
       // Powerslide tries to blit here from a IDirectDrawSurface source
-      if (likely(DDrawCommonInterface::IsWrappedSurface(reinterpret_cast<IDirectDrawSurface*>(lpDDSrcSurface)))) {
-        Logger::debug("DDraw3Surface::Blt: Blitting IDirectDrawSurface surface");
+      if (likely(DDrawCommonInterface::IsWrappedSurface(reinterpret_cast<IDirectDrawSurface*>(lpDDSrcSurface))))
         return m_parent->Blt(lpDestRect, reinterpret_cast<IDirectDrawSurface*>(lpDDSrcSurface), lpSrcRect, dwFlags, lpDDBltFx);
-      }
 
       Logger::err("DDraw3Surface::Blt: Received an unwrapped source surface");
       return DDERR_UNSUPPORTED;
@@ -386,22 +360,15 @@ namespace dxvk {
 
   // Docs: "The IDirectDrawSurface3::BltBatch method is not currently implemented."
   HRESULT STDMETHODCALLTYPE DDraw3Surface::BltBatch(LPDDBLTBATCH lpDDBltBatch, DWORD dwCount, DWORD dwFlags) {
-    Logger::debug(">>> DDraw3Surface::BltBatch");
     return DDERR_UNSUPPORTED;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::BltFast(DWORD dwX, DWORD dwY, LPDIRECTDRAWSURFACE3 lpDDSrcSurface, LPRECT lpSrcRect, DWORD dwTrans) {
-    Logger::debug("<<< DDraw3Surface::BltFast: Proxy");
-
-    const bool sourceIsWrappedSurface = lpDDSrcSurface == nullptr ||
-                                        DDrawCommonInterface::IsWrappedSurface(lpDDSrcSurface);
-
-    if (unlikely(!sourceIsWrappedSurface)) {
+    if (unlikely(lpDDSrcSurface != nullptr
+             && !DDrawCommonInterface::IsWrappedSurface(lpDDSrcSurface))) {
       // Powerslide tries to blit here from a IDirectDrawSurface source
-      if (likely(DDrawCommonInterface::IsWrappedSurface(reinterpret_cast<IDirectDrawSurface*>(lpDDSrcSurface)))) {
-        Logger::debug("DDraw3Surface::BltFast: Blitting IDirectDrawSurface surface");
+      if (likely(DDrawCommonInterface::IsWrappedSurface(reinterpret_cast<IDirectDrawSurface*>(lpDDSrcSurface))))
         return m_parent->BltFast(dwX, dwY, reinterpret_cast<IDirectDrawSurface*>(lpDDSrcSurface), lpSrcRect, dwTrans);
-      }
 
       Logger::err("DDraw3Surface::BltFast: Received an unwrapped source surface");
       return DDERR_UNSUPPORTED;
@@ -469,17 +436,11 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::DeleteAttachedSurface(DWORD dwFlags, LPDIRECTDRAWSURFACE3 lpDDSAttachedSurface) {
-    Logger::debug("<<< DDraw3Surface::DeleteAttachedSurface: Proxy");
-
-    const bool attachedSurfaceIsWrappedSurface = lpDDSAttachedSurface == nullptr ||
-                                                 DDrawCommonInterface::IsWrappedSurface(lpDDSAttachedSurface);
-
-    if (unlikely(!attachedSurfaceIsWrappedSurface)) {
+    if (unlikely(lpDDSAttachedSurface != nullptr
+             && !DDrawCommonInterface::IsWrappedSurface(lpDDSAttachedSurface))) {
       // Some games, like Nightmare Creatures, try to attach an IDirectDrawSurface depth stencil directly...
-      if (likely(DDrawCommonInterface::IsWrappedSurface(reinterpret_cast<IDirectDrawSurface*>(lpDDSAttachedSurface)))) {
-        Logger::debug("DDraw3Surface::DeleteAttachedSurface: Detaching IDirectDrawSurface surface");
+      if (likely(DDrawCommonInterface::IsWrappedSurface(reinterpret_cast<IDirectDrawSurface*>(lpDDSAttachedSurface))))
         return m_parent->DeleteAttachedSurface(dwFlags, reinterpret_cast<IDirectDrawSurface*>(lpDDSAttachedSurface));
-      }
 
       Logger::err("DDraw3Surface::DeleteAttachedSurface: Received an unwrapped surface");
       return DDERR_UNSUPPORTED;
@@ -498,40 +459,34 @@ namespace dxvk {
 
     DDraw3Surface* attachedSurf = static_cast<DDraw3Surface*>(lpDDSAttachedSurface);
 
-    if (unlikely(attachedSurf->GetCommonSurface()->IsBackBufferOrFlippable() &&
-                 attachedSurf->GetCommonSurface() == m_commonIntf->GetDDrawRenderTarget())) {
-      Logger::debug("DDraw3Surface::DeleteAttachedSurface: Removing cached DDraw RT surface");
-      m_commonIntf->SetDDrawRenderTarget(nullptr);
-      return DD_OK;
-    }
-
     HRESULT hr = m_proxy->DeleteAttachedSurface(dwFlags, attachedSurf->GetProxied());
     if (unlikely(FAILED(hr)))
       return hr;
 
+    attachedSurf->SetParentSurface(nullptr);
+
     if (likely(m_depthStencil == attachedSurf)) {
-      attachedSurf->ClearParentSurface();
       m_depthStencil = nullptr;
+    // Clear the next flippable surface or flippable surface detachment
+    } else if (unlikely(attachedSurf->GetCommonSurface()->IsBackBufferOrFlippable() &&
+                        attachedSurf->GetCommonSurface()->GetDDSurface() == m_parent->GetNextFlippable())) {
+      m_parent->SetNextFlippable(nullptr);
     }
 
     return DD_OK;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::EnumAttachedSurfaces(LPVOID lpContext, LPDDENUMSURFACESCALLBACK lpEnumSurfacesCallback) {
-    Logger::warn(">>> DDraw3Surface::EnumAttachedSurfaces");
     return m_parent->EnumAttachedSurfaces(lpContext, lpEnumSurfacesCallback);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::EnumOverlayZOrders(DWORD dwFlags, LPVOID lpContext, LPDDENUMSURFACESCALLBACK lpfnCallback) {
-    Logger::debug("<<< DDraw3Surface::EnumOverlayZOrders: Proxy");
     return m_proxy->EnumOverlayZOrders(dwFlags, lpContext, lpfnCallback);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::Flip(LPDIRECTDRAWSURFACE3 lpDDSurfaceTargetOverride, DWORD dwFlags) {
-    const bool overrideIsWrappedSurface = lpDDSurfaceTargetOverride == nullptr ||
-                                          DDrawCommonInterface::IsWrappedSurface(lpDDSurfaceTargetOverride);
-
-    if (unlikely(!overrideIsWrappedSurface)) {
+    if (unlikely(lpDDSurfaceTargetOverride != nullptr
+             && !DDrawCommonInterface::IsWrappedSurface(lpDDSurfaceTargetOverride))) {
       Logger::err("DDraw3Surface::Flip: Received an unwrapped override surface");
       return DDERR_UNSUPPORTED;
     }
@@ -539,62 +494,43 @@ namespace dxvk {
     Com<DDraw3Surface> overrideSurf = static_cast<DDraw3Surface*>(lpDDSurfaceTargetOverride);
 
     d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
-    if (likely(d3d9Device != nullptr)) {
-      Logger::debug("*** DDraw3Surface::Flip: Presenting");
-
+    // Overlays can have odd video formats which DXVK doesn't support for RT
+    // use, so let DDraw present in case the flipped surface is an overlay
+    if (likely(d3d9Device != nullptr && !m_commonSurf->IsOverlay())) {
       // Lost surfaces are not flippable
       HRESULT hr = m_proxy->IsLost();
-      if (unlikely(FAILED(hr))) {
-        Logger::debug("DDraw3Surface::Flip: Lost surface");
+      if (unlikely(FAILED(hr)))
         return hr;
-      }
 
-      if (unlikely(!(m_commonSurf->IsFrontBuffer() || m_commonSurf->IsBackBufferOrFlippable()))) {
-        Logger::debug("DDraw3Surface::Flip: Unflippable surface");
+      if (unlikely(!(m_commonSurf->IsFrontBuffer() || m_commonSurf->IsBackBufferOrFlippable())))
         return DDERR_NOTFLIPPABLE;
-      }
 
       const bool exclusiveMode = m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE;
 
       // Non-exclusive mode validations
-      if (unlikely(m_commonSurf->IsPrimarySurface() && !exclusiveMode)) {
-        Logger::debug("DDraw3Surface::Flip: Primary surface flip in non-exclusive mode");
+      if (unlikely(m_commonSurf->IsPrimarySurface() && !exclusiveMode))
         return DDERR_NOEXCLUSIVEMODE;
-      }
 
       // Exclusive mode validations
-      if (unlikely(m_commonSurf->IsBackBufferOrFlippable() && exclusiveMode)) {
-        Logger::debug("DDraw3Surface::Flip: Back buffer flip in exclusive mode");
+      if (unlikely(m_commonSurf->IsBackBufferOrFlippable() && exclusiveMode))
         return DDERR_NOTFLIPPABLE;
-      }
 
-      if (unlikely(overrideSurf != nullptr && !overrideSurf->GetParent()->GetCommonSurface()->IsBackBufferOrFlippable())) {
-        Logger::debug("DDraw3Surface::Flip: Unflippable override surface");
+      if (unlikely(overrideSurf != nullptr && !overrideSurf->GetParent()->GetCommonSurface()->IsBackBufferOrFlippable()))
         return DDERR_NOTFLIPPABLE;
+
+      DDrawSurface* nextFlippable;
+      // Workaround for The Sims/other games flipping a different
+      // swapchain than the one set on the current D3D device
+      if (unlikely(m_commonIntf->GetOptions()->forceRTFlip && m_commonSurf->IsPrimarySurface())) {
+        nextFlippable = m_commonSurf->GetCommonD3DDevice()->GetCurrentRenderTarget();
+      } else {
+        nextFlippable = m_parent->GetNextFlippable();
       }
-
-      if (m_commonSurf->IsPrimarySurface()) {
-        DDraw3Surface* rt = m_commonIntf->GetDDrawRenderTarget() != nullptr ?
-                            m_commonIntf->GetDDrawRenderTarget()->GetDD3Surface() : nullptr;
-
-        if (unlikely(rt != nullptr)) {
-          Logger::debug("DDraw3Surface::Flip: Presenting from DDraw RT");
-          if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer)) {
-            InitializeOrUploadD3D9();
-            if (m_shadowSurf != nullptr && rt->GetCommonSurface()->IsDDrawSurfaceDirty())
-              GetShadowOrProxied()->BltFast(0, 0, rt->GetShadowOrProxied(), nullptr, DDBLTFAST_NOCOLORKEY);
-          }
-          rt->InitializeOrUploadD3D9();
-          d3d9Device->Present(NULL, NULL, NULL, NULL);
-          return DD_OK;
-        }
-      }
-
-      DDrawSurface* nextFlippable = m_parent->GetNextFlippable();
 
       if (likely(nextFlippable != nullptr)) {
-        if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer)) {
+        if (m_commonIntf->GetOptions()->emulateFrontBuffer) {
           InitializeOrUploadD3D9();
+          // Workaround for front buffer image retention issues
           if (m_shadowSurf != nullptr && nextFlippable->GetCommonSurface()->IsDDrawSurfaceDirty())
             m_parent->GetShadowOrProxied()->BltFast(0, 0, nextFlippable->GetShadowOrProxied(), nullptr, DDBLTFAST_NOCOLORKEY);
         }
@@ -606,19 +542,6 @@ namespace dxvk {
       d3d9Device->Present(NULL, NULL, NULL, NULL);
 
     } else {
-      Logger::debug("<<< DDraw3Surface::Flip: Proxy");
-
-      if (m_commonSurf->IsPrimarySurface()) {
-        DDraw3Surface* rt = m_commonIntf->GetDDrawRenderTarget() != nullptr ?
-                            m_commonIntf->GetDDrawRenderTarget()->GetDD3Surface() : nullptr;
-
-        if (unlikely(rt != nullptr)) {
-          Logger::debug("DDraw3Surface::Flip: Blitting DDraw RT");
-          m_proxy->Blt(nullptr, rt->GetShadowOrProxied(), nullptr, DDBLT_WAIT, nullptr);
-          return DD_OK;
-        }
-      }
-
       if (overrideSurf == nullptr) {
         return m_proxy->Flip(lpDDSurfaceTargetOverride, dwFlags);
       } else {
@@ -630,8 +553,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::GetAttachedSurface(LPDDSCAPS lpDDSCaps, LPDIRECTDRAWSURFACE3 *lplpDDAttachedSurface) {
-    Logger::debug("<<< DDraw3Surface::GetAttachedSurface: Proxy");
-
     if (unlikely(lpDDSCaps == nullptr || lplpDDAttachedSurface == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -659,7 +580,6 @@ namespace dxvk {
     // These are rather common, as some games query expecting to get nothing in return, for
     // example it's a common use case to query the mip attach chain until nothing is returned
     if (FAILED(hr)) {
-      Logger::debug("DDraw3Surface::GetAttachedSurface: Failed to find the requested surface");
       *lplpDDAttachedSurface = surface.ptr();
       return hr;
     }
@@ -691,8 +611,6 @@ namespace dxvk {
 
   // Blitting can be done at any time and completes within its call frame
   HRESULT STDMETHODCALLTYPE DDraw3Surface::GetBltStatus(DWORD dwFlags) {
-    Logger::debug(">>> DDraw3Surface::GetBltStatus");
-
     if (likely(dwFlags == DDGBS_CANBLT || dwFlags == DDGBS_ISBLTDONE))
       return DD_OK;
 
@@ -700,8 +618,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::GetCaps(LPDDSCAPS lpDDSCaps) {
-    Logger::debug(">>> DDraw3Surface::GetCaps");
-
     if (unlikely(lpDDSCaps == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -711,8 +627,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::GetClipper(LPDIRECTDRAWCLIPPER *lplpDDClipper) {
-    Logger::debug(">>> DDraw3Surface::GetClipper");
-
     if (unlikely(lplpDDClipper == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -729,12 +643,20 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::GetColorKey(DWORD dwFlags, LPDDCOLORKEY lpDDColorKey) {
-    Logger::debug("<<< DDraw3Surface::GetColorKey: Proxy");
     return m_proxy->GetColorKey(dwFlags, lpDDColorKey);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::GetDC(HDC *lphDC) {
-    Logger::debug("<<< DDraw3Surface::GetDC: Proxy");
+    // Direct D3D9 path which can sometimes be faster (and other times slower)
+    if (unlikely(m_commonIntf->GetOptions()->forceDCForwarding && m_commonSurf->IsInitialized())) {
+      InitializeOrUploadD3D9();
+
+      HRESULT hr = m_commonSurf->GetD3D9Surface()->GetDC(lphDC);
+      if (unlikely(FAILED(hr)))
+        return DDERR_INVALIDPARAMS;
+
+      return DD_OK;
+    }
 
     // Write back any dirty surface data from bound D3D9 back buffers or depth stencils
     DownloadSurfaceData();
@@ -744,8 +666,6 @@ namespace dxvk {
 
   // Flipping can be done at any time and completes within its call frame
   HRESULT STDMETHODCALLTYPE DDraw3Surface::GetFlipStatus(DWORD dwFlags) {
-    Logger::debug(">>> DDraw3Surface::GetFlipStatus");
-
     if (likely(dwFlags == DDGFS_CANFLIP || dwFlags == DDGFS_ISFLIPDONE))
       return DD_OK;
 
@@ -753,13 +673,10 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::GetOverlayPosition(LPLONG lplX, LPLONG lplY) {
-    Logger::debug("<<< DDraw3Surface::GetOverlayPosition: Proxy");
     return m_proxy->GetOverlayPosition(lplX, lplY);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::GetPalette(LPDIRECTDRAWPALETTE *lplpDDPalette) {
-    Logger::debug(">>> DDraw3Surface::GetPalette");
-
     if (unlikely(lplpDDPalette == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -776,8 +693,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::GetPixelFormat(LPDDPIXELFORMAT lpDDPixelFormat) {
-    Logger::debug(">>> DDraw3Surface::GetPixelFormat");
-
     if (unlikely(lpDDPixelFormat == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -787,8 +702,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::GetSurfaceDesc(LPDDSURFACEDESC lpDDSurfaceDesc) {
-    Logger::debug(">>> DDraw3Surface::GetSurfaceDesc");
-
     if (unlikely(lpDDSurfaceDesc == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -803,18 +716,14 @@ namespace dxvk {
   // According to the docs: "Because the DirectDrawSurface object is initialized
   // when it's created, this method always returns DDERR_ALREADYINITIALIZED."
   HRESULT STDMETHODCALLTYPE DDraw3Surface::Initialize(LPDIRECTDRAW lpDD, LPDDSURFACEDESC lpDDSurfaceDesc) {
-    Logger::debug(">>> DDraw3Surface::Initialize");
     return DDERR_ALREADYINITIALIZED;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::IsLost() {
-    Logger::debug("<<< DDraw3Surface::IsLost: Proxy");
     return m_proxy->IsLost();
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::Lock(LPRECT lpDestRect, LPDDSURFACEDESC lpDDSurfaceDesc, DWORD dwFlags, HANDLE hEvent) {
-    Logger::debug("<<< DDraw3Surface::Lock: Proxy");
-
     // Write back any dirty surface data from bound D3D9 back buffers or depth stencils
     DownloadSurfaceData();
 
@@ -822,7 +731,16 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::ReleaseDC(HDC hDC) {
-    Logger::debug("<<< DDraw3Surface::ReleaseDC: Proxy");
+    // Direct D3D9 path which can sometimes be faster (and other times slower)
+    if (unlikely(m_commonIntf->GetOptions()->forceDCForwarding && m_commonSurf->IsInitialized())) {
+      HRESULT hr = m_commonSurf->GetD3D9Surface()->ReleaseDC(hDC);
+      if (unlikely(FAILED(hr)))
+        return DDERR_INVALIDPARAMS;
+
+      m_commonSurf->DirtyD3D9Surface();
+
+      return DD_OK;
+    }
 
     HRESULT hr = GetShadowOrProxied()->ReleaseDC(hDC);
     if (unlikely(FAILED(hr)))
@@ -846,13 +764,10 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::Restore() {
-    Logger::debug("<<< DDraw3Surface::Restore: Proxy");
     return m_proxy->Restore();
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::SetClipper(LPDIRECTDRAWCLIPPER lpDDClipper) {
-    Logger::debug("<<< DDraw3Surface::SetClipper: Proxy");
-
     // A nullptr lpDDClipper gets the current clipper detached
     if (lpDDClipper == nullptr) {
       HRESULT hr = m_proxy->SetClipper(lpDDClipper);
@@ -872,19 +787,16 @@ namespace dxvk {
       // Retrieve a hWnd, if needed, during clipper attachment
       HWND hWnd = nullptr;
       hr = ddrawClipper->GetProxied()->GetHWnd(&hWnd);
-      if (unlikely(FAILED(hr))) {
-        Logger::debug("DDraw3Surface::SetClipper: Failed to retrieve hWnd");
-      } else {
-        m_commonIntf->SetHWND(hWnd);
-      }
+      if (unlikely(FAILED(hr)))
+        return DD_OK;
+
+      m_commonIntf->SetHWND(hWnd);
     }
 
     return DD_OK;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::SetColorKey(DWORD dwFlags, LPDDCOLORKEY lpDDColorKey) {
-    Logger::debug("<<< DDraw3Surface::SetColorKey: Proxy");
-
     // The Combat Mission series of games set a color key which is
     // outside the color range of the surface they are setting it on...
     // clamp it to the surface color depth in that case. This doesn't
@@ -920,13 +832,10 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::SetOverlayPosition(LONG lX, LONG lY) {
-    Logger::debug("<<< DDraw3Surface::SetOverlayPosition: Proxy");
     return m_proxy->SetOverlayPosition(lX, lY);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::SetPalette(LPDIRECTDRAWPALETTE lpDDPalette) {
-    Logger::debug("<<< DDraw3Surface::SetPalette: Proxy");
-
     // A nullptr lpDDPalette gets the current palette detached
     if (lpDDPalette == nullptr) {
       HRESULT hr = GetShadowOrProxied()->SetPalette(lpDDPalette);
@@ -948,8 +857,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::Unlock(LPVOID lpSurfaceData) {
-    Logger::debug("<<< DDraw3Surface::Unlock: Proxy");
-
     HRESULT hr = GetShadowOrProxied()->Unlock(lpSurfaceData);
     if (unlikely(FAILED(hr)))
       return hr;
@@ -972,8 +879,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::UpdateOverlay(LPRECT lpSrcRect, LPDIRECTDRAWSURFACE3 lpDDDestSurface, LPRECT lpDestRect, DWORD dwFlags, LPDDOVERLAYFX lpDDOverlayFx) {
-    Logger::debug("<<< DDraw3Surface::UpdateOverlay: Proxy");
-
     if (unlikely(lpDDDestSurface == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -988,17 +893,12 @@ namespace dxvk {
 
   // Docs: "This method is for software emulation only; it does nothing if the hardware supports overlays."
   HRESULT STDMETHODCALLTYPE DDraw3Surface::UpdateOverlayDisplay(DWORD dwFlags) {
-    Logger::debug(">>> DDraw3Surface::UpdateOverlayDisplay");
     return DDERR_UNSUPPORTED;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::UpdateOverlayZOrder(DWORD dwFlags, LPDIRECTDRAWSURFACE3 lpDDSReference) {
-    Logger::debug("<<< DDraw3Surface::UpdateOverlayZOrder: Proxy");
-
-    const bool referenceIsWrappedSurface = lpDDSReference == nullptr ||
-                                           DDrawCommonInterface::IsWrappedSurface(lpDDSReference);
-
-    if (unlikely(!referenceIsWrappedSurface)) {
+    if (unlikely(lpDDSReference != nullptr
+              && !DDrawCommonInterface::IsWrappedSurface(lpDDSReference))) {
       Logger::err("DDraw3Surface::UpdateOverlayZOrder: Received an unwrapped surface");
       return DDERR_UNSUPPORTED;
     }
@@ -1012,35 +912,30 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::GetDDInterface(LPVOID *lplpDD) {
-    if (unlikely(m_commonIntf->GetDDInterface() == nullptr)) {
-      Logger::warn("<<< DDraw2Surface::GetDDInterface: Proxy");
-      return m_proxy->GetDDInterface(lplpDD);
-    }
-
-    Logger::debug(">>> DDraw3Surface::GetDDInterface");
-
     if (unlikely(lplpDD == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    // Was an easy footgun to return a proxied interface
+    InitReturnPtr(lplpDD);
+
+    if (unlikely(m_commonIntf->GetDDInterface() == nullptr)) {
+      Logger::err("DDraw3Surface::GetDDInterface: Found no valid parent interface");
+      return DDERR_NOTFOUND;
+    }
+
     *lplpDD = ref(m_commonIntf->GetDDInterface());
 
     return DD_OK;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::PageLock(DWORD dwFlags) {
-    Logger::debug("<<< DDraw3Surface::PageLock: Proxy");
     return m_proxy->PageLock(dwFlags);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::PageUnlock(DWORD dwFlags) {
-    Logger::debug("<<< DDraw3Surface::PageUnlock: Proxy");
     return m_proxy->PageUnlock(dwFlags);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::SetSurfaceDesc(LPDDSURFACEDESC lpDDSD, DWORD dwFlags) {
-    Logger::debug("<<< DDraw3Surface::SetSurfaceDesc: Proxy");
-
     // Can be used only to set the surface data and pixel format
     // used by an explicit system-memory surface (will be validated)
     HRESULT hr = m_proxy->SetSurfaceDesc(lpDDSD, dwFlags);
@@ -1072,10 +967,8 @@ namespace dxvk {
     d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
 
     // Fast skip
-    if (unlikely(d3d9Device == nullptr)) {
-      Logger::debug("DDraw3Surface::InitializeOrUploadD3D9: Null device, can't initialize right now");
+    if (unlikely(d3d9Device == nullptr))
       return DD_OK;
-    }
 
     if (unlikely(!m_commonSurf->IsInitialized())) {
       if (m_commonSurf->IsTexture())
@@ -1106,19 +999,15 @@ namespace dxvk {
       m_commonSurf->RefreshD3D9Device();
 
     if (unlikely(m_commonSurf->IsD3D9BackBuffer())) {
-      Logger::debug("DDraw3Surface::DownloadSurfaceData: Surface is a bound swapchain surface");
-
       if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
-        Logger::debug(str::format("DDraw3Surface::DownloadSurfaceData: Downloading nr. [[3-", m_surfCount, "]]"));
+        //Logger::debug(str::format("DDraw3Surface::DownloadSurfaceData: Downloading nr. [[3-", m_surfCount, "]]"));
         BlitToDDrawSurface<IDirectDrawSurface3, DDSURFACEDESC>(GetShadowOrProxied(), m_commonSurf->GetD3D9Surface(),
                                                                m_commonSurf->IsDXTFormat());
         m_commonSurf->UnDirtyD3D9Surface();
       }
     } else if (unlikely(m_commonSurf->IsD3D9DepthStencil())) {
-      Logger::debug("DDraw3Surface::DownloadSurfaceData: Surface is a bound depth stencil");
-
       if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
-        Logger::debug(str::format("DDraw3Surface::DownloadSurfaceData: Downloading nr. [[3-", m_surfCount, "]]"));
+        //Logger::debug(str::format("DDraw3Surface::DownloadSurfaceData: Downloading nr. [[3-", m_surfCount, "]]"));
         BlitToDDrawSurface<IDirectDrawSurface3, DDSURFACEDESC>(m_proxy.ptr(), m_commonSurf->GetD3D9Surface(),
                                                                m_commonSurf->IsDXTFormat());
         m_commonSurf->UnDirtyD3D9Surface();
@@ -1131,16 +1020,13 @@ namespace dxvk {
     if (!m_commonSurf->IsDDrawSurfaceDirty())
       return DD_OK;
 
-    Logger::debug(str::format("DDraw3Surface::UploadSurfaceData: Uploading nr. [[3-", m_surfCount, "]]"));
+    //Logger::debug(str::format("DDraw3Surface::UploadSurfaceData: Uploading nr. [[3-", m_surfCount, "]]"));
 
     if (m_commonSurf->IsTexture()) {
       BlitToD3D9Texture<IDirectDrawSurface3, DDSURFACEDESC>(m_commonSurf->GetD3D9Texture(), m_proxy.ptr(),
                                                             m_commonSurf->GetMipCount(), m_commonSurf->IsDXTFormat());
     // Blit surfaces directly
     } else {
-      if (unlikely(m_commonSurf->IsDepthStencil()))
-        Logger::debug("DDraw3Surface::UploadSurfaceData: Uploading depth stencil");
-
       BlitToD3D9Surface<IDirectDrawSurface3, DDSURFACEDESC>(m_commonSurf->GetD3D9Surface(), GetShadowOrProxied(),
                                                             m_commonSurf->IsDXTFormat());
     }

--- a/src/ddraw/ddraw2/ddraw3_surface.h
+++ b/src/ddraw/ddraw2/ddraw3_surface.h
@@ -149,18 +149,17 @@ namespace dxvk {
       return m_depthStencil.ptr();
     }
 
-    void ClearAttachedDepthStencil() {
-      m_depthStencil = nullptr;
-    }
-
     void SetParentSurface(DDraw3Surface* surface) {
       m_parentSurf = surface;
-      m_commonSurf->SetIsAttached(true);
+
+      if (m_parentSurf != nullptr)
+        m_commonSurf->SetIsAttached(true);
+      else
+        m_commonSurf->SetIsAttached(false);
     }
 
-    void ClearParentSurface() {
-      m_parentSurf = nullptr;
-      m_commonSurf->SetIsAttached(false);
+    DDraw3Surface* GetParentSurface() const {
+      return m_parentSurf;
     }
 
   private:

--- a/src/ddraw/ddraw4/ddraw4_interface.cpp
+++ b/src/ddraw/ddraw4/ddraw4_interface.cpp
@@ -51,8 +51,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> DDraw4Interface::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
@@ -60,8 +58,6 @@ namespace dxvk {
 
     // Standard way of retrieving a D3D6 interface
     if (riid == __uuidof(IDirect3D3)) {
-      Logger::debug("DDraw4Interface::QueryInterface: Query for IDirect3D3");
-
       // Initialize the IDirect3D3 interlocked object
       if (unlikely(m_d3d6Intf == nullptr)) {
         Com<IDirect3D3> ppvProxyObject;
@@ -78,12 +74,8 @@ namespace dxvk {
     }
     // Some games query for legacy ddraw interfaces
     if (unlikely(riid == __uuidof(IDirectDraw))) {
-      if (m_commonIntf->GetDDInterface() != nullptr) {
-        Logger::debug("DDraw4Interface::QueryInterface: Query for existing IDirectDraw");
+      if (m_commonIntf->GetDDInterface() != nullptr)
         return m_commonIntf->GetDDInterface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw4Interface::QueryInterface: Query for IDirectDraw");
 
       Com<IDirectDraw> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -96,12 +88,8 @@ namespace dxvk {
     }
     // Some games query for legacy ddraw interfaces
     if (unlikely(riid == __uuidof(IDirectDraw2))) {
-      if (m_commonIntf->GetDD2Interface() != nullptr) {
-        Logger::debug("DDraw4Interface::QueryInterface: Query for existing IDirectDraw2");
+      if (m_commonIntf->GetDD2Interface() != nullptr)
         return m_commonIntf->GetDD2Interface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw4Interface::QueryInterface: Query for IDirectDraw2");
 
       Com<IDirectDraw2> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -114,12 +102,8 @@ namespace dxvk {
     }
     // Legacy way of getting a DDraw7 interface
     if (unlikely(riid == __uuidof(IDirectDraw7))) {
-      if (m_commonIntf->GetDD7Interface() != nullptr) {
-        Logger::debug("DDraw4Interface::QueryInterface: Query for existing IDirectDraw7");
+      if (m_commonIntf->GetDD7Interface() != nullptr)
         return m_commonIntf->GetDD7Interface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw4Interface::QueryInterface: Query for IDirectDraw7");
 
       Com<IDirectDraw7> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -132,12 +116,8 @@ namespace dxvk {
     }
     // Standard way of retrieving a D3D3 interface
     if (unlikely(riid == __uuidof(IDirect3D))) {
-      if (m_commonIntf->GetDDInterface() != nullptr) {
-        Logger::debug("DDraw4Interface::QueryInterface: Forwarded query for IDirect3D");
+      if (m_commonIntf->GetDDInterface() != nullptr)
         return m_commonIntf->GetDDInterface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw4Interface::QueryInterface: Query for IDirect3D");
 
       Com<D3D3Interface> d3d3Intf = new D3D3Interface(nullptr, m_commonIntf.ptr(), this);
       m_commonIntf->SetD3D3Interface(d3d3Intf.ptr());
@@ -147,12 +127,8 @@ namespace dxvk {
     }
     // Standard way of retrieving a D3D5 interface
     if (unlikely(riid == __uuidof(IDirect3D2))) {
-      if (m_commonIntf->GetDDInterface() != nullptr) {
-        Logger::debug("DDraw4Interface::QueryInterface: Forwarded query for IDirect3D2");
+      if (m_commonIntf->GetDDInterface() != nullptr)
         return m_commonIntf->GetDDInterface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw4Interface::QueryInterface: Query for IDirect3D2");
 
       Com<D3D5Interface> d3d5Intf = new D3D5Interface(nullptr, m_commonIntf.ptr(), this);
       *ppvObject = d3d5Intf.ref();
@@ -161,12 +137,10 @@ namespace dxvk {
     }
     // Quite a lot of games query for this IID during intro playback
     if (unlikely(riid == GUID_IAMMediaStream)) {
-      Logger::debug("DDraw4Interface::QueryInterface: Query for IAMMediaStream");
       return m_proxy->QueryInterface(riid, ppvObject);
     }
     // Also seen queried by some games, such as V-Rally 2: Expert Edition
     if (unlikely(riid == GUID_IMediaStream)) {
-      Logger::debug("DDraw4Interface::QueryInterface: Query for IMediaStream");
       return m_proxy->QueryInterface(riid, ppvObject);
     }
 
@@ -183,13 +157,10 @@ namespace dxvk {
 
   // The documentation states: "The IDirectDraw4::Compact method is not currently implemented."
   HRESULT STDMETHODCALLTYPE DDraw4Interface::Compact() {
-    Logger::debug(">>> DDraw4Interface::Compact");
-    return DD_OK;
+    return DDERR_UNSUPPORTED;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::CreateClipper(DWORD dwFlags, LPDIRECTDRAWCLIPPER *lplpDDClipper, IUnknown *pUnkOuter) {
-    Logger::debug(">>> DDraw4Interface::CreateClipper");
-
     if (unlikely(lplpDDClipper == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -197,10 +168,8 @@ namespace dxvk {
 
     Com<IDirectDrawClipper> lplpDDClipperProxy;
     HRESULT hr = m_proxy->CreateClipper(dwFlags, &lplpDDClipperProxy, pUnkOuter);
-    if (unlikely(FAILED(hr))) {
-      Logger::warn("DDraw4Interface::CreateClipper: Failed to create proxy clipper");
+    if (unlikely(FAILED(hr)))
       return hr;
-    }
 
     *lplpDDClipper = ref(new DDrawClipper(m_commonIntf.ptr(), std::move(lplpDDClipperProxy), this));
 
@@ -208,8 +177,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::CreatePalette(DWORD dwFlags, LPPALETTEENTRY lpColorTable, LPDIRECTDRAWPALETTE *lplpDDPalette, IUnknown *pUnkOuter) {
-    Logger::debug(">>> DDraw4Interface::CreatePalette");
-
     if (unlikely(lplpDDPalette == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -217,10 +184,8 @@ namespace dxvk {
 
     Com<IDirectDrawPalette> lplpDDPaletteProxy;
     HRESULT hr = m_proxy->CreatePalette(dwFlags, lpColorTable, &lplpDDPaletteProxy, pUnkOuter);
-    if (unlikely(FAILED(hr))) {
-      Logger::warn("DDraw4Interface::CreatePalette: Failed to create proxy palette");
+    if (unlikely(FAILED(hr)))
       return hr;
-    }
 
     *lplpDDPalette = ref(new DDrawPalette(std::move(lplpDDPaletteProxy), this));
 
@@ -228,8 +193,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::CreateSurface(LPDDSURFACEDESC2 lpDDSurfaceDesc, LPDIRECTDRAWSURFACE4 *lplpDDSurface, IUnknown *pUnkOuter) {
-    Logger::debug(">>> DDraw4Interface::CreateSurface");
-
     // The cooperative level is always checked first
     if (unlikely(!m_commonIntf->IsCooperativeLevelSet()))
       return DDERR_NOCOOPERATIVELEVELSET;
@@ -266,26 +229,35 @@ namespace dxvk {
       lpDDSurfaceDesc->ddsCaps.dwCaps |= DDSCAPS_SYSTEMMEMORY;
     }
 
-    if (unlikely((lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_ZBUFFER)
-              && (lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFFFF))) {
-      if (m_commonIntf->GetOptions()->useD24X8forD32) {
-        // In case of up-front unsupported and unadvertised D32 depth stencil use,
-        // replace it with D24X8, as some games, such as Sacrifice, rely on it
-        // to properly enable 32-bit display modes (and revert to 16-bit otherwise)
-        Logger::info("DDraw4Interface::CreateSurface: Using D24X8 instead of D32");
-        lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFFFF;
-      } else {
-        Logger::warn("DDraw4Interface::CreateSurface: Use of unsupported D32");
+    if (unlikely(lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_ZBUFFER)) {
+      if (unlikely(m_commonIntf->GetOptions()->useD16forD24X8
+                && lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFF
+                && lpDDSurfaceDesc->ddpfPixelFormat.dwStencilBitMask == 0x0)) {
+        // Games such as Need for Speed: Porsche are broken with 32-bit color
+        // on night tracks with "projected" lights, because they clearly were
+        // designed with 16-bit Z buffers in mind. Fix it up by silently swapping
+        // D16 for D24X8 on depth stencil creation.
+        Logger::info("DDraw4Interface::CreateSurface: Using D16 instead of D24X8");
+        lpDDSurfaceDesc->ddpfPixelFormat.dwZBufferBitDepth = 16;
+        lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFF;
+      } else if (unlikely(lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFFFF)) {
+        if (m_commonIntf->GetOptions()->useD24X8forD32) {
+          // In case of up-front unsupported and unadvertised D32 depth stencil use,
+          // replace it with D24X8, as some games, such as Sacrifice, rely on it
+          // to properly enable 32-bit display modes (and revert to 16-bit otherwise)
+          Logger::info("DDraw4Interface::CreateSurface: Using D24X8 instead of D32");
+          lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFFFF;
+        } else {
+          Logger::warn("DDraw4Interface::CreateSurface: Use of unsupported D32");
+        }
       }
     }
 
     Com<IDirectDrawSurface4> ddrawSurface4Proxied;
     hr = m_proxy->CreateSurface(lpDDSurfaceDesc, &ddrawSurface4Proxied, pUnkOuter);
     // Some games simply try creating surfaces with various formats until something works...
-    if (unlikely(FAILED(hr))) {
-      Logger::debug("DDraw4Interface::CreateSurface: Failed to create proxy surface");
+    if (unlikely(FAILED(hr)))
       return hr;
-    }
 
     try{
       Com<DDraw4Surface> surface4 = new DDraw4Surface(nullptr, std::move(ddrawSurface4Proxied), this, nullptr, true);
@@ -333,8 +305,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::DuplicateSurface(LPDIRECTDRAWSURFACE4 lpDDSurface, LPDIRECTDRAWSURFACE4 *lplpDupDDSurface) {
-    Logger::debug("<<< DDraw4Interface::DuplicateSurface: Proxy");
-
     if (unlikely(lpDDSurface == nullptr || lplpDupDDSurface == nullptr))
       return DDERR_CANTDUPLICATE;
 
@@ -363,13 +333,10 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::EnumDisplayModes(DWORD dwFlags, LPDDSURFACEDESC2 lpDDSurfaceDesc, LPVOID lpContext, LPDDENUMMODESCALLBACK2 lpEnumModesCallback) {
-    Logger::debug("<<< DDraw4Interface::EnumDisplayModes: Proxy");
     return m_proxy->EnumDisplayModes(dwFlags, lpDDSurfaceDesc, lpContext, lpEnumModesCallback);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::EnumSurfaces(DWORD dwFlags, LPDDSURFACEDESC2 lpDDSD, LPVOID lpContext, LPDDENUMSURFACESCALLBACK2 lpEnumSurfacesCallback) {
-    Logger::debug("<<< DDraw4Interface::EnumSurfaces: Proxy");
-
     if (unlikely(lpEnumSurfacesCallback == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -400,8 +367,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::FlipToGDISurface() {
-    Logger::debug("*** DDraw4Interface::FlipToGDISurface: Ignoring");
-
     DDrawCommonSurface* ps = m_commonIntf->GetPrimarySurface();
 
     // A primary surface must exist for a GDI flip to be possible
@@ -415,8 +380,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::GetCaps(LPDDCAPS lpDDDriverCaps, LPDDCAPS lpDDHELCaps) {
-    Logger::debug("<<< DDraw4Interface::GetCaps: Proxy");
-
     if (unlikely(lpDDDriverCaps == nullptr && lpDDHELCaps == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -443,8 +406,6 @@ namespace dxvk {
 
     D3DCommonDevice* commonDevice = m_commonIntf->GetCommonD3DDevice();
     if (likely(commonDevice != nullptr)) {
-      Logger::debug("DDraw4Interface::GetCaps: Getting memory stats from D3D9");
-
       d3d9::IDirect3DDevice9* d3d9Device = commonDevice->GetD3D9Device();
 
       total9 = static_cast<DWORD>(commonDevice->GetTotalTextureMemory());
@@ -456,16 +417,14 @@ namespace dxvk {
         free9 = free9 > delta + ReservedMemory ? free9 - (delta + ReservedMemory) : 0;
       }
 
-      Logger::debug(str::format("DDraw4Interface::GetCaps: Total: ", total9));
-      Logger::debug(str::format("DDraw4Interface::GetCaps: Free : ", free9));
+      //Logger::debug(str::format("DDraw4Interface::GetCaps: Total: ", total9));
+      //Logger::debug(str::format("DDraw4Interface::GetCaps: Free : ", free9));
     } else {
-      Logger::debug("DDraw4Interface::GetCaps: Getting memory stats from DDraw");
-
       const DWORD total6 = lpDDDriverCaps != nullptr ? lpDDDriverCaps->dwVidMemTotal : 0;
       const DWORD free6  = lpDDDriverCaps != nullptr ? lpDDDriverCaps->dwVidMemFree  : 0;
 
-      Logger::debug(str::format("DDraw4Interface::GetCaps: DDraw Total: ", total6));
-      Logger::debug(str::format("DDraw4Interface::GetCaps: DDraw Free : ", free6));
+      //Logger::debug(str::format("DDraw4Interface::GetCaps: DDraw Total: ", total6));
+      //Logger::debug(str::format("DDraw4Interface::GetCaps: DDraw Free : ", free6));
 
       if (unlikely(total6 < MaxMemory)) {
         total9 = total6;
@@ -476,8 +435,8 @@ namespace dxvk {
         free9 = free6 > delta + ReservedMemory ? free6 - (delta + ReservedMemory) : 0;
       }
 
-      Logger::debug(str::format("DDraw4Interface::GetCaps: Total: ", total9));
-      Logger::debug(str::format("DDraw4Interface::GetCaps: Free : ", free9));
+      //Logger::debug(str::format("DDraw4Interface::GetCaps: Total: ", total9));
+      //Logger::debug(str::format("DDraw4Interface::GetCaps: Free : ", free9));
     }
 
     if (lpDDDriverCaps != nullptr) {
@@ -501,8 +460,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::GetDisplayMode(LPDDSURFACEDESC2 lpDDSurfaceDesc) {
-    Logger::debug("<<< DDraw4Interface::GetDisplayMode: Proxy");
-
     if (unlikely(lpDDSurfaceDesc == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -519,8 +476,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::GetFourCCCodes(LPDWORD lpNumCodes, LPDWORD lpCodes) {
-    Logger::debug(">>> DDraw4Interface::GetFourCCCodes");
-
     if (likely(lpNumCodes != nullptr && lpCodes != nullptr)) {
       const uint32_t copyNumCodes = std::min<uint32_t>(ddrawCaps::NumberOfFOURCCCodes, *lpNumCodes);
       for (uint32_t i = 0; i < copyNumCodes; i++) {
@@ -535,8 +490,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::GetGDISurface(LPDIRECTDRAWSURFACE4 *lplpGDIDDSurface) {
-    Logger::debug("<<< DDraw4Interface::GetGDISurface: Proxy");
-
     if (unlikely(lplpGDIDDSurface == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -544,16 +497,12 @@ namespace dxvk {
 
     Com<IDirectDrawSurface4> gdiSurface;
     HRESULT hr = m_proxy->GetGDISurface(&gdiSurface);
-
-    if (unlikely(FAILED(hr))) {
-      Logger::debug("DDraw4Interface::GetGDISurface: Failed to retrieve GDI surface");
+    if (unlikely(FAILED(hr)))
       return hr;
-    }
 
     if (unlikely(DDrawCommonInterface::IsWrappedSurface(gdiSurface.ptr()))) {
       *lplpGDIDDSurface = gdiSurface.ref();
     } else {
-      Logger::debug("DDraw4Interface::GetGDISurface: Received a non-wrapped GDI surface");
       try {
         *lplpGDIDDSurface = ref(new DDraw4Surface(nullptr, std::move(gdiSurface),
                                                   this, nullptr, false));
@@ -567,17 +516,14 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::GetMonitorFrequency(LPDWORD lpdwFrequency) {
-    Logger::debug("<<< DDraw4Interface::GetMonitorFrequency: Proxy");
     return m_proxy->GetMonitorFrequency(lpdwFrequency);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::GetScanLine(LPDWORD lpdwScanLine) {
-    Logger::debug("<<< DDraw4Interface::GetScanLine: Proxy");
     return m_proxy->GetScanLine(lpdwScanLine);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::GetVerticalBlankStatus(LPBOOL lpbIsInVB) {
-    Logger::debug("<<< DDraw4Interface::GetVerticalBlankStatus: Proxy");
     return m_proxy->GetVerticalBlankStatus(lpbIsInVB);
   }
 
@@ -588,8 +534,6 @@ namespace dxvk {
   // On native DDraw the initial interface most likely gets reused. In practice,
   // applications that don't use IClassFactory won't call this, so keep it simple.
   HRESULT STDMETHODCALLTYPE DDraw4Interface::Initialize(GUID* lpGUID) {
-    Logger::debug(">>> DDraw4Interface::Initialize");
-
     if (unlikely(m_commonIntf->IsInitialized()))
       return DDERR_ALREADYINITIALIZED;
 
@@ -599,13 +543,10 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::RestoreDisplayMode() {
-    Logger::debug("<<< DDraw4Interface::RestoreDisplayMode: Proxy");
     return m_proxy->RestoreDisplayMode();
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::SetCooperativeLevel(HWND hWnd, DWORD dwFlags) {
-    Logger::debug("<<< DDraw4Interface::SetCooperativeLevel: Proxy");
-
     // DDSCL_CREATEDEVICEWINDOW doesn't appear to behave properly in
     // Wine, so use the cached hWnd to set the device window instead
     if (unlikely((dwFlags & DDSCL_CREATEDEVICEWINDOW) && hWnd == nullptr
@@ -625,8 +566,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::SetDisplayMode(DWORD dwWidth, DWORD dwHeight, DWORD dwBPP, DWORD dwRefreshRate, DWORD dwFlags) {
-    Logger::debug("<<< DDraw4Interface::SetDisplayMode: Proxy");
-
     Logger::debug(str::format("DDraw4Interface::SetDisplayMode: ", dwWidth, "x", dwHeight, ":", dwBPP, "@", dwRefreshRate));
 
     HRESULT hr = m_proxy->SetDisplayMode(dwWidth, dwHeight, dwBPP, dwRefreshRate, dwFlags);
@@ -659,8 +598,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::WaitForVerticalBlank(DWORD dwFlags, HANDLE hEvent) {
-    Logger::debug(">>> DDraw4Interface::WaitForVerticalBlank");
-
     if (unlikely(dwFlags & DDWAITVB_BLOCKBEGINEVENT))
       return DDERR_UNSUPPORTED;
 
@@ -681,8 +618,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::GetAvailableVidMem(LPDDSCAPS2 lpDDCaps, LPDWORD lpdwTotal, LPDWORD lpdwFree) {
-    Logger::debug(">>> DDraw4Interface::GetAvailableVidMem");
-
     if (unlikely(lpdwTotal == nullptr && lpdwFree == nullptr))
       return DD_OK;
 
@@ -692,8 +627,6 @@ namespace dxvk {
 
     D3DCommonDevice* commonDevice = m_commonIntf->GetCommonD3DDevice();
     if (likely(commonDevice != nullptr)) {
-      Logger::debug("DDraw4Interface::GetAvailableVidMem: Getting memory stats from D3D9");
-
       d3d9::IDirect3DDevice9* d3d9Device = commonDevice->GetD3D9Device();
 
       DWORD total9 = static_cast<DWORD>(commonDevice->GetTotalTextureMemory());
@@ -705,8 +638,8 @@ namespace dxvk {
         free9 = free9 > delta + ReservedMemory ? free9 - (delta + ReservedMemory) : 0;
       }
 
-      Logger::debug(str::format("DDraw4Interface::GetAvailableVidMem: Total: ", total9));
-      Logger::debug(str::format("DDraw4Interface::GetAvailableVidMem: Free : ", free9));
+      //Logger::debug(str::format("DDraw4Interface::GetAvailableVidMem: Total: ", total9));
+      //Logger::debug(str::format("DDraw4Interface::GetAvailableVidMem: Free : ", free9));
 
       if (lpdwTotal != nullptr)
         *lpdwTotal = total9;
@@ -714,8 +647,6 @@ namespace dxvk {
         *lpdwFree  = free9;
 
     } else {
-      Logger::debug("DDraw4Interface::GetAvailableVidMem: Getting memory stats from DDraw");
-
       DWORD total6 = 0;
       DWORD free6  = 0;
 
@@ -729,8 +660,8 @@ namespace dxvk {
         return hr;
       }
 
-      Logger::debug(str::format("DDraw4Interface::GetAvailableVidMem: DDraw Total: ", total6));
-      Logger::debug(str::format("DDraw4Interface::GetAvailableVidMem: DDraw Free : ", free6));
+      //Logger::debug(str::format("DDraw4Interface::GetAvailableVidMem: DDraw Total: ", total6));
+      //Logger::debug(str::format("DDraw4Interface::GetAvailableVidMem: DDraw Free : ", free6));
 
       DWORD total9 = 0;
       DWORD free9  = 0;
@@ -744,8 +675,8 @@ namespace dxvk {
         free9 = free6 > delta + ReservedMemory ? free6 - (delta + ReservedMemory) : 0;
       }
 
-      Logger::debug(str::format("DDraw4Interface::GetAvailableVidMem: Total: ", total9));
-      Logger::debug(str::format("DDraw4Interface::GetAvailableVidMem: Free : ", free9));
+      //Logger::debug(str::format("DDraw4Interface::GetAvailableVidMem: Total: ", total9));
+      //Logger::debug(str::format("DDraw4Interface::GetAvailableVidMem: Free : ", free9));
 
       if (lpdwTotal != nullptr)
         *lpdwTotal = total9;
@@ -757,8 +688,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::GetSurfaceFromDC(HDC hdc, LPDIRECTDRAWSURFACE4 *pSurf) {
-    Logger::debug(">>> DDraw4Interface::GetSurfaceFromDC");
-
     if (unlikely(pSurf == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -766,10 +695,8 @@ namespace dxvk {
 
     Com<IDirectDrawSurface4> surface;
     HRESULT hr = m_proxy->GetSurfaceFromDC(hdc, &surface);
-    if (unlikely(FAILED(hr))) {
-      Logger::warn("DDraw4Interface::GetSurfaceFromDC: Failed to get surface from DC");
+    if (unlikely(FAILED(hr)))
       return hr;
-    }
 
     try {
       *pSurf = ref(new DDraw4Surface(nullptr, std::move(surface), this, nullptr, false));
@@ -782,19 +709,14 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::RestoreAllSurfaces() {
-    Logger::debug("<<< DDraw4Interface::RestoreAllSurfaces: Proxy");
     return m_proxy->RestoreAllSurfaces();
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::TestCooperativeLevel() {
     D3DCommonDevice* commonDevice = m_commonIntf->GetCommonD3DDevice();
 
-    if (unlikely(commonDevice == nullptr)) {
-      Logger::debug("<<< DDraw4Interface::TestCooperativeLevel: Proxy");
+    if (unlikely(commonDevice == nullptr))
       return m_proxy->TestCooperativeLevel();
-    }
-
-    Logger::debug(">>> DDraw4Interface::TestCooperativeLevel");
 
     d3d9::IDirect3DDevice9* d3d9Device = commonDevice->GetD3D9Device();
 
@@ -806,8 +728,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::GetDeviceIdentifier(LPDDDEVICEIDENTIFIER pDDDI, DWORD dwFlags) {
-    Logger::debug(">>> DDraw4Interface::GetDeviceIdentifier");
-
     if (unlikely(pDDDI == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -821,7 +741,6 @@ namespace dxvk {
     const d3d9::D3DADAPTER_IDENTIFIER9* adapterIdentifier9 = m_commonIntf->GetAdapterIdentifier();
     // This is typically the "2D accelerator" in the system
     if (unlikely(dwFlags & DDGDI_GETHOSTIDENTIFIER)) {
-      Logger::debug("DDraw4Interface::GetDeviceIdentifier: Retrieving secondary adapter info");
       CopyToStringArray(pDDDI->szDriver, "vga.dll");
       // The Matrox G400 TechDemo expects the description to be aligned with native
       CopyToStringArray(pDDDI->szDescription, "DirectDraw HAL");
@@ -832,7 +751,6 @@ namespace dxvk {
       pDDDI->dwRevision               = 0;
       pDDDI->guidDeviceIdentifier     = pDDDIproxy.guidDeviceIdentifier;
     } else {
-      Logger::debug("DDraw4Interface::GetDeviceIdentifier: Retrieving primary adapter info");
       memcpy(&pDDDI->szDriver,      &adapterIdentifier9->Driver,      sizeof(adapterIdentifier9->Driver));
       memcpy(&pDDDI->szDescription, &adapterIdentifier9->Description, sizeof(adapterIdentifier9->Description));
       // Neither ATI, nor Nvidia (Windows XP) native drivers at the time reported a version

--- a/src/ddraw/ddraw4/ddraw4_surface.cpp
+++ b/src/ddraw/ddraw4/ddraw4_surface.cpp
@@ -91,13 +91,17 @@ namespace dxvk {
     // Clear the cached depth stencil on the parent if matched
     if (unlikely(m_parentSurf != nullptr && m_commonSurf->IsDepthStencil()
       && m_parentSurf->GetAttachedDepthStencil() == this)) {
-      m_parentSurf->ClearAttachedDepthStencil();
+      m_parentSurf->SetAttachedDepthStencil(nullptr);
     }
 
     DDrawCommonInterface::RemoveWrappedSurface(this);
 
+    if (m_depthStencil != nullptr)
+      m_depthStencil->SetParentSurface(nullptr);
+
     // Release all public references on all attached surfaces
     for (auto & attachedSurface : m_attachedSurfaces) {
+      attachedSurface.second->SetParentSurface(nullptr);
       uint32_t attachedRef;
       do {
         attachedRef = attachedSurface.second->Release();
@@ -113,8 +117,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> DDraw4Surface::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
@@ -122,8 +124,6 @@ namespace dxvk {
 
     // Shouldn't ever be called in practice
     if (unlikely(riid == __uuidof(IDirect3DTexture))) {
-      Logger::debug("DDraw4Surface::QueryInterface: Query for IDirect3DTexture");
-
       if (unlikely(m_texture3 == nullptr)) {
         Com<IDirect3DTexture> ppvProxyObject;
         HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -139,8 +139,6 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirect3DTexture2))) {
-      Logger::debug("DDraw4Surface::QueryInterface: Query for IDirect3DTexture2");
-
       if (unlikely(m_texture6 == nullptr)) {
         Com<IDirect3DTexture2> ppvProxyObject;
         HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -158,7 +156,6 @@ namespace dxvk {
     }
     // Wrap IDirectDrawGammaControl, to potentially ignore application set gamma ramps
     if (riid == __uuidof(IDirectDrawGammaControl)) {
-      Logger::debug("DDraw4Surface::QueryInterface: Query for IDirectDrawGammaControl");
       void* gammaControlProxiedVoid = nullptr;
       // This can never reasonably fail
       m_proxy->QueryInterface(__uuidof(IDirectDrawGammaControl), &gammaControlProxiedVoid);
@@ -167,17 +164,12 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirectDrawColorControl))) {
-      Logger::debug("DDraw4Surface::QueryInterface: Query for IDirectDrawColorControl");
       return E_NOINTERFACE;
     }
     if (unlikely(riid == __uuidof(IUnknown)
               || riid == __uuidof(IDirectDrawSurface))) {
-      if (m_commonSurf->GetDDSurface() != nullptr) {
-        Logger::debug("DDraw4Surface::QueryInterface: Query for existing IDirectDrawSurface");
+      if (m_commonSurf->GetDDSurface() != nullptr)
         return m_commonSurf->GetDDSurface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw4Surface::QueryInterface: Query for IDirectDrawSurface");
 
       Com<IDirectDrawSurface> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -205,12 +197,8 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface2))) {
-      if (m_commonSurf->GetDD2Surface() != nullptr) {
-        Logger::debug("DDraw4Surface::QueryInterface: Query for existing IDirectDrawSurface2");
+      if (m_commonSurf->GetDD2Surface() != nullptr)
         return m_commonSurf->GetDD2Surface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw4Surface::QueryInterface: Query for IDirectDrawSurface2");
 
       Com<IDirectDrawSurface2> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -228,12 +216,8 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface3))) {
-      if (m_commonSurf->GetDD3Surface() != nullptr) {
-        Logger::debug("DDraw4Surface::QueryInterface: Query for existing IDirectDrawSurface3");
+      if (m_commonSurf->GetDD3Surface() != nullptr)
         return m_commonSurf->GetDD3Surface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw4Surface::QueryInterface: Query for IDirectDrawSurface3");
 
       Com<IDirectDrawSurface3> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -251,12 +235,8 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface7))) {
-      if (m_commonSurf->GetDD7Surface() != nullptr) {
-        Logger::debug("DDraw4Surface::QueryInterface: Query for existing IDirectDrawSurface7");
+      if (m_commonSurf->GetDD7Surface() != nullptr)
         return m_commonSurf->GetDD7Surface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw4Surface::QueryInterface: Query for IDirectDrawSurface7");
 
       Com<IDirectDrawSurface7> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -285,8 +265,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::AddAttachedSurface(LPDIRECTDRAWSURFACE4 lpDDSAttachedSurface) {
-    Logger::debug("<<< DDraw4Surface::AddAttachedSurface: Proxy");
-
     if (unlikely(lpDDSAttachedSurface == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -297,37 +275,30 @@ namespace dxvk {
 
     DDraw4Surface* attachedSurf = static_cast<DDraw4Surface*>(lpDDSAttachedSurface);
 
-    // Unsupported by Wine's DDraw implementation, so we'll do our own handling
-    if (unlikely(attachedSurf->GetCommonSurface()->IsBackBufferOrFlippable())) {
-      Logger::debug("DDraw4Surface::AddAttachedSurface: Caching surface as DDraw RT");
-      m_commonIntf->SetDDrawRenderTarget(attachedSurf->GetCommonSurface());
-      return DD_OK;
-    }
-
     HRESULT hr = m_proxy->AddAttachedSurface(attachedSurf->GetProxied());
     if (unlikely(FAILED(hr)))
       return hr;
 
     attachedSurf->SetParentSurface(this);
-    if (likely(attachedSurf->GetCommonSurface()->IsDepthStencil()))
+
+    if (likely(attachedSurf->GetCommonSurface()->IsDepthStencil())) {
       m_depthStencil = attachedSurf;
+    // If a flippable surface is attached, mark it as the next flippable surface
+    } else if (unlikely(attachedSurf->GetCommonSurface()->IsBackBufferOrFlippable())) {
+      m_nextFlippable = attachedSurf;
+    }
 
     return DD_OK;
   }
 
   // Docs: "The IDirectDrawSurface4::AddOverlayDirtyRect method is not currently implemented."
   HRESULT STDMETHODCALLTYPE DDraw4Surface::AddOverlayDirtyRect(LPRECT lpRect) {
-    Logger::debug(">>> DDraw4Surface::AddOverlayDirtyRect");
     return DDERR_UNSUPPORTED;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::Blt(LPRECT lpDestRect, LPDIRECTDRAWSURFACE4 lpDDSrcSurface, LPRECT lpSrcRect, DWORD dwFlags, LPDDBLTFX lpDDBltFx) {
-    Logger::debug("<<< DDraw4Surface::Blt: Proxy");
-
-    const bool sourceIsWrappedSurface = lpDDSrcSurface == nullptr ||
-                                        DDrawCommonInterface::IsWrappedSurface(lpDDSrcSurface);
-
-    if (unlikely(!sourceIsWrappedSurface)) {
+    if (unlikely(lpDDSrcSurface != nullptr
+             && !DDrawCommonInterface::IsWrappedSurface(lpDDSrcSurface))) {
       Logger::err("DDraw4Surface::Blt: Received an unwrapped source surface");
       return DDERR_UNSUPPORTED;
     }
@@ -392,17 +363,12 @@ namespace dxvk {
 
   // Docs: "The IDirectDrawSurface4::BltBatch method is not currently implemented."
   HRESULT STDMETHODCALLTYPE DDraw4Surface::BltBatch(LPDDBLTBATCH lpDDBltBatch, DWORD dwCount, DWORD dwFlags) {
-    Logger::debug(">>> DDraw4Surface::BltBatch");
     return DDERR_UNSUPPORTED;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::BltFast(DWORD dwX, DWORD dwY, LPDIRECTDRAWSURFACE4 lpDDSrcSurface, LPRECT lpSrcRect, DWORD dwTrans) {
-    Logger::debug("<<< DDraw4Surface::BltFast: Proxy");
-
-    const bool sourceIsWrappedSurface = lpDDSrcSurface == nullptr ||
-                                        DDrawCommonInterface::IsWrappedSurface(lpDDSrcSurface);
-
-    if (unlikely(!sourceIsWrappedSurface)) {
+    if (unlikely(lpDDSrcSurface != nullptr
+             && !DDrawCommonInterface::IsWrappedSurface(lpDDSrcSurface))) {
       Logger::err("DDraw4Surface::BltFast: Received an unwrapped source surface");
       return DDERR_UNSUPPORTED;
     }
@@ -469,12 +435,8 @@ namespace dxvk {
 
   // This call will only detach DDSCAPS_ZBUFFER type surfaces and will reject anything else.
   HRESULT STDMETHODCALLTYPE DDraw4Surface::DeleteAttachedSurface(DWORD dwFlags, LPDIRECTDRAWSURFACE4 lpDDSAttachedSurface) {
-    Logger::debug("<<< DDraw4Surface::DeleteAttachedSurface: Proxy");
-
-    const bool attachedSurfaceIsWrappedSurface = lpDDSAttachedSurface == nullptr ||
-                                                 DDrawCommonInterface::IsWrappedSurface(lpDDSAttachedSurface);
-
-    if (unlikely(!attachedSurfaceIsWrappedSurface)) {
+    if (unlikely(lpDDSAttachedSurface != nullptr
+             && !DDrawCommonInterface::IsWrappedSurface(lpDDSAttachedSurface))) {
       Logger::err("DDraw4Surface::DeleteAttachedSurface: Received an unwrapped surface");
       return DDERR_UNSUPPORTED;
     }
@@ -492,28 +454,24 @@ namespace dxvk {
 
     DDraw4Surface* attachedSurf = static_cast<DDraw4Surface*>(lpDDSAttachedSurface);
 
-    if (unlikely(attachedSurf->GetCommonSurface()->IsBackBufferOrFlippable() &&
-                 attachedSurf->GetCommonSurface() == m_commonIntf->GetDDrawRenderTarget())) {
-      Logger::debug("DDraw4Surface::DeleteAttachedSurface: Removing cached DDraw RT surface");
-      m_commonIntf->SetDDrawRenderTarget(nullptr);
-      return DD_OK;
-    }
-
     HRESULT hr = m_proxy->DeleteAttachedSurface(dwFlags, attachedSurf->GetProxied());
     if (unlikely(FAILED(hr)))
       return hr;
 
+    attachedSurf->SetParentSurface(nullptr);
+
     if (likely(m_depthStencil == attachedSurf)) {
-      attachedSurf->ClearParentSurface();
       m_depthStencil = nullptr;
+    // Clear the next flippable surface or flippable surface detachment
+    } else if (unlikely(attachedSurf->GetCommonSurface()->IsBackBufferOrFlippable() &&
+                        attachedSurf == m_nextFlippable)) {
+      m_nextFlippable = nullptr;
     }
 
     return DD_OK;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::EnumAttachedSurfaces(LPVOID lpContext, LPDDENUMSURFACESCALLBACK2 lpEnumSurfacesCallback) {
-    Logger::debug(">>> DDraw4Surface::EnumAttachedSurfaces");
-
     if (unlikely(lpEnumSurfacesCallback == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -558,15 +516,12 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::EnumOverlayZOrders(DWORD dwFlags, LPVOID lpContext, LPDDENUMSURFACESCALLBACK2 lpfnCallback) {
-    Logger::debug("<<< DDraw4Surface::EnumOverlayZOrders: Proxy");
     return m_proxy->EnumOverlayZOrders(dwFlags, lpContext, lpfnCallback);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::Flip(LPDIRECTDRAWSURFACE4 lpDDSurfaceTargetOverride, DWORD dwFlags) {
-    const bool overrideIsWrappedSurface = lpDDSurfaceTargetOverride == nullptr ||
-                                          DDrawCommonInterface::IsWrappedSurface(lpDDSurfaceTargetOverride);
-
-    if (unlikely(!overrideIsWrappedSurface)) {
+    if (unlikely(lpDDSurfaceTargetOverride != nullptr
+             && !DDrawCommonInterface::IsWrappedSurface(lpDDSurfaceTargetOverride))) {
       Logger::err("DDraw4Surface::Flip: Received an unwrapped override surface");
       return DDERR_UNSUPPORTED;
     }
@@ -574,39 +529,29 @@ namespace dxvk {
     Com<DDraw4Surface> overrideSurf = static_cast<DDraw4Surface*>(lpDDSurfaceTargetOverride);
 
     d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
-    if (likely(d3d9Device != nullptr)) {
-      Logger::debug("*** DDraw4Surface::Flip: Presenting");
-
+    // Overlays can have odd video formats which DXVK doesn't support for RT
+    // use, so let DDraw present in case the flipped surface is an overlay
+    if (likely(d3d9Device != nullptr && !m_commonSurf->IsOverlay())) {
       // Lost surfaces are not flippable
       HRESULT hr = m_proxy->IsLost();
-      if (unlikely(FAILED(hr))) {
-        Logger::debug("DDraw4Surface::Flip: Lost surface");
+      if (unlikely(FAILED(hr)))
         return hr;
-      }
 
-      if (unlikely(!(m_commonSurf->IsFrontBuffer() || m_commonSurf->IsBackBufferOrFlippable()))) {
-        Logger::debug("DDraw4Surface::Flip: Unflippable surface");
+      if (unlikely(!(m_commonSurf->IsFrontBuffer() || m_commonSurf->IsBackBufferOrFlippable())))
         return DDERR_NOTFLIPPABLE;
-      }
 
       const bool exclusiveMode = m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE;
 
       // Non-exclusive mode validations
-      if (unlikely(m_commonSurf->IsPrimarySurface() && !exclusiveMode)) {
-        Logger::debug("DDraw4Surface::Flip: Primary surface flip in non-exclusive mode");
+      if (unlikely(m_commonSurf->IsPrimarySurface() && !exclusiveMode))
         return DDERR_NOEXCLUSIVEMODE;
-      }
 
       // Exclusive mode validations
-      if (unlikely(m_commonSurf->IsBackBufferOrFlippable() && exclusiveMode)) {
-        Logger::debug("DDraw4Surface::Flip: Back buffer flip in exclusive mode");
+      if (unlikely(m_commonSurf->IsBackBufferOrFlippable() && exclusiveMode))
         return DDERR_NOTFLIPPABLE;
-      }
 
-      if (unlikely(overrideSurf != nullptr && !overrideSurf->GetCommonSurface()->IsBackBufferOrFlippable())) {
-        Logger::debug("DDraw4Surface::Flip: Unflippable override surface");
+      if (unlikely(overrideSurf != nullptr && !overrideSurf->GetCommonSurface()->IsBackBufferOrFlippable()))
         return DDERR_NOTFLIPPABLE;
-      }
 
       // If the interface is waiting for VBlank and we get a no VSync flip, switch
       // to doing immediate presents by resetting the swapchain appropriately
@@ -640,31 +585,16 @@ namespace dxvk {
         }
       }
 
-      if (m_commonSurf->IsPrimarySurface()) {
-        // TODO: Handle such odd cases more elegantly; The Sims uploads data to an
-        // offscreen surface RT, and then flips the primary surface, however that
-        // offsceen surface isn't part of the same swapchain...
-        DDraw4Surface* rt = m_commonIntf->GetOptions()->forceRTFlip ?
-                            m_commonSurf->GetCommonD3DDevice()->GetCurrentRenderTarget4() :
-                            m_commonIntf->GetDDrawRenderTarget() != nullptr ?
-                            m_commonIntf->GetDDrawRenderTarget()->GetDD4Surface() : nullptr;
-
-        if (unlikely(rt != nullptr)) {
-          Logger::debug("DDraw4Surface::Flip: Presenting from DDraw RT");
-          if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer)) {
-            InitializeOrUploadD3D9();
-            if (m_shadowSurf != nullptr && rt->GetCommonSurface()->IsDDrawSurfaceDirty())
-              GetShadowOrProxied()->BltFast(0, 0, rt->GetShadowOrProxied(), nullptr, DDBLTFAST_NOCOLORKEY);
-          }
-          rt->InitializeOrUploadD3D9();
-          d3d9Device->Present(NULL, NULL, NULL, NULL);
-          return DD_OK;
-        }
+      // Workaround for The Sims/other games flipping a different
+      // swapchain than the one set on the current D3D device
+      if (unlikely(m_commonIntf->GetOptions()->forceRTFlip && m_commonSurf->IsPrimarySurface())) {
+        m_nextFlippable = m_commonSurf->GetCommonD3DDevice()->GetCurrentRenderTarget4();
       }
 
       if (likely(m_nextFlippable != nullptr)) {
-        if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer)) {
+        if (m_commonIntf->GetOptions()->emulateFrontBuffer) {
           InitializeOrUploadD3D9();
+          // Workaround for front buffer image retention issues
           if (m_shadowSurf != nullptr && m_nextFlippable->GetCommonSurface()->IsDDrawSurfaceDirty())
             GetShadowOrProxied()->BltFast(0, 0, m_nextFlippable->GetShadowOrProxied(), nullptr, DDBLTFAST_NOCOLORKEY);
         }
@@ -676,21 +606,8 @@ namespace dxvk {
       d3d9Device->Present(NULL, NULL, NULL, NULL);
 
     } else {
-      Logger::debug("<<< DDraw4Surface::Flip: Proxy");
-
       // Update the VBlank wait status based on the flip flags
       m_commonIntf->SetWaitForVBlank(IsVSyncFlipFlag(dwFlags));
-
-      if (m_commonSurf->IsPrimarySurface()) {
-        DDraw4Surface* rt = m_commonIntf->GetDDrawRenderTarget() != nullptr ?
-                            m_commonIntf->GetDDrawRenderTarget()->GetDD4Surface() : nullptr;
-
-        if (unlikely(rt != nullptr)) {
-          Logger::debug("DDraw4Surface::Flip: Blitting DDraw RT");
-          m_proxy->Blt(nullptr, rt->GetShadowOrProxied(), nullptr, DDBLT_WAIT, nullptr);
-          return DD_OK;
-        }
-      }
 
       if (overrideSurf == nullptr) {
         return m_proxy->Flip(lpDDSurfaceTargetOverride, dwFlags);
@@ -703,8 +620,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::GetAttachedSurface(LPDDSCAPS2 lpDDSCaps, LPDIRECTDRAWSURFACE4 *lplpDDAttachedSurface) {
-    Logger::debug("<<< DDraw4Surface::GetAttachedSurface: Proxy");
-
     if (unlikely(lpDDSCaps == nullptr || lplpDDAttachedSurface == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -733,7 +648,6 @@ namespace dxvk {
     // These are rather common, as some games query expecting to get nothing in return, for
     // example it's a common use case to query the mip attach chain until nothing is returned
     if (FAILED(hr)) {
-      Logger::debug("DDraw4Surface::GetAttachedSurface: Failed to find the requested surface");
       *lplpDDAttachedSurface = surface.ptr();
       return hr;
     }
@@ -765,8 +679,6 @@ namespace dxvk {
 
   // Blitting can be done at any time and completes within its call frame
   HRESULT STDMETHODCALLTYPE DDraw4Surface::GetBltStatus(DWORD dwFlags) {
-    Logger::debug(">>> DDraw4Surface::GetBltStatus");
-
     if (likely(dwFlags == DDGBS_CANBLT || dwFlags == DDGBS_ISBLTDONE))
       return DD_OK;
 
@@ -774,8 +686,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::GetCaps(LPDDSCAPS2 lpDDSCaps) {
-    Logger::debug(">>> DDraw4Surface::GetCaps");
-
     if (unlikely(lpDDSCaps == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -785,8 +695,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::GetClipper(LPDIRECTDRAWCLIPPER *lplpDDClipper) {
-    Logger::debug(">>> DDraw4Surface::GetClipper");
-
     if (unlikely(lplpDDClipper == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -803,12 +711,20 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::GetColorKey(DWORD dwFlags, LPDDCOLORKEY lpDDColorKey) {
-    Logger::debug("<<< DDraw4Surface::GetColorKey: Proxy");
     return m_proxy->GetColorKey(dwFlags, lpDDColorKey);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::GetDC(HDC *lphDC) {
-    Logger::debug("<<< DDraw4Surface::GetDC: Proxy");
+    // Direct D3D9 path which can sometimes be faster (and other times slower)
+    if (unlikely(m_commonIntf->GetOptions()->forceDCForwarding && m_commonSurf->IsInitialized())) {
+      InitializeOrUploadD3D9();
+
+      HRESULT hr = m_commonSurf->GetD3D9Surface()->GetDC(lphDC);
+      if (unlikely(FAILED(hr)))
+        return DDERR_INVALIDPARAMS;
+
+      return DD_OK;
+    }
 
     // Write back any dirty surface data from bound D3D9 back buffers or depth stencils
     DownloadSurfaceData();
@@ -818,8 +734,6 @@ namespace dxvk {
 
   // Flipping can be done at any time and completes within its call frame
   HRESULT STDMETHODCALLTYPE DDraw4Surface::GetFlipStatus(DWORD dwFlags) {
-    Logger::debug(">>> DDraw4Surface::GetFlipStatus");
-
     if (likely(dwFlags == DDGFS_CANFLIP || dwFlags == DDGFS_ISFLIPDONE))
       return DD_OK;
 
@@ -827,13 +741,10 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::GetOverlayPosition(LPLONG lplX, LPLONG lplY) {
-    Logger::debug("<<< DDraw4Surface::GetOverlayPosition: Proxy");
     return m_proxy->GetOverlayPosition(lplX, lplY);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::GetPalette(LPDIRECTDRAWPALETTE *lplpDDPalette) {
-    Logger::debug(">>> DDraw4Surface::GetPalette");
-
     if (unlikely(lplpDDPalette == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -850,8 +761,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::GetPixelFormat(LPDDPIXELFORMAT lpDDPixelFormat) {
-    Logger::debug(">>> DDraw4Surface::GetPixelFormat");
-
     if (unlikely(lpDDPixelFormat == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -861,8 +770,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::GetSurfaceDesc(LPDDSURFACEDESC2 lpDDSurfaceDesc) {
-    Logger::debug(">>> DDraw4Surface::GetSurfaceDesc");
-
     if (unlikely(lpDDSurfaceDesc == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -877,18 +784,14 @@ namespace dxvk {
   // According to the docs: "Because the DirectDrawSurface object is initialized
   // when it's created, this method always returns DDERR_ALREADYINITIALIZED."
   HRESULT STDMETHODCALLTYPE DDraw4Surface::Initialize(LPDIRECTDRAW lpDD, LPDDSURFACEDESC2 lpDDSurfaceDesc) {
-    Logger::debug(">>> DDraw4Surface::Initialize");
     return DDERR_ALREADYINITIALIZED;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::IsLost() {
-    Logger::debug("<<< DDraw4Surface::IsLost: Proxy");
     return m_proxy->IsLost();
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::Lock(LPRECT lpDestRect, LPDDSURFACEDESC2 lpDDSurfaceDesc, DWORD dwFlags, HANDLE hEvent) {
-    Logger::debug("<<< DDraw4Surface::Lock: Proxy");
-
     // Write back any dirty surface data from bound D3D9 back buffers or depth stencils
     DownloadSurfaceData();
 
@@ -896,7 +799,16 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::ReleaseDC(HDC hDC) {
-    Logger::debug("<<< DDraw4Surface::ReleaseDC: Proxy");
+    // Direct D3D9 path which can sometimes be faster (and other times slower)
+    if (unlikely(m_commonIntf->GetOptions()->forceDCForwarding && m_commonSurf->IsInitialized())) {
+      HRESULT hr = m_commonSurf->GetD3D9Surface()->ReleaseDC(hDC);
+      if (unlikely(FAILED(hr)))
+        return DDERR_INVALIDPARAMS;
+
+      m_commonSurf->DirtyD3D9Surface();
+
+      return DD_OK;
+    }
 
     HRESULT hr = GetShadowOrProxied()->ReleaseDC(hDC);
     if (unlikely(FAILED(hr)))
@@ -920,13 +832,10 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::Restore() {
-    Logger::debug("<<< DDraw4Surface::Restore: Proxy");
     return m_proxy->Restore();
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::SetClipper(LPDIRECTDRAWCLIPPER lpDDClipper) {
-    Logger::debug("<<< DDraw4Surface::SetClipper: Proxy");
-
     // A nullptr lpDDClipper gets the current clipper detached
     if (lpDDClipper == nullptr) {
       HRESULT hr = m_proxy->SetClipper(lpDDClipper);
@@ -946,19 +855,16 @@ namespace dxvk {
       // Retrieve a hWnd, if needed, during clipper attachment
       HWND hWnd = nullptr;
       hr = ddrawClipper->GetProxied()->GetHWnd(&hWnd);
-      if (unlikely(FAILED(hr))) {
-        Logger::debug("DDraw4Surface::SetClipper: Failed to retrieve hWnd");
-      } else {
-        m_commonIntf->SetHWND(hWnd);
-      }
+      if (unlikely(FAILED(hr)))
+        return DD_OK;
+
+      m_commonIntf->SetHWND(hWnd);
     }
 
     return DD_OK;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::SetColorKey(DWORD dwFlags, LPDDCOLORKEY lpDDColorKey) {
-    Logger::debug("<<< DDraw4Surface::SetColorKey: Proxy");
-
     // The Combat Mission series of games set a color key which is
     // outside the color range of the surface they are setting it on...
     // clamp it to the surface color depth in that case. This doesn't
@@ -994,13 +900,10 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::SetOverlayPosition(LONG lX, LONG lY) {
-    Logger::debug("<<< DDraw4Surface::SetOverlayPosition: Proxy");
     return m_proxy->SetOverlayPosition(lX, lY);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::SetPalette(LPDIRECTDRAWPALETTE lpDDPalette) {
-    Logger::debug("<<< DDraw4Surface::SetPalette: Proxy");
-
     // A nullptr lpDDPalette gets the current palette detached
     if (lpDDPalette == nullptr) {
       HRESULT hr = GetShadowOrProxied()->SetPalette(lpDDPalette);
@@ -1022,8 +925,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::Unlock(LPRECT lpSurfaceData) {
-    Logger::debug("<<< DDraw4Surface::Unlock: Proxy");
-
     HRESULT hr = GetShadowOrProxied()->Unlock(lpSurfaceData);
     if (unlikely(FAILED(hr)))
       return hr;
@@ -1046,8 +947,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::UpdateOverlay(LPRECT lpSrcRect, LPDIRECTDRAWSURFACE4 lpDDDestSurface, LPRECT lpDestRect, DWORD dwFlags, LPDDOVERLAYFX lpDDOverlayFx) {
-    Logger::debug("<<< DDraw4Surface::UpdateOverlay: Proxy");
-
     if (unlikely(lpDDDestSurface == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -1062,17 +961,12 @@ namespace dxvk {
 
   // Docs: "The IDirectDrawSurface4::UpdateOverlayDisplay method is not currently implemented."
   HRESULT STDMETHODCALLTYPE DDraw4Surface::UpdateOverlayDisplay(DWORD dwFlags) {
-    Logger::debug(">>> DDraw4Surface::UpdateOverlayDisplay");
     return DDERR_UNSUPPORTED;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::UpdateOverlayZOrder(DWORD dwFlags, LPDIRECTDRAWSURFACE4 lpDDSReference) {
-    Logger::debug("<<< DDraw4Surface::UpdateOverlayZOrder: Proxy");
-
-    const bool referenceIsWrappedSurface = lpDDSReference == nullptr ||
-                                           DDrawCommonInterface::IsWrappedSurface(lpDDSReference);
-
-    if (unlikely(!referenceIsWrappedSurface)) {
+    if (unlikely(lpDDSReference != nullptr
+              && !DDrawCommonInterface::IsWrappedSurface(lpDDSReference))) {
       Logger::err("DDraw4Surface::UpdateOverlayZOrder: Received an unwrapped surface");
       return DDERR_UNSUPPORTED;
     }
@@ -1086,35 +980,30 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::GetDDInterface(LPVOID *lplpDD) {
-    if (unlikely(m_commonIntf->GetDD4Interface() == nullptr)) {
-      Logger::warn("<<< DDraw4Surface::GetDDInterface: Proxy");
-      return m_proxy->GetDDInterface(lplpDD);
-    }
-
-    Logger::debug(">>> DDraw4Surface::GetDDInterface");
-
     if (unlikely(lplpDD == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    // Was an easy footgun to return a proxied interface
+    InitReturnPtr(lplpDD);
+
+    if (unlikely(m_commonIntf->GetDD4Interface() == nullptr)) {
+      Logger::err("DDraw4Surface::GetDDInterface: Found no valid parent interface");
+      return DDERR_NOTFOUND;
+    }
+
     *lplpDD = ref(m_commonIntf->GetDD4Interface());
 
     return DD_OK;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::PageLock(DWORD dwFlags) {
-    Logger::debug("<<< DDraw4Surface::PageLock: Proxy");
     return m_proxy->PageLock(dwFlags);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::PageUnlock(DWORD dwFlags) {
-    Logger::debug("<<< DDraw4Surface::PageUnlock: Proxy");
     return m_proxy->PageUnlock(dwFlags);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::SetSurfaceDesc(LPDDSURFACEDESC2 lpDDSD, DWORD dwFlags) {
-    Logger::debug("<<< DDraw4Surface::SetSurfaceDesc: Proxy");
-
     // Can be used only to set the surface data and pixel format
     // used by an explicit system-memory surface (will be validated)
     HRESULT hr = m_proxy->SetSurfaceDesc(lpDDSD, dwFlags);
@@ -1134,25 +1023,20 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::SetPrivateData(REFGUID tag, LPVOID pData, DWORD cbSize, DWORD dwFlags) {
-    Logger::debug("<<< DDraw4Surface::SetPrivateData: Proxy");
     return m_proxy->SetPrivateData(tag, pData, cbSize, dwFlags);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::GetPrivateData(REFGUID tag, LPVOID pBuffer, LPDWORD pcbBufferSize) {
-    Logger::debug("<<< DDraw4Surface::GetPrivateData: Proxy");
     return m_proxy->GetPrivateData(tag, pBuffer, pcbBufferSize);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::FreePrivateData(REFGUID tag) {
-    Logger::debug("<<< DDraw4Surface::FreePrivateData: Proxy");
     return m_proxy->FreePrivateData(tag);
   }
 
   // Docs: "The only defined uniqueness value is 0, indicating that the surface
   // is likely to be changing beyond the control of DirectDraw."
   HRESULT STDMETHODCALLTYPE DDraw4Surface::GetUniquenessValue(LPDWORD pValue) {
-    Logger::debug(">>> DDraw4Surface::GetUniquenessValue");
-
     if (unlikely(pValue == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -1162,7 +1046,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::ChangeUniquenessValue() {
-    Logger::debug(">>> DDraw4Surface::ChangeUniquenessValue");
     return DD_OK;
   }
 
@@ -1218,10 +1101,8 @@ namespace dxvk {
     d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
 
     // Fast skip
-    if (unlikely(d3d9Device == nullptr)) {
-      Logger::debug("DDraw4Surface::InitializeOrUploadD3D9: Null device, can't initialize right now");
+    if (unlikely(d3d9Device == nullptr))
       return DD_OK;
-    }
 
     if (unlikely(!m_commonSurf->IsInitialized())) {
       if (m_commonSurf->IsTexture())
@@ -1252,19 +1133,15 @@ namespace dxvk {
       m_commonSurf->RefreshD3D9Device();
 
     if (unlikely(m_commonSurf->IsD3D9BackBuffer())) {
-      Logger::debug("DDraw4Surface::DownloadSurfaceData: Surface is a bound swapchain surface");
-
       if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
-        Logger::debug(str::format("DDraw4Surface::DownloadSurfaceData: Downloading nr. [[4-", m_surfCount, "]]"));
+        //Logger::debug(str::format("DDraw4Surface::DownloadSurfaceData: Downloading nr. [[4-", m_surfCount, "]]"));
         BlitToDDrawSurface<IDirectDrawSurface4, DDSURFACEDESC2>(GetShadowOrProxied(), m_commonSurf->GetD3D9Surface(),
                                                                 m_commonSurf->IsDXTFormat());
         m_commonSurf->UnDirtyD3D9Surface();
       }
     } else if (unlikely(m_commonSurf->IsD3D9DepthStencil())) {
-      Logger::debug("DDraw4Surface::DownloadSurfaceData: Surface is a bound depth stencil");
-
       if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
-        Logger::debug(str::format("DDraw4Surface::DownloadSurfaceData: Downloading nr. [[4-", m_surfCount, "]]"));
+        //Logger::debug(str::format("DDraw4Surface::DownloadSurfaceData: Downloading nr. [[4-", m_surfCount, "]]"));
         BlitToDDrawSurface<IDirectDrawSurface4, DDSURFACEDESC2>(m_proxy.ptr(), m_commonSurf->GetD3D9Surface(),
                                                                 m_commonSurf->IsDXTFormat());
         m_commonSurf->UnDirtyD3D9Surface();
@@ -1308,10 +1185,8 @@ namespace dxvk {
         Logger::debug(str::format("DDraw4Surface::UpdateMipMapCount: Mismatch with declared ", desc2->dwMipMapCount, " mip levels"));
     }
 
-    if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps)) {
-      Logger::debug("DDraw4Surface::UpdateMipMapCount: Using auto mip map generation");
+    if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps))
       mipCount = 0;
-    }
 
     m_commonSurf->SetMipCount(mipCount);
   }
@@ -1321,16 +1196,13 @@ namespace dxvk {
     if (!m_commonSurf->IsDDrawSurfaceDirty())
       return DD_OK;
 
-    Logger::debug(str::format("DDraw4Surface::UploadSurfaceData: Uploading nr. [[4-", m_surfCount, "]]"));
+    //Logger::debug(str::format("DDraw4Surface::UploadSurfaceData: Uploading nr. [[4-", m_surfCount, "]]"));
 
     if (m_commonSurf->IsTexture()) {
       BlitToD3D9Texture<IDirectDrawSurface4, DDSURFACEDESC2>(m_commonSurf->GetD3D9Texture(), m_proxy.ptr(),
                                                              m_commonSurf->GetMipCount(), m_commonSurf->IsDXTFormat());
     // Blit surfaces directly
     } else {
-      if (unlikely(m_commonSurf->IsDepthStencil()))
-        Logger::debug("DDrawSurface::UploadSurfaceData: Uploading depth stencil");
-
       BlitToD3D9Surface<IDirectDrawSurface4, DDSURFACEDESC2>(m_commonSurf->GetD3D9Surface(), GetShadowOrProxied(),
                                                              m_commonSurf->IsDXTFormat());
     }

--- a/src/ddraw/ddraw4/ddraw4_surface.h
+++ b/src/ddraw/ddraw4/ddraw4_surface.h
@@ -168,22 +168,17 @@ namespace dxvk {
       return m_depthStencil.ptr();
     }
 
-    void ClearAttachedDepthStencil() {
-      m_depthStencil = nullptr;
+    void SetParentSurface(DDraw4Surface* surface) {
+      m_parentSurf = surface;
+
+      if (m_parentSurf != nullptr)
+        m_commonSurf->SetIsAttached(true);
+      else
+        m_commonSurf->SetIsAttached(false);
     }
 
     DDraw4Surface* GetParentSurface() const {
       return m_parentSurf;
-    }
-
-    void SetParentSurface(DDraw4Surface* surface) {
-      m_parentSurf = surface;
-      m_commonSurf->SetIsAttached(true);
-    }
-
-    void ClearParentSurface() {
-      m_parentSurf = nullptr;
-      m_commonSurf->SetIsAttached(false);
     }
 
   private:

--- a/src/ddraw/ddraw7/ddraw7_interface.cpp
+++ b/src/ddraw/ddraw7/ddraw7_interface.cpp
@@ -65,8 +65,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> DDraw7Interface::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
@@ -74,8 +72,6 @@ namespace dxvk {
 
     // Standard way of retrieving a D3D7 interface
     if (riid == __uuidof(IDirect3D7)) {
-      Logger::debug("DDraw7Interface::QueryInterface: Query for IDirect3D7");
-
       // Initialize the IDirect3D7 interlocked object
       if (unlikely(m_d3d7Intf == nullptr)) {
         Com<IDirect3D7> ppvProxyObject;
@@ -92,12 +88,8 @@ namespace dxvk {
     }
     // Some games query for legacy ddraw interfaces
     if (unlikely(riid == __uuidof(IDirectDraw))) {
-      if (m_commonIntf->GetDDInterface() != nullptr) {
-        Logger::debug("DDraw7Interface::QueryInterface: Query for existing IDirectDraw");
+      if (m_commonIntf->GetDDInterface() != nullptr)
         return m_commonIntf->GetDDInterface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw7Interface::QueryInterface: Query for legacy IDirectDraw");
 
       Com<IDirectDraw> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -109,12 +101,8 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirectDraw2))) {
-      if (m_commonIntf->GetDD2Interface() != nullptr) {
-        Logger::debug("DDraw7Interface::QueryInterface: Query for existing IDirectDraw2");
+      if (m_commonIntf->GetDD2Interface() != nullptr)
         return m_commonIntf->GetDD2Interface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::warn("DDraw7Interface::QueryInterface: Query for legacy IDirectDraw2");
 
       Com<IDirectDraw2> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -126,12 +114,8 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirectDraw4))) {
-      if (m_commonIntf->GetDD4Interface() != nullptr) {
-        Logger::debug("DDraw7Interface::QueryInterface: Query for existing IDirectDraw4");
+      if (m_commonIntf->GetDD4Interface() != nullptr)
         return m_commonIntf->GetDD4Interface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw7Interface::QueryInterface: Query for legacy IDirectDraw4");
 
       Com<IDirectDraw4> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -144,12 +128,10 @@ namespace dxvk {
     }
     // Quite a lot of games query for this IID during intro playback
     if (unlikely(riid == GUID_IAMMediaStream)) {
-      Logger::debug("DDraw7Interface::QueryInterface: Query for IAMMediaStream");
       return m_proxy->QueryInterface(riid, ppvObject);
     }
     // Also seen queried by some games, such as V-Rally 2: Expert Edition
     if (unlikely(riid == GUID_IMediaStream)) {
-      Logger::debug("DDraw7Interface::QueryInterface: Query for IMediaStream");
       return m_proxy->QueryInterface(riid, ppvObject);
     }
 
@@ -166,13 +148,10 @@ namespace dxvk {
 
   // The documentation states: "The IDirectDraw7::Compact method is not currently implemented."
   HRESULT STDMETHODCALLTYPE DDraw7Interface::Compact() {
-    Logger::debug(">>> DDraw7Interface::Compact");
-    return DD_OK;
+    return DDERR_UNSUPPORTED;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::CreateClipper(DWORD dwFlags, LPDIRECTDRAWCLIPPER *lplpDDClipper, IUnknown *pUnkOuter) {
-    Logger::debug(">>> DDraw7Interface::CreateClipper");
-
     if (unlikely(lplpDDClipper == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -180,10 +159,8 @@ namespace dxvk {
 
     Com<IDirectDrawClipper> lplpDDClipperProxy;
     HRESULT hr = m_proxy->CreateClipper(dwFlags, &lplpDDClipperProxy, pUnkOuter);
-    if (unlikely(FAILED(hr))) {
-      Logger::warn("DDraw7Interface::CreateClipper: Failed to create proxy clipper");
+    if (unlikely(FAILED(hr)))
       return hr;
-    }
 
     *lplpDDClipper = ref(new DDrawClipper(m_commonIntf.ptr(), std::move(lplpDDClipperProxy), this));
 
@@ -191,8 +168,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::CreatePalette(DWORD dwFlags, LPPALETTEENTRY lpColorTable, LPDIRECTDRAWPALETTE *lplpDDPalette, IUnknown *pUnkOuter) {
-    Logger::debug(">>> DDraw7Interface::CreatePalette");
-
     if (unlikely(lplpDDPalette == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -200,10 +175,8 @@ namespace dxvk {
 
     Com<IDirectDrawPalette> lplpDDPaletteProxy;
     HRESULT hr = m_proxy->CreatePalette(dwFlags, lpColorTable, &lplpDDPaletteProxy, pUnkOuter);
-    if (unlikely(FAILED(hr))) {
-      Logger::warn("DDraw7Interface::CreatePalette: Failed to create proxy palette");
+    if (unlikely(FAILED(hr)))
       return hr;
-    }
 
     *lplpDDPalette = ref(new DDrawPalette(std::move(lplpDDPaletteProxy), this));
 
@@ -211,8 +184,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::CreateSurface(LPDDSURFACEDESC2 lpDDSurfaceDesc, LPDIRECTDRAWSURFACE7 *lplpDDSurface, IUnknown *pUnkOuter) {
-    Logger::debug(">>> DDraw7Interface::CreateSurface");
-
     // The cooperative level is always checked first
     if (unlikely(!m_commonIntf->IsCooperativeLevelSet()))
       return DDERR_NOCOOPERATIVELEVELSET;
@@ -249,26 +220,35 @@ namespace dxvk {
       lpDDSurfaceDesc->ddsCaps.dwCaps |= DDSCAPS_SYSTEMMEMORY;
     }
 
-    if (unlikely((lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_ZBUFFER)
-              && (lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFFFF))) {
-      if (m_commonIntf->GetOptions()->useD24X8forD32) {
-        // In case of up-front unsupported and unadvertised D32 depth stencil use,
-        // replace it with D24X8, as some games, such as Sacrifice, rely on it
-        // to properly enable 32-bit display modes (and revert to 16-bit otherwise)
-        Logger::info("DDraw7Interface::CreateSurface: Using D24X8 instead of D32");
-        lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFFFF;
-      } else {
-        Logger::warn("DDraw7Interface::CreateSurface: Use of unsupported D32");
+    if (unlikely(lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_ZBUFFER)) {
+      if (unlikely(m_commonIntf->GetOptions()->useD16forD24X8
+                && lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFF
+                && lpDDSurfaceDesc->ddpfPixelFormat.dwStencilBitMask == 0x0)) {
+        // Games such as Need for Speed: Porsche are broken with 32-bit color
+        // on night tracks with "projected" lights, because they clearly were
+        // designed with 16-bit Z buffers in mind. Fix it up by silently swapping
+        // D16 for D24X8 on depth stencil creation.
+        Logger::info("DDraw7Interface::CreateSurface: Using D16 instead of D24X8");
+        lpDDSurfaceDesc->ddpfPixelFormat.dwZBufferBitDepth = 16;
+        lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFF;
+      } else if (unlikely(lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFFFF)) {
+        if (m_commonIntf->GetOptions()->useD24X8forD32) {
+          // In case of up-front unsupported and unadvertised D32 depth stencil use,
+          // replace it with D24X8, as some games, such as Sacrifice, rely on it
+          // to properly enable 32-bit display modes (and revert to 16-bit otherwise)
+          Logger::info("DDraw7Interface::CreateSurface: Using D24X8 instead of D32");
+          lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFFFF;
+        } else {
+          Logger::warn("DDraw7Interface::CreateSurface: Use of unsupported D32");
+        }
       }
     }
 
     Com<IDirectDrawSurface7> ddraw7SurfaceProxied;
     hr = m_proxy->CreateSurface(lpDDSurfaceDesc, &ddraw7SurfaceProxied, pUnkOuter);
     // Some games simply try creating surfaces with various formats until something works...
-    if (unlikely(FAILED(hr))) {
-      Logger::debug("DDraw7Interface::CreateSurface: Failed to create proxy surface");
+    if (unlikely(FAILED(hr)))
       return hr;
-    }
 
     try{
       Com<DDraw7Surface> surface7 = new DDraw7Surface(nullptr, std::move(ddraw7SurfaceProxied), this, nullptr, true);
@@ -316,8 +296,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::DuplicateSurface(LPDIRECTDRAWSURFACE7 lpDDSurface, LPDIRECTDRAWSURFACE7 *lplpDupDDSurface) {
-    Logger::debug("<<< DDraw7Interface::DuplicateSurface: Proxy");
-
     if (unlikely(lpDDSurface == nullptr || lplpDupDDSurface == nullptr))
       return DDERR_CANTDUPLICATE;
 
@@ -346,13 +324,10 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::EnumDisplayModes(DWORD dwFlags, LPDDSURFACEDESC2 lpDDSurfaceDesc, LPVOID lpContext, LPDDENUMMODESCALLBACK2 lpEnumModesCallback) {
-    Logger::debug("<<< DDraw7Interface::EnumDisplayModes: Proxy");
     return m_proxy->EnumDisplayModes(dwFlags, lpDDSurfaceDesc, lpContext, lpEnumModesCallback);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::EnumSurfaces(DWORD dwFlags, LPDDSURFACEDESC2 lpDDSD, LPVOID lpContext, LPDDENUMSURFACESCALLBACK7 lpEnumSurfacesCallback) {
-    Logger::debug("<<< DDraw7Interface::EnumSurfaces: Proxy");
-
     if (unlikely(lpEnumSurfacesCallback == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -383,8 +358,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::FlipToGDISurface() {
-    Logger::debug("*** DDraw7Interface::FlipToGDISurface: Ignoring");
-
     DDrawCommonSurface* ps = m_commonIntf->GetPrimarySurface();
 
     // A primary surface must exist for a GDI flip to be possible
@@ -398,8 +371,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::GetCaps(LPDDCAPS lpDDDriverCaps, LPDDCAPS lpDDHELCaps) {
-    Logger::debug("<<< DDraw7Interface::GetCaps: Proxy");
-
     if (unlikely(lpDDDriverCaps == nullptr && lpDDHELCaps == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -428,8 +399,6 @@ namespace dxvk {
     if (likely(commonDevice != nullptr)) {
       d3d9::IDirect3DDevice9* d3d9Device = commonDevice->GetD3D9Device();
 
-      Logger::debug("DDraw7Interface::GetCaps: Getting memory stats from D3D9");
-
       total9 = static_cast<DWORD>(commonDevice->GetTotalTextureMemory());
       free9  = static_cast<DWORD>(d3d9Device->GetAvailableTextureMem());
 
@@ -439,16 +408,14 @@ namespace dxvk {
         free9 = free9 > delta + ReservedMemory ? free9 - (delta + ReservedMemory) : 0;
       }
 
-      Logger::debug(str::format("DDraw7Interface::GetCaps: Total: ", total9));
-      Logger::debug(str::format("DDraw7Interface::GetCaps: Free : ", free9));
+      //Logger::debug(str::format("DDraw7Interface::GetCaps: Total: ", total9));
+      //Logger::debug(str::format("DDraw7Interface::GetCaps: Free : ", free9));
     } else {
-      Logger::debug("DDraw7Interface::GetCaps: Getting memory stats from DDraw");
-
       const DWORD total7 = lpDDDriverCaps != nullptr ? lpDDDriverCaps->dwVidMemTotal : 0;
       const DWORD free7  = lpDDDriverCaps != nullptr ? lpDDDriverCaps->dwVidMemFree  : 0;
 
-      Logger::debug(str::format("DDraw7Interface::GetCaps: DDraw Total: ", total7));
-      Logger::debug(str::format("DDraw7Interface::GetCaps: DDraw Free : ", free7));
+      //Logger::debug(str::format("DDraw7Interface::GetCaps: DDraw Total: ", total7));
+      //Logger::debug(str::format("DDraw7Interface::GetCaps: DDraw Free : ", free7));
 
       if (unlikely(total7 < MaxMemory)) {
         total9 = total7;
@@ -459,8 +426,8 @@ namespace dxvk {
         free9 = free7 > delta + ReservedMemory ? free7 - (delta + ReservedMemory) : 0;
       }
 
-      Logger::debug(str::format("DDraw7Interface::GetCaps: Total: ", total9));
-      Logger::debug(str::format("DDraw7Interface::GetCaps: Free : ", free9));
+      //Logger::debug(str::format("DDraw7Interface::GetCaps: Total: ", total9));
+      //Logger::debug(str::format("DDraw7Interface::GetCaps: Free : ", free9));
     }
 
     if (lpDDDriverCaps != nullptr) {
@@ -484,8 +451,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::GetDisplayMode(LPDDSURFACEDESC2 lpDDSurfaceDesc) {
-    Logger::debug("<<< DDraw7Interface::GetDisplayMode: Proxy");
-
     if (unlikely(lpDDSurfaceDesc == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -502,8 +467,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::GetFourCCCodes(LPDWORD lpNumCodes, LPDWORD lpCodes) {
-    Logger::debug(">>> DDraw7Interface::GetFourCCCodes");
-
     if (likely(lpNumCodes != nullptr && lpCodes != nullptr)) {
       const uint32_t copyNumCodes = std::min<uint32_t>(ddrawCaps::NumberOfFOURCCCodes, *lpNumCodes);
       for (uint32_t i = 0; i < copyNumCodes; i++) {
@@ -518,8 +481,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::GetGDISurface(LPDIRECTDRAWSURFACE7 *lplpGDIDDSurface) {
-    Logger::debug("<<< DDraw7Interface::GetGDISurface: Proxy");
-
     if (unlikely(lplpGDIDDSurface == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -527,16 +488,12 @@ namespace dxvk {
 
     Com<IDirectDrawSurface7> gdiSurface;
     HRESULT hr = m_proxy->GetGDISurface(&gdiSurface);
-
-    if (unlikely(FAILED(hr))) {
-      Logger::debug("DDraw7Interface::GetGDISurface: Failed to retrieve GDI surface");
+    if (unlikely(FAILED(hr)))
       return hr;
-    }
 
     if (unlikely(DDrawCommonInterface::IsWrappedSurface(gdiSurface.ptr()))) {
       *lplpGDIDDSurface = gdiSurface.ref();
     } else {
-      Logger::debug("DDraw7Interface::GetGDISurface: Received a non-wrapped GDI surface");
       try {
         *lplpGDIDDSurface = ref(new DDraw7Surface(nullptr, std::move(gdiSurface),
                                                   this, nullptr, false));
@@ -550,17 +507,14 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::GetMonitorFrequency(LPDWORD lpdwFrequency) {
-    Logger::debug("<<< DDraw7Interface::GetMonitorFrequency: Proxy");
     return m_proxy->GetMonitorFrequency(lpdwFrequency);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::GetScanLine(LPDWORD lpdwScanLine) {
-    Logger::debug("<<< DDraw7Interface::GetScanLine: Proxy");
     return m_proxy->GetScanLine(lpdwScanLine);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::GetVerticalBlankStatus(LPBOOL lpbIsInVB) {
-    Logger::debug("<<< DDraw7Interface::GetVerticalBlankStatus: Proxy");
     return m_proxy->GetVerticalBlankStatus(lpbIsInVB);
   }
 
@@ -571,8 +525,6 @@ namespace dxvk {
   // On native DDraw the initial interface most likely gets reused. In practice,
   // applications that don't use IClassFactory won't call this, so keep it simple.
   HRESULT STDMETHODCALLTYPE DDraw7Interface::Initialize(GUID* lpGUID) {
-    Logger::debug(">>> DDraw7Interface::Initialize");
-
     if (unlikely(m_commonIntf->IsInitialized()))
       return DDERR_ALREADYINITIALIZED;
 
@@ -582,13 +534,10 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::RestoreDisplayMode() {
-    Logger::debug("<<< DDraw7Interface::RestoreDisplayMode: Proxy");
     return m_proxy->RestoreDisplayMode();
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::SetCooperativeLevel(HWND hWnd, DWORD dwFlags) {
-    Logger::debug("<<< DDraw7Interface::SetCooperativeLevel: Proxy");
-
     // DDSCL_CREATEDEVICEWINDOW doesn't appear to behave properly in
     // Wine, so use the cached hWnd to set the device window instead
     if (unlikely((dwFlags & DDSCL_CREATEDEVICEWINDOW) && hWnd == nullptr
@@ -608,8 +557,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::SetDisplayMode(DWORD dwWidth, DWORD dwHeight, DWORD dwBPP, DWORD dwRefreshRate, DWORD dwFlags) {
-    Logger::debug("<<< DDraw7Interface::SetDisplayMode: Proxy");
-
     Logger::debug(str::format("DDraw7Interface::SetDisplayMode: ", dwWidth, "x", dwHeight, ":", dwBPP, "@", dwRefreshRate));
 
     HRESULT hr = m_proxy->SetDisplayMode(dwWidth, dwHeight, dwBPP, dwRefreshRate, dwFlags);
@@ -642,8 +589,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::WaitForVerticalBlank(DWORD dwFlags, HANDLE hEvent) {
-    Logger::debug(">>> DDraw7Interface::WaitForVerticalBlank");
-
     if (unlikely(dwFlags & DDWAITVB_BLOCKBEGINEVENT))
       return DDERR_UNSUPPORTED;
 
@@ -664,8 +609,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::GetAvailableVidMem(LPDDSCAPS2 lpDDCaps, LPDWORD lpdwTotal, LPDWORD lpdwFree) {
-    Logger::debug(">>> DDraw7Interface::GetAvailableVidMem");
-
     if (unlikely(lpdwTotal == nullptr && lpdwFree == nullptr))
       return DD_OK;
 
@@ -677,8 +620,6 @@ namespace dxvk {
     if (likely(commonDevice != nullptr)) {
       d3d9::IDirect3DDevice9* d3d9Device = commonDevice->GetD3D9Device();
 
-      Logger::debug("DDraw7Interface::GetAvailableVidMem: Getting memory stats from D3D9");
-
       DWORD total9 = static_cast<DWORD>(commonDevice->GetTotalTextureMemory());
       DWORD free9  = static_cast<DWORD>(d3d9Device->GetAvailableTextureMem());
 
@@ -688,8 +629,8 @@ namespace dxvk {
         free9 = free9 > delta + ReservedMemory ? free9 - (delta + ReservedMemory) : 0;
       }
 
-      Logger::debug(str::format("DDraw7Interface::GetAvailableVidMem: Total: ", total9));
-      Logger::debug(str::format("DDraw7Interface::GetAvailableVidMem: Free : ", free9));
+      //Logger::debug(str::format("DDraw7Interface::GetAvailableVidMem: Total: ", total9));
+      //Logger::debug(str::format("DDraw7Interface::GetAvailableVidMem: Free : ", free9));
 
       if (lpdwTotal != nullptr)
         *lpdwTotal = total9;
@@ -697,8 +638,6 @@ namespace dxvk {
         *lpdwFree  = free9;
 
     } else {
-      Logger::debug("DDraw7Interface::GetAvailableVidMem: Getting memory stats from DDraw");
-
       DWORD total7 = 0;
       DWORD free7  = 0;
 
@@ -712,8 +651,8 @@ namespace dxvk {
         return hr;
       }
 
-      Logger::debug(str::format("DDraw7Interface::GetAvailableVidMem: DDraw Total: ", total7));
-      Logger::debug(str::format("DDraw7Interface::GetAvailableVidMem: DDraw Free : ", free7));
+      //Logger::debug(str::format("DDraw7Interface::GetAvailableVidMem: DDraw Total: ", total7));
+      //Logger::debug(str::format("DDraw7Interface::GetAvailableVidMem: DDraw Free : ", free7));
 
       DWORD total9 = 0;
       DWORD free9  = 0;
@@ -727,8 +666,8 @@ namespace dxvk {
         free9 = free7 > delta + ReservedMemory ? free7 - (delta + ReservedMemory) : 0;
       }
 
-      Logger::debug(str::format("DDraw7Interface::GetAvailableVidMem: Total: ", total9));
-      Logger::debug(str::format("DDraw7Interface::GetAvailableVidMem: Free : ", free9));
+      //Logger::debug(str::format("DDraw7Interface::GetAvailableVidMem: Total: ", total9));
+      //Logger::debug(str::format("DDraw7Interface::GetAvailableVidMem: Free : ", free9));
 
       if (lpdwTotal != nullptr)
         *lpdwTotal = total9;
@@ -740,8 +679,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::GetSurfaceFromDC(HDC hdc, LPDIRECTDRAWSURFACE7 *pSurf) {
-    Logger::debug(">>> DDraw7Interface::GetSurfaceFromDC");
-
     if (unlikely(pSurf == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -749,10 +686,8 @@ namespace dxvk {
 
     Com<IDirectDrawSurface7> surface;
     HRESULT hr = m_proxy->GetSurfaceFromDC(hdc, &surface);
-    if (unlikely(FAILED(hr))) {
-      Logger::warn("DDraw7Interface::GetSurfaceFromDC: Failed to get surface from DC");
+    if (unlikely(FAILED(hr)))
       return hr;
-    }
 
     try {
       *pSurf = ref(new DDraw7Surface(nullptr, std::move(surface), this, nullptr, false));
@@ -765,19 +700,14 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::RestoreAllSurfaces() {
-    Logger::debug("<<< DDraw7Interface::RestoreAllSurfaces: Proxy");
     return m_proxy->RestoreAllSurfaces();
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::TestCooperativeLevel() {
     D3DCommonDevice* commonDevice = m_commonIntf->GetCommonD3DDevice();
 
-    if (unlikely(commonDevice == nullptr)) {
-      Logger::debug("<<< DDraw7Interface::TestCooperativeLevel: Proxy");
+    if (unlikely(commonDevice == nullptr))
       return m_proxy->TestCooperativeLevel();
-    }
-
-    Logger::debug(">>> DDraw7Interface::TestCooperativeLevel");
 
     d3d9::IDirect3DDevice9* d3d9Device = commonDevice->GetD3D9Device();
 
@@ -789,8 +719,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::GetDeviceIdentifier(LPDDDEVICEIDENTIFIER2 pDDDI, DWORD dwFlags) {
-    Logger::debug(">>> DDraw7Interface::GetDeviceIdentifier");
-
     if (unlikely(pDDDI == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -804,7 +732,6 @@ namespace dxvk {
     const d3d9::D3DADAPTER_IDENTIFIER9* adapterIdentifier9 = m_commonIntf->GetAdapterIdentifier();
     // This is typically the "2D accelerator" in the system
     if (unlikely(dwFlags & DDGDI_GETHOSTIDENTIFIER)) {
-      Logger::debug("DDraw7Interface::GetDeviceIdentifier: Retrieving secondary adapter info");
       CopyToStringArray(pDDDI->szDriver, "vga.dll");
       // The Matrox G400 TechDemo expects the description to be aligned with native
       CopyToStringArray(pDDDI->szDescription, "DirectDraw HAL");
@@ -816,7 +743,6 @@ namespace dxvk {
       pDDDI->guidDeviceIdentifier     = pDDDIproxy.guidDeviceIdentifier;
       pDDDI->dwWHQLLevel              = 0;
     } else {
-      Logger::debug("DDraw7Interface::GetDeviceIdentifier: Retrieving primary adapter info");
       memcpy(&pDDDI->szDriver,      &adapterIdentifier9->Driver,      sizeof(adapterIdentifier9->Driver));
       memcpy(&pDDDI->szDescription, &adapterIdentifier9->Description, sizeof(adapterIdentifier9->Description));
       // Neither ATI, nor Nvidia (Windows XP) native drivers at the time reported a version

--- a/src/ddraw/ddraw7/ddraw7_surface.cpp
+++ b/src/ddraw/ddraw7/ddraw7_surface.cpp
@@ -94,13 +94,17 @@ namespace dxvk {
     // Clear the cached depth stencil on the parent if matched
     if (unlikely(m_parentSurf != nullptr && m_commonSurf->IsDepthStencil()
       && m_parentSurf->GetAttachedDepthStencil() == this)) {
-      m_parentSurf->ClearAttachedDepthStencil();
+      m_parentSurf->SetAttachedDepthStencil(nullptr);
     }
 
     DDrawCommonInterface::RemoveWrappedSurface(this);
 
+    if (m_depthStencil != nullptr)
+      m_depthStencil->SetParentSurface(nullptr);
+
     // Release all public references on all attached surfaces
     for (auto & attachedSurface : m_attachedSurfaces) {
+      attachedSurface.second->SetParentSurface(nullptr);
       uint32_t attachedRef;
       do {
         attachedRef = attachedSurface.second->Release();
@@ -116,8 +120,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> DDraw7Surface::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
@@ -125,17 +127,14 @@ namespace dxvk {
 
     // Shouldn't ever be called in practice
     if (unlikely(riid == __uuidof(IDirect3DTexture))) {
-      Logger::debug("DDraw7Surface::QueryInterface: Query for IDirect3DTexture");
       return E_NOINTERFACE;
     }
     // Black & White queries for IDirect3DTexture2 for whatever reason...
     if (unlikely(riid == __uuidof(IDirect3DTexture2))) {
-      Logger::debug("DDraw7Surface::QueryInterface: Query for IDirect3DTexture2");
       return E_NOINTERFACE;
     }
     // Wrap IDirectDrawGammaControl, to potentially ignore application set gamma ramps
     if (riid == __uuidof(IDirectDrawGammaControl)) {
-      Logger::debug("DDraw7Surface::QueryInterface: Query for IDirectDrawGammaControl");
       void* gammaControlProxiedVoid = nullptr;
       // This can never reasonably fail
       m_proxy->QueryInterface(__uuidof(IDirectDrawGammaControl), &gammaControlProxiedVoid);
@@ -144,18 +143,13 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirectDrawColorControl))) {
-      Logger::debug("DDraw7Surface::QueryInterface: Query for IDirectDrawColorControl");
       return E_NOINTERFACE;
     }
     // Some games query for legacy ddraw surfaces
     if (unlikely(riid == __uuidof(IUnknown)
               || riid == __uuidof(IDirectDrawSurface))) {
-      if (m_commonSurf->GetDDSurface() != nullptr) {
-        Logger::debug("DDraw7Surface::QueryInterface: Query for existing IDirectDrawSurface");
+      if (m_commonSurf->GetDDSurface() != nullptr)
         return m_commonSurf->GetDDSurface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw7Surface::QueryInterface: Query for legacy IDirectDrawSurface");
 
       Com<IDirectDrawSurface> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -173,12 +167,8 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface2))) {
-      if (m_commonSurf->GetDD2Surface() != nullptr) {
-        Logger::debug("DDraw7Surface::QueryInterface: Query for existing IDirectDrawSurface2");
+      if (m_commonSurf->GetDD2Surface() != nullptr)
         return m_commonSurf->GetDD2Surface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw7Surface::QueryInterface: Query for legacy IDirectDrawSurface2");
 
       Com<IDirectDrawSurface2> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -196,12 +186,8 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface3))) {
-      if (m_commonSurf->GetDD3Surface() != nullptr) {
-        Logger::debug("DDraw7Surface::QueryInterface: Query for existing IDirectDrawSurface3");
+      if (m_commonSurf->GetDD3Surface() != nullptr)
         return m_commonSurf->GetDD3Surface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw7Surface::QueryInterface: Query for legacy IDirectDrawSurface3");
 
       Com<IDirectDrawSurface3> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -219,12 +205,8 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface4))) {
-      if (m_commonSurf->GetDD4Surface() != nullptr) {
-        Logger::debug("DDraw7Surface::QueryInterface: Query for existing IDirectDrawSurface4");
+      if (m_commonSurf->GetDD4Surface() != nullptr)
         return m_commonSurf->GetDD4Surface()->QueryInterface(riid, ppvObject);
-      }
-
-      Logger::debug("DDraw7Surface::QueryInterface: Query for legacy IDirectDrawSurface4");
 
       Com<IDirectDrawSurface4> ppvProxyObject;
       HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
@@ -255,8 +237,6 @@ namespace dxvk {
   // On IDirectDrawSurface7, this call will only attach DDSCAPS_ZBUFFER
   // type surfaces and will fail if called with any other surface type.
   HRESULT STDMETHODCALLTYPE DDraw7Surface::AddAttachedSurface(LPDIRECTDRAWSURFACE7 lpDDSAttachedSurface) {
-    Logger::debug("<<< DDraw7Surface::AddAttachedSurface: Proxy");
-
     if (unlikely(lpDDSAttachedSurface == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -279,17 +259,12 @@ namespace dxvk {
 
   // Docs: "The IDirectDrawSurface7::AddOverlayDirtyRect method is not currently implemented."
   HRESULT STDMETHODCALLTYPE DDraw7Surface::AddOverlayDirtyRect(LPRECT lpRect) {
-    Logger::debug(">>> DDraw7Surface::AddOverlayDirtyRect");
     return DDERR_UNSUPPORTED;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::Blt(LPRECT lpDestRect, LPDIRECTDRAWSURFACE7 lpDDSrcSurface, LPRECT lpSrcRect, DWORD dwFlags, LPDDBLTFX lpDDBltFx) {
-    Logger::debug("<<< DDraw7Surface::Blt: Proxy");
-
-    const bool sourceIsWrappedSurface = lpDDSrcSurface == nullptr ||
-                                        DDrawCommonInterface::IsWrappedSurface(lpDDSrcSurface);
-
-    if (unlikely(!sourceIsWrappedSurface)) {
+    if (unlikely(lpDDSrcSurface != nullptr
+             && !DDrawCommonInterface::IsWrappedSurface(lpDDSrcSurface))) {
       Logger::err("DDraw7Surface::Blt: Received an unwrapped source surface");
       return DDERR_UNSUPPORTED;
     }
@@ -354,17 +329,12 @@ namespace dxvk {
 
   // Docs: "The IDirectDrawSurface7::BltBatch method is not currently implemented."
   HRESULT STDMETHODCALLTYPE DDraw7Surface::BltBatch(LPDDBLTBATCH lpDDBltBatch, DWORD dwCount, DWORD dwFlags) {
-    Logger::debug(">>> DDraw7Surface::BltBatch");
     return DDERR_UNSUPPORTED;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::BltFast(DWORD dwX, DWORD dwY, LPDIRECTDRAWSURFACE7 lpDDSrcSurface, LPRECT lpSrcRect, DWORD dwTrans) {
-    Logger::debug("<<< DDraw7Surface::BltFast: Proxy");
-
-    const bool sourceIsWrappedSurface = lpDDSrcSurface == nullptr ||
-                                        DDrawCommonInterface::IsWrappedSurface(lpDDSrcSurface);
-
-    if (unlikely(!sourceIsWrappedSurface)) {
+    if (unlikely(lpDDSrcSurface != nullptr
+             && !DDrawCommonInterface::IsWrappedSurface(lpDDSrcSurface))) {
       Logger::err("DDraw7Surface::BltFast: Received an unwrapped source surface");
       return DDERR_UNSUPPORTED;
     }
@@ -431,12 +401,8 @@ namespace dxvk {
 
   // This call will only detach DDSCAPS_ZBUFFER type surfaces and will reject anything else.
   HRESULT STDMETHODCALLTYPE DDraw7Surface::DeleteAttachedSurface(DWORD dwFlags, LPDIRECTDRAWSURFACE7 lpDDSAttachedSurface) {
-    Logger::debug("<<< DDraw7Surface::DeleteAttachedSurface: Proxy");
-
-    const bool attachedSurfaceIsWrappedSurface = lpDDSAttachedSurface == nullptr ||
-                                                 DDrawCommonInterface::IsWrappedSurface(lpDDSAttachedSurface);
-
-    if (unlikely(!attachedSurfaceIsWrappedSurface)) {
+    if (unlikely(lpDDSAttachedSurface != nullptr
+             && !DDrawCommonInterface::IsWrappedSurface(lpDDSAttachedSurface))) {
       Logger::err("DDraw7Surface::DeleteAttachedSurface: Received an unwrapped surface");
       return DDERR_UNSUPPORTED;
     }
@@ -458,17 +424,15 @@ namespace dxvk {
     if (unlikely(FAILED(hr)))
       return hr;
 
-    if (likely(m_depthStencil == attachedSurf)) {
-      attachedSurf->ClearParentSurface();
+    attachedSurf->SetParentSurface(nullptr);
+
+    if (likely(m_depthStencil == attachedSurf))
       m_depthStencil = nullptr;
-    }
 
     return DD_OK;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::EnumAttachedSurfaces(LPVOID lpContext, LPDDENUMSURFACESCALLBACK7 lpEnumSurfacesCallback) {
-    Logger::debug(">>> DDraw7Surface::EnumAttachedSurfaces");
-
     if (unlikely(lpEnumSurfacesCallback == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -513,15 +477,12 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::EnumOverlayZOrders(DWORD dwFlags, LPVOID lpContext, LPDDENUMSURFACESCALLBACK7 lpfnCallback) {
-    Logger::debug("<<< DDraw7Surface::EnumOverlayZOrders: Proxy");
     return m_proxy->EnumOverlayZOrders(dwFlags, lpContext, lpfnCallback);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::Flip(LPDIRECTDRAWSURFACE7 lpDDSurfaceTargetOverride, DWORD dwFlags) {
-    const bool overrideIsWrappedSurface = lpDDSurfaceTargetOverride == nullptr ||
-                                          DDrawCommonInterface::IsWrappedSurface(lpDDSurfaceTargetOverride);
-
-    if (unlikely(!overrideIsWrappedSurface)) {
+    if (unlikely(lpDDSurfaceTargetOverride != nullptr
+             && !DDrawCommonInterface::IsWrappedSurface(lpDDSurfaceTargetOverride))) {
       Logger::err("DDraw7Surface::Flip: Received an unwrapped override surface");
       return DDERR_UNSUPPORTED;
     }
@@ -529,39 +490,29 @@ namespace dxvk {
     Com<DDraw7Surface> overrideSurf = static_cast<DDraw7Surface*>(lpDDSurfaceTargetOverride);
 
     d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
-    if (likely(d3d9Device != nullptr)) {
-      Logger::debug("*** DDraw7Surface::Flip: Presenting");
-
+    // Overlays can have odd video formats which DXVK doesn't support for RT
+    // use, so let DDraw present in case the flipped surface is an overlay
+    if (likely(d3d9Device != nullptr && !m_commonSurf->IsOverlay())) {
       // Lost surfaces are not flippable
       HRESULT hr = m_proxy->IsLost();
-      if (unlikely(FAILED(hr))) {
-        Logger::debug("DDraw7Surface::Flip: Lost surface");
+      if (unlikely(FAILED(hr)))
         return hr;
-      }
 
-      if (unlikely(!(m_commonSurf->IsFrontBuffer() || m_commonSurf->IsBackBufferOrFlippable()))) {
-        Logger::debug("DDraw7Surface::Flip: Unflippable surface");
+      if (unlikely(!(m_commonSurf->IsFrontBuffer() || m_commonSurf->IsBackBufferOrFlippable())))
         return DDERR_NOTFLIPPABLE;
-      }
 
       const bool exclusiveMode = m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE;
 
       // Non-exclusive mode validations
-      if (unlikely(m_commonSurf->IsPrimarySurface() && !exclusiveMode)) {
-        Logger::debug("DDraw7Surface::Flip: Primary surface flip in non-exclusive mode");
+      if (unlikely(m_commonSurf->IsPrimarySurface() && !exclusiveMode))
         return DDERR_NOEXCLUSIVEMODE;
-      }
 
       // Exclusive mode validations
-      if (unlikely(m_commonSurf->IsBackBufferOrFlippable() && exclusiveMode)) {
-        Logger::debug("DDraw7Surface::Flip: Back buffer flip in exclusive mode");
+      if (unlikely(m_commonSurf->IsBackBufferOrFlippable() && exclusiveMode))
         return DDERR_NOTFLIPPABLE;
-      }
 
-      if (unlikely(overrideSurf != nullptr && !overrideSurf->GetCommonSurface()->IsBackBufferOrFlippable())) {
-        Logger::debug("DDraw7Surface::Flip: Unflippable override surface");
+      if (unlikely(overrideSurf != nullptr && !overrideSurf->GetCommonSurface()->IsBackBufferOrFlippable()))
         return DDERR_NOTFLIPPABLE;
-      }
 
       // If the interface is waiting for VBlank and we get a no VSync flip, switch
       // to doing immediate presents by resetting the swapchain appropriately
@@ -595,9 +546,16 @@ namespace dxvk {
         }
       }
 
+      // Workaround for The Sims/other games flipping a different
+      // swapchain than the one set on the current D3D device
+      if (unlikely(m_commonIntf->GetOptions()->forceRTFlip && m_commonSurf->IsPrimarySurface())) {
+        m_nextFlippable = m_commonSurf->GetCommonD3DDevice()->GetCurrentRenderTarget7();
+      }
+
       if (likely(m_nextFlippable != nullptr)) {
-        if (unlikely(m_commonIntf->GetOptions()->emulateFrontBuffer)) {
+        if (m_commonIntf->GetOptions()->emulateFrontBuffer) {
           InitializeOrUploadD3D9();
+          // Workaround for front buffer image retention issues
           if (m_shadowSurf != nullptr && m_nextFlippable->GetCommonSurface()->IsDDrawSurfaceDirty())
             GetShadowOrProxied()->BltFast(0, 0, m_nextFlippable->GetShadowOrProxied(), nullptr, DDBLTFAST_NOCOLORKEY);
         }
@@ -609,8 +567,6 @@ namespace dxvk {
       d3d9Device->Present(NULL, NULL, NULL, NULL);
 
     } else {
-      Logger::debug("<<< DDraw7Surface::Flip: Proxy");
-
       // Update the VBlank wait status based on the flip flags
       m_commonIntf->SetWaitForVBlank(IsVSyncFlipFlag(dwFlags));
 
@@ -625,8 +581,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::GetAttachedSurface(LPDDSCAPS2 lpDDSCaps, LPDIRECTDRAWSURFACE7 *lplpDDAttachedSurface) {
-    Logger::debug("<<< DDraw7Surface::GetAttachedSurface: Proxy");
-
     if (unlikely(lpDDSCaps == nullptr || lplpDDAttachedSurface == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -657,7 +611,6 @@ namespace dxvk {
     // These are rather common, as some games query expecting to get nothing in return, for
     // example it's a common use case to query the mip attach chain until nothing is returned
     if (FAILED(hr)) {
-      Logger::debug("DDraw7Surface::GetAttachedSurface: Failed to find the requested surface");
       *lplpDDAttachedSurface = surface.ptr();
       return hr;
     }
@@ -689,8 +642,6 @@ namespace dxvk {
 
   // Blitting can be done at any time and completes within its call frame
   HRESULT STDMETHODCALLTYPE DDraw7Surface::GetBltStatus(DWORD dwFlags) {
-    Logger::debug(">>> DDraw7Surface::GetBltStatus");
-
     if (likely(dwFlags == DDGBS_CANBLT || dwFlags == DDGBS_ISBLTDONE))
       return DD_OK;
 
@@ -698,8 +649,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::GetCaps(LPDDSCAPS2 lpDDSCaps) {
-    Logger::debug(">>> DDraw7Surface::GetCaps");
-
     if (unlikely(lpDDSCaps == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -709,8 +658,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::GetClipper(LPDIRECTDRAWCLIPPER *lplpDDClipper) {
-    Logger::debug(">>> DDraw7Surface::GetClipper");
-
     if (unlikely(lplpDDClipper == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -727,12 +674,20 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::GetColorKey(DWORD dwFlags, LPDDCOLORKEY lpDDColorKey) {
-    Logger::debug("<<< DDraw7Surface::GetColorKey: Proxy");
     return m_proxy->GetColorKey(dwFlags, lpDDColorKey);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::GetDC(HDC *lphDC) {
-    Logger::debug("<<< DDraw7Surface::GetDC: Proxy");
+    // Direct D3D9 path which can sometimes be faster (and other times slower)
+    if (unlikely(m_commonIntf->GetOptions()->forceDCForwarding && m_commonSurf->IsInitialized())) {
+      InitializeOrUploadD3D9();
+
+      HRESULT hr = m_commonSurf->GetD3D9Surface()->GetDC(lphDC);
+      if (unlikely(FAILED(hr)))
+        return DDERR_INVALIDPARAMS;
+
+      return DD_OK;
+    }
 
     // Write back any dirty surface data from bound D3D9 back buffers or depth stencils
     DownloadSurfaceData();
@@ -742,8 +697,6 @@ namespace dxvk {
 
   // Flipping can be done at any time and completes within its call frame
   HRESULT STDMETHODCALLTYPE DDraw7Surface::GetFlipStatus(DWORD dwFlags) {
-    Logger::debug(">>> DDraw7Surface::GetFlipStatus");
-
     if (likely(dwFlags == DDGFS_CANFLIP || dwFlags == DDGFS_ISFLIPDONE))
       return DD_OK;
 
@@ -751,13 +704,10 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::GetOverlayPosition(LPLONG lplX, LPLONG lplY) {
-    Logger::debug("<<< DDraw7Surface::GetOverlayPosition: Proxy");
     return m_proxy->GetOverlayPosition(lplX, lplY);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::GetPalette(LPDIRECTDRAWPALETTE *lplpDDPalette) {
-    Logger::debug(">>> DDraw7Surface::GetPalette");
-
     if (unlikely(lplpDDPalette == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -774,8 +724,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::GetPixelFormat(LPDDPIXELFORMAT lpDDPixelFormat) {
-    Logger::debug(">>> DDraw7Surface::GetPixelFormat");
-
     if (unlikely(lpDDPixelFormat == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -785,8 +733,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::GetSurfaceDesc(LPDDSURFACEDESC2 lpDDSurfaceDesc) {
-    Logger::debug(">>> DDraw7Surface::GetSurfaceDesc");
-
     if (unlikely(lpDDSurfaceDesc == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -801,18 +747,14 @@ namespace dxvk {
   // According to the docs: "Because the DirectDrawSurface object is initialized
   // when it's created, this method always returns DDERR_ALREADYINITIALIZED."
   HRESULT STDMETHODCALLTYPE DDraw7Surface::Initialize(LPDIRECTDRAW lpDD, LPDDSURFACEDESC2 lpDDSurfaceDesc) {
-    Logger::debug(">>> DDraw7Surface::Initialize");
     return DDERR_ALREADYINITIALIZED;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::IsLost() {
-    Logger::debug("<<< DDraw7Surface::IsLost: Proxy");
     return m_proxy->IsLost();
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::Lock(LPRECT lpDestRect, LPDDSURFACEDESC2 lpDDSurfaceDesc, DWORD dwFlags, HANDLE hEvent) {
-    Logger::debug("<<< DDraw7Surface::Lock: Proxy");
-
     // Write back any dirty surface data from bound D3D9 back buffers or depth stencils
     DownloadSurfaceData();
 
@@ -820,7 +762,16 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::ReleaseDC(HDC hDC) {
-    Logger::debug("<<< DDraw7Surface::ReleaseDC: Proxy");
+    // Direct D3D9 path which can sometimes be faster (and other times slower)
+    if (unlikely(m_commonIntf->GetOptions()->forceDCForwarding && m_commonSurf->IsInitialized())) {
+      HRESULT hr = m_commonSurf->GetD3D9Surface()->ReleaseDC(hDC);
+      if (unlikely(FAILED(hr)))
+        return DDERR_INVALIDPARAMS;
+
+      m_commonSurf->DirtyD3D9Surface();
+
+      return DD_OK;
+    }
 
     HRESULT hr = GetShadowOrProxied()->ReleaseDC(hDC);
     if (unlikely(FAILED(hr)))
@@ -844,13 +795,10 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::Restore() {
-    Logger::debug("<<< DDraw7Surface::Restore: Proxy");
     return m_proxy->Restore();
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::SetClipper(LPDIRECTDRAWCLIPPER lpDDClipper) {
-    Logger::debug("<<< DDraw7Surface::SetClipper: Proxy");
-
     // A nullptr lpDDClipper gets the current clipper detached
     if (lpDDClipper == nullptr) {
       HRESULT hr = m_proxy->SetClipper(lpDDClipper);
@@ -870,19 +818,16 @@ namespace dxvk {
       // Retrieve a hWnd, if needed, during clipper attachment
       HWND hWnd = nullptr;
       hr = ddrawClipper->GetProxied()->GetHWnd(&hWnd);
-      if (unlikely(FAILED(hr))) {
-        Logger::debug("DDraw7Surface::SetClipper: Failed to retrieve hWnd");
-      } else {
-        m_commonIntf->SetHWND(hWnd);
-      }
+      if (unlikely(FAILED(hr)))
+        return DD_OK;
+
+      m_commonIntf->SetHWND(hWnd);
     }
 
     return DD_OK;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::SetColorKey(DWORD dwFlags, LPDDCOLORKEY lpDDColorKey) {
-    Logger::debug("<<< DDraw7Surface::SetColorKey: Proxy");
-
     // The Combat Mission series of games set a color key which is
     // outside the color range of the surface they are setting it on...
     // clamp it to the surface color depth in that case. This doesn't
@@ -918,13 +863,10 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::SetOverlayPosition(LONG lX, LONG lY) {
-    Logger::debug("<<< DDraw7Surface::SetOverlayPosition: Proxy");
     return m_proxy->SetOverlayPosition(lX, lY);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::SetPalette(LPDIRECTDRAWPALETTE lpDDPalette) {
-    Logger::debug("<<< DDraw7Surface::SetPalette: Proxy");
-
     // A nullptr lpDDPalette gets the current palette detached
     if (lpDDPalette == nullptr) {
       HRESULT hr = GetShadowOrProxied()->SetPalette(lpDDPalette);
@@ -946,8 +888,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::Unlock(LPRECT lpSurfaceData) {
-    Logger::debug("<<< DDraw7Surface::Unlock: Proxy");
-
     HRESULT hr = GetShadowOrProxied()->Unlock(lpSurfaceData);
     if (unlikely(FAILED(hr)))
       return hr;
@@ -970,8 +910,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::UpdateOverlay(LPRECT lpSrcRect, LPDIRECTDRAWSURFACE7 lpDDDestSurface, LPRECT lpDestRect, DWORD dwFlags, LPDDOVERLAYFX lpDDOverlayFx) {
-    Logger::debug("<<< DDraw7Surface::UpdateOverlay: Proxy");
-
     if (unlikely(lpDDDestSurface == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -986,17 +924,12 @@ namespace dxvk {
 
   // Docs: "The IDirectDrawSurface7::UpdateOverlayDisplay method is not currently implemented."
   HRESULT STDMETHODCALLTYPE DDraw7Surface::UpdateOverlayDisplay(DWORD dwFlags) {
-    Logger::debug(">>> DDraw7Surface::UpdateOverlayDisplay");
     return DDERR_UNSUPPORTED;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::UpdateOverlayZOrder(DWORD dwFlags, LPDIRECTDRAWSURFACE7 lpDDSReference) {
-    Logger::debug("<<< DDraw7Surface::UpdateOverlayZOrder: Proxy");
-
-    const bool referenceIsWrappedSurface = lpDDSReference == nullptr ||
-                                           DDrawCommonInterface::IsWrappedSurface(lpDDSReference);
-
-    if (unlikely(!referenceIsWrappedSurface)) {
+    if (unlikely(lpDDSReference != nullptr
+              && !DDrawCommonInterface::IsWrappedSurface(lpDDSReference))) {
       Logger::err("DDraw7Surface::UpdateOverlayZOrder: Received an unwrapped surface");
       return DDERR_UNSUPPORTED;
     }
@@ -1010,30 +943,30 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::GetDDInterface(LPVOID *lplpDD) {
-    Logger::debug(">>> DDraw7Surface::GetDDInterface");
-
     if (unlikely(lplpDD == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    // Was an easy footgun to return a proxied interface
+    InitReturnPtr(lplpDD);
+
+    if (unlikely(m_parent == nullptr)) {
+      Logger::err("DDraw7Surface::GetDDInterface: Found no valid parent interface");
+      return DDERR_NOTFOUND;
+    }
+
     *lplpDD = ref(m_parent);
 
     return DD_OK;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::PageLock(DWORD dwFlags) {
-    Logger::debug("<<< DDraw7Surface::PageLock: Proxy");
     return m_proxy->PageLock(dwFlags);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::PageUnlock(DWORD dwFlags) {
-    Logger::debug("<<< DDraw7Surface::PageUnlock: Proxy");
     return m_proxy->PageUnlock(dwFlags);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::SetSurfaceDesc(LPDDSURFACEDESC2 lpDDSD, DWORD dwFlags) {
-    Logger::debug("<<< DDraw7Surface::SetSurfaceDesc: Proxy");
-
     // Can be used only to set the surface data and pixel format
     // used by an explicit system-memory surface (will be validated)
     HRESULT hr = m_proxy->SetSurfaceDesc(lpDDSD, dwFlags);
@@ -1053,27 +986,22 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::SetPrivateData(REFGUID tag, LPVOID pData, DWORD cbSize, DWORD dwFlags) {
-    Logger::debug("<<< DDraw7Surface::SetPrivateData: Proxy");
     return m_proxy->SetPrivateData(tag, pData, cbSize, dwFlags);
   }
 
   // Silent Hunter II needs to get these from the proxy surface, as it
   // sets them otherwise... it doesn't call SetPrivateData at all
   HRESULT STDMETHODCALLTYPE DDraw7Surface::GetPrivateData(REFGUID tag, LPVOID pBuffer, LPDWORD pcbBufferSize) {
-    Logger::debug("<<< DDraw7Surface::GetPrivateData: Proxy");
     return m_proxy->GetPrivateData(tag, pBuffer, pcbBufferSize);
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::FreePrivateData(REFGUID tag) {
-    Logger::debug("<<< DDraw7Surface::FreePrivateData: Proxy");
     return m_proxy->FreePrivateData(tag);
   }
 
   // Docs: "The only defined uniqueness value is 0, indicating that the surface
   // is likely to be changing beyond the control of DirectDraw."
   HRESULT STDMETHODCALLTYPE DDraw7Surface::GetUniquenessValue(LPDWORD pValue) {
-    Logger::debug(">>> DDraw7Surface::GetUniquenessValue");
-
     if (unlikely(pValue == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -1083,18 +1011,13 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::ChangeUniquenessValue() {
-    Logger::debug(">>> DDraw7Surface::ChangeUniquenessValue");
     return DD_OK;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::SetPriority(DWORD prio) {
-    Logger::debug(">>> DDraw7Surface::SetPriority");
-
     m_commonSurf->RefreshD3D9Device();
-    if (unlikely(!m_commonSurf->IsInitialized())) {
-      Logger::debug("DDraw7Surface::SetPriority: Not yet initialized");
+    if (unlikely(!m_commonSurf->IsInitialized()))
       return m_proxy->SetPriority(prio);
-    }
 
     if (unlikely(!m_commonSurf->IsManaged()))
       return DDERR_INVALIDOBJECT;
@@ -1109,13 +1032,9 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::GetPriority(LPDWORD prio) {
-    Logger::debug(">>> DDraw7Surface::GetPriority");
-
     m_commonSurf->RefreshD3D9Device();
-    if (unlikely(!m_commonSurf->IsInitialized())) {
-      Logger::debug("DDraw7Surface::GetPriority: Not yet initialized");
+    if (unlikely(!m_commonSurf->IsInitialized()))
       return m_proxy->GetPriority(prio);
-    }
 
     if (unlikely(prio == nullptr))
       return DDERR_INVALIDPARAMS;
@@ -1129,13 +1048,9 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::SetLOD(DWORD lod) {
-    Logger::debug("<<< DDraw7Surface::SetLOD: Proxy");
-
     m_commonSurf->RefreshD3D9Device();
-    if (unlikely(!m_commonSurf->IsInitialized())) {
-      Logger::debug("DDraw7Surface::SetLOD: Not yet initialized");
+    if (unlikely(!m_commonSurf->IsInitialized()))
       return m_proxy->SetLOD(lod);
-    }
 
     if (unlikely(!m_commonSurf->IsManaged()))
       return DDERR_INVALIDOBJECT;
@@ -1157,13 +1072,9 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::GetLOD(LPDWORD lod) {
-    Logger::debug(">>> DDraw7Surface::GetLOD");
-
     m_commonSurf->RefreshD3D9Device();
-    if (unlikely(!m_commonSurf->IsInitialized())) {
-      Logger::debug("DDraw7Surface::GetLOD: Not yet initialized");
+    if (unlikely(!m_commonSurf->IsInitialized()))
       return m_proxy->GetLOD(lod);
-    }
 
     if (unlikely(lod == nullptr))
       return DDERR_INVALIDPARAMS;
@@ -1238,10 +1149,8 @@ namespace dxvk {
     d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
 
     // Fast skip
-    if (unlikely(d3d9Device == nullptr)) {
-      Logger::debug("DDraw7Surface::InitializeOrUploadD3D9: Null device, can't initialize right now");
+    if (unlikely(d3d9Device == nullptr))
       return DD_OK;
-    }
 
     if (unlikely(!m_commonSurf->IsInitialized())) {
       if (m_commonSurf->IsTextureOrCubeMap())
@@ -1275,19 +1184,15 @@ namespace dxvk {
       m_commonSurf->RefreshD3D9Device();
 
     if (unlikely(m_commonSurf->IsD3D9BackBuffer())) {
-      Logger::debug("DDraw7Surface::DownloadSurfaceData: Surface is a bound swapchain surface");
-
       if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
-        Logger::debug(str::format("DDraw7Surface::DownloadSurfaceData: Downloading nr. [[7-", m_surfCount, "]]"));
+        //Logger::debug(str::format("DDraw7Surface::DownloadSurfaceData: Downloading nr. [[7-", m_surfCount, "]]"));
         BlitToDDrawSurface<IDirectDrawSurface7, DDSURFACEDESC2>(GetShadowOrProxied(), m_commonSurf->GetD3D9Surface(),
                                                                 m_commonSurf->IsDXTFormat());
         m_commonSurf->UnDirtyD3D9Surface();
       }
     } else if (unlikely(m_commonSurf->IsD3D9DepthStencil())) {
-      Logger::debug("DDraw7Surface::DownloadSurfaceData: Surface is a bound depth stencil");
-
       if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
-        Logger::debug(str::format("DDraw7Surface::DownloadSurfaceData: Downloading nr. [[7-", m_surfCount, "]]"));
+        //Logger::debug(str::format("DDraw7Surface::DownloadSurfaceData: Downloading nr. [[7-", m_surfCount, "]]"));
         BlitToDDrawSurface<IDirectDrawSurface7, DDSURFACEDESC2>(m_proxy.ptr(), m_commonSurf->GetD3D9Surface(),
                                                                 m_commonSurf->IsDXTFormat());
         m_commonSurf->UnDirtyD3D9Surface();
@@ -1331,10 +1236,8 @@ namespace dxvk {
         Logger::debug(str::format("DDraw7Surface::UpdateMipMapCount: Mismatch with declared ", desc2->dwMipMapCount, " mip levels"));
     }
 
-    if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps)) {
-      Logger::debug("DDraw7Surface::UpdateMipMapCount: Using auto mip map generation");
+    if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps))
       mipCount = 0;
-    }
 
     m_commonSurf->SetMipCount(mipCount);
   }
@@ -1364,8 +1267,6 @@ namespace dxvk {
   }
 
   inline void DDraw7Surface::InitializeAllCubeMapSurfaces() {
-    Logger::debug("DDraw7Surface::InitializeAllCubeMapSurfaces: Retrieving cube map faces");
-
     CubeMapAttachedSurfaces cubeMapAttachedSurfaces;
     m_proxy->EnumAttachedSurfaces(&cubeMapAttachedSurfaces, EnumAndAttachCubeMapFacesCallback);
 
@@ -1378,31 +1279,26 @@ namespace dxvk {
     // We can't know in advance which faces have been generated,
     // so check them one by one, initialize and bind as needed
     if (cubeMapAttachedSurfaces.negativeX != nullptr) {
-      Logger::debug("DDraw7Surface::InitializeAllCubeMapSurfaces: Detected negative X cube map face");
       m_cubeMapSurfaces[1] = cubeMapAttachedSurfaces.negativeX;
       InitializeAndAttachCubeFace(cubeMapAttachedSurfaces.negativeX, m_commonSurf->GetD3D9CubeTexture(),
                                   d3d9::D3DCUBEMAP_FACE_NEGATIVE_X);
     }
     if (cubeMapAttachedSurfaces.positiveY != nullptr) {
-      Logger::debug("DDraw7Surface::InitializeAllCubeMapSurfaces: Detected positive Y cube map face");
       m_cubeMapSurfaces[2] = cubeMapAttachedSurfaces.positiveY;
       InitializeAndAttachCubeFace(cubeMapAttachedSurfaces.positiveY, m_commonSurf->GetD3D9CubeTexture(),
                                   d3d9::D3DCUBEMAP_FACE_POSITIVE_Y);
     }
     if (cubeMapAttachedSurfaces.negativeY != nullptr) {
-      Logger::debug("DDraw7Surface::InitializeAllCubeMapSurfaces: Detected negative Y cube map face");
       m_cubeMapSurfaces[3] = cubeMapAttachedSurfaces.negativeY;
       InitializeAndAttachCubeFace(cubeMapAttachedSurfaces.negativeY, m_commonSurf->GetD3D9CubeTexture(),
                                   d3d9::D3DCUBEMAP_FACE_NEGATIVE_Y);
     }
     if (cubeMapAttachedSurfaces.positiveZ != nullptr) {
-      Logger::debug("DDraw7Surface::InitializeAllCubeMapSurfaces: Detected positive Z cube map face");
       m_cubeMapSurfaces[4] = cubeMapAttachedSurfaces.positiveZ;
       InitializeAndAttachCubeFace(cubeMapAttachedSurfaces.positiveZ, m_commonSurf->GetD3D9CubeTexture(),
                                   d3d9::D3DCUBEMAP_FACE_POSITIVE_Z);
     }
     if (cubeMapAttachedSurfaces.negativeZ != nullptr) {
-      Logger::debug("DDraw7Surface::InitializeAllCubeMapSurfaces: Detected negative Z cube map face");
       m_cubeMapSurfaces[5] = cubeMapAttachedSurfaces.negativeZ;
       InitializeAndAttachCubeFace(cubeMapAttachedSurfaces.negativeZ, m_commonSurf->GetD3D9CubeTexture(),
                                   d3d9::D3DCUBEMAP_FACE_NEGATIVE_Z);
@@ -1414,7 +1310,7 @@ namespace dxvk {
     if (!m_commonSurf->IsDDrawSurfaceDirty())
       return DD_OK;
 
-    Logger::debug(str::format("DDraw7Surface::UploadSurfaceData: Uploading nr. [[7-", m_surfCount, "]]"));
+    //Logger::debug(str::format("DDraw7Surface::UploadSurfaceData: Uploading nr. [[7-", m_surfCount, "]]"));
 
     // Cube maps will also get marked as textures, so need to be handled first
     if (unlikely(m_commonSurf->IsCubeMap())) {
@@ -1424,33 +1320,21 @@ namespace dxvk {
       const bool     isDXTFormat = m_commonSurf->IsDXTFormat();
       if (likely(m_cubeMapSurfaces[0] != nullptr)) {
         BlitToD3D9CubeMap(m_commonSurf->GetD3D9CubeTexture(), m_cubeMapSurfaces[0], mipCount, isDXTFormat);
-      } else {
-        Logger::debug("DDraw7Surface::UploadSurfaceData: Positive X face is null, skpping");
       }
       if (likely(m_cubeMapSurfaces[1] != nullptr)) {
         BlitToD3D9CubeMap(m_commonSurf->GetD3D9CubeTexture(), m_cubeMapSurfaces[1], mipCount, isDXTFormat);
-      } else {
-        Logger::debug("DDraw7Surface::UploadSurfaceData: Negative X face is null, skpping");
       }
       if (likely(m_cubeMapSurfaces[2] != nullptr)) {
         BlitToD3D9CubeMap(m_commonSurf->GetD3D9CubeTexture(), m_cubeMapSurfaces[2], mipCount, isDXTFormat);
-      } else {
-        Logger::debug("DDraw7Surface::UploadSurfaceData: Positive Y face is null, skpping");
       }
       if (likely(m_cubeMapSurfaces[3] != nullptr)) {
         BlitToD3D9CubeMap(m_commonSurf->GetD3D9CubeTexture(), m_cubeMapSurfaces[3], mipCount, isDXTFormat);
-      } else {
-        Logger::debug("DDraw7Surface::UploadSurfaceData: Negative Y face is null, skpping");
       }
       if (likely(m_cubeMapSurfaces[4] != nullptr)) {
         BlitToD3D9CubeMap(m_commonSurf->GetD3D9CubeTexture(), m_cubeMapSurfaces[4], mipCount, isDXTFormat);
-      } else {
-        Logger::debug("DDraw7Surface::UploadSurfaceData: Positive Z face is null, skpping");
       }
       if (likely(m_cubeMapSurfaces[5] != nullptr)) {
         BlitToD3D9CubeMap(m_commonSurf->GetD3D9CubeTexture(), m_cubeMapSurfaces[5], mipCount, isDXTFormat);
-      } else {
-        Logger::debug("DDraw7Surface::UploadSurfaceData: Negative Z face is null, skpping");
       }
     // Blit all the mips for textures
     } else if (m_commonSurf->IsTexture()) {
@@ -1458,9 +1342,6 @@ namespace dxvk {
                                                              m_commonSurf->GetMipCount(), m_commonSurf->IsDXTFormat());
     // Blit surfaces directly
     } else {
-      if (unlikely(m_commonSurf->IsDepthStencil()))
-        Logger::debug("DDrawSurface::UploadSurfaceData: Uploading depth stencil");
-
       BlitToD3D9Surface<IDirectDrawSurface7, DDSURFACEDESC2>(m_commonSurf->GetD3D9Surface(), GetShadowOrProxied(),
                                                              m_commonSurf->IsDXTFormat());
     }

--- a/src/ddraw/ddraw7/ddraw7_surface.h
+++ b/src/ddraw/ddraw7/ddraw7_surface.h
@@ -177,22 +177,17 @@ namespace dxvk {
       return m_depthStencil.ptr();
     }
 
-    void ClearAttachedDepthStencil() {
-      m_depthStencil = nullptr;
+    void SetParentSurface(DDraw7Surface* surface) {
+      m_parentSurf = surface;
+
+      if (m_parentSurf != nullptr)
+        m_commonSurf->SetIsAttached(true);
+      else
+        m_commonSurf->SetIsAttached(false);
     }
 
     DDraw7Surface* GetParentSurface() const {
       return m_parentSurf;
-    }
-
-    void SetParentSurface(DDraw7Surface* surface) {
-      m_parentSurf = surface;
-      m_commonSurf->SetIsAttached(true);
-    }
-
-    void ClearParentSurface() {
-      m_parentSurf = nullptr;
-      m_commonSurf->SetIsAttached(false);
     }
 
   private:

--- a/src/ddraw/ddraw_class_factory.cpp
+++ b/src/ddraw/ddraw_class_factory.cpp
@@ -6,10 +6,27 @@ namespace dxvk {
     : m_createInstance ( createInstance ) {
   }
 
-  HRESULT STDMETHODCALLTYPE DDrawClassFactory::CreateInstance(IUnknown *pUnkOuter, REFIID riid, void **ppvObject) {
-    Logger::debug(">>> DDrawClassFactory::CreateInstance");
+  HRESULT STDMETHODCALLTYPE DDrawClassFactory::QueryInterface(REFIID riid, void** ppvObject) {
+    if (unlikely(ppvObject == nullptr))
+      return E_POINTER;
 
+    InitReturnPtr(ppvObject);
+
+    if (riid == __uuidof(IUnknown) || riid == __uuidof(IClassFactory)) {
+      *ppvObject = ref(this);
+      return S_OK;
+    }
+
+    return E_NOINTERFACE;
+  }
+
+  HRESULT STDMETHODCALLTYPE DDrawClassFactory::CreateInstance(IUnknown *pUnkOuter, REFIID riid, void **ppvObject) {
     return m_createInstance(pUnkOuter, riid, ppvObject);
+  }
+
+  HRESULT STDMETHODCALLTYPE DDrawClassFactory::LockServer(BOOL fLock) {
+    Logger::warn("!!! DDrawClassFactory::LockServer: Stub");
+    return S_OK;
   }
 
 }

--- a/src/ddraw/ddraw_class_factory.h
+++ b/src/ddraw/ddraw_class_factory.h
@@ -12,28 +12,11 @@ namespace dxvk {
 
     DDrawClassFactory(FunctionType createInstance);
 
+    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject);
+
     HRESULT STDMETHODCALLTYPE CreateInstance(IUnknown *pUnkOuter, REFIID riid, void **ppvObject);
 
-    HRESULT STDMETHODCALLTYPE LockServer(BOOL fLock) {
-      Logger::warn("!!! DDrawClassFactory::LockServer: Stub");
-      return S_OK;
-    }
-
-    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject) {
-      Logger::debug(">>> DDrawClassFactory::QueryInterface");
-
-      if (unlikely(ppvObject == nullptr))
-        return E_POINTER;
-
-      InitReturnPtr(ppvObject);
-
-      if (riid == __uuidof(IUnknown) || riid == __uuidof(IClassFactory)) {
-        *ppvObject = ref(this);
-        return S_OK;
-      }
-
-      return E_NOINTERFACE;
-    }
+    HRESULT STDMETHODCALLTYPE LockServer(BOOL fLock);
 
   private:
 

--- a/src/ddraw/ddraw_clipper.cpp
+++ b/src/ddraw/ddraw_clipper.cpp
@@ -16,8 +16,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawClipper::Initialize(LPDIRECTDRAW lpDD, DWORD dwFlags) {
-    Logger::debug(">>> DDrawClipper::Initialize");
-
     if (unlikely(m_isInitialized))
       return DDERR_ALREADYINITIALIZED;
 
@@ -27,8 +25,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawClipper::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> DDrawClipper::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
@@ -46,23 +42,18 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawClipper::GetClipList(LPRECT lpRect, LPRGNDATA lpClipList, LPDWORD lpdwSize) {
-    Logger::debug("<<< DDrawClipper::GetClipList: Proxy");
     return m_proxy->GetClipList(lpRect, lpClipList, lpdwSize);
   }
 
   HRESULT STDMETHODCALLTYPE DDrawClipper::IsClipListChanged(BOOL *lpbChanged) {
-    Logger::debug("<<< DDrawClipper::IsClipListChanged: Proxy");
     return m_proxy->IsClipListChanged(lpbChanged);
   }
 
   HRESULT STDMETHODCALLTYPE DDrawClipper::SetClipList(LPRGNDATA lpClipList, DWORD dwFlags) {
-    Logger::debug("<<< DDrawClipper::SetClipList: Proxy");
     return m_proxy->SetClipList(lpClipList, dwFlags);
   }
 
   HRESULT STDMETHODCALLTYPE DDrawClipper::SetHWnd(DWORD dwFlags, HWND hWnd) {
-    Logger::debug("<<< DDrawClipper::SetHWnd: Proxy");
-
     HRESULT hr = m_proxy->SetHWnd(dwFlags, hWnd);
     if (unlikely(FAILED(hr)))
       return hr;
@@ -70,7 +61,6 @@ namespace dxvk {
     // The Eschalon: Book I launcher creates a device before attaching the clipper to
     // the primary surface, but right after it sets a HWND on the newly created clipper
     if (unlikely(m_commonIntf != nullptr && m_commonIntf->GetHWND() == nullptr)) {
-      Logger::debug("DDrawClipper::SetHWnd: Caching passed hWnd");
       // Only set the cached hWnd if it's absent
       m_commonIntf->SetHWND(hWnd);
     }
@@ -79,7 +69,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawClipper::GetHWnd(HWND *lphWnd) {
-    Logger::debug("<<< DDrawClipper::GetHWnd: Proxy");
     return m_proxy->GetHWnd(lphWnd);
   }
 

--- a/src/ddraw/ddraw_common_interface.h
+++ b/src/ddraw/ddraw_common_interface.h
@@ -147,14 +147,6 @@ namespace dxvk {
       return m_ps;
     }
 
-    void SetDDrawRenderTarget(DDrawCommonSurface* rt) {
-      m_rt = rt;
-    }
-
-    DDrawCommonSurface* GetDDrawRenderTarget() {
-      return m_rt;
-    }
-
     DDrawModeSize* GetModeSize() {
       return &m_modeSize;
     }
@@ -230,7 +222,6 @@ namespace dxvk {
     DWORD                             m_cooperativeLevel   = 0;
 
     DDrawCommonSurface*               m_ps                 = nullptr;
-    DDrawCommonSurface*               m_rt                 = nullptr;
     DDrawModeSize                     m_modeSize           = { };
 
     d3d9::D3DADAPTER_IDENTIFIER9      m_adapterIdentifier9 = { };

--- a/src/ddraw/ddraw_common_surface.cpp
+++ b/src/ddraw/ddraw_common_surface.cpp
@@ -158,12 +158,12 @@ namespace dxvk {
 
     if (unlikely(dwHeight == 0 || dwWidth == 0)) {
       Logger::err("DDrawCommonSurface::InitializeD3D9: Surface has 0 height or width");
-      return DDERR_GENERIC;
+      return DDERR_UNSUPPORTED;
     }
 
     if (unlikely(m_format9 == d3d9::D3DFMT_UNKNOWN)) {
       Logger::err("DDrawCommonSurface::InitializeD3D9: Surface has an unknown format");
-      return DDERR_GENERIC;
+      return DDERR_UNSUPPORTED;
     }
 
     // Don't initialize P8 textures/surfaces since we don't support them.
@@ -176,7 +176,6 @@ namespace dxvk {
         Logger::warn("DDrawCommonSurface::InitializeD3D9: Unsupported format D3DFMT_P8");
 
       return DD_OK;
-
     // Similarly, D3DFMT_R3G3B2 isn't supported by D3D9 dxvk, however some
     // applications require it to be supported by ddraw, even if they do not
     // use it. Simply ignore any D3DFMT_R3G3B2 textures/surfaces for now.
@@ -213,13 +212,13 @@ namespace dxvk {
     // isn't supported in D3D9, but we have a D3D7 exception in place.
     //
     if (IsRenderTarget() || initRenderTarget) {
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Usage: D3DUSAGE_RENDERTARGET");
+      //Logger::debug("DDrawCommonSurface::InitializeD3D9: Usage: D3DUSAGE_RENDERTARGET");
       pool  = d3d9::D3DPOOL_DEFAULT;
       usage |= D3DUSAGE_RENDERTARGET;
     }
     // All depth stencils will be created in DEFAULT
     if (IsDepthStencil()) {
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Usage: D3DUSAGE_DEPTHSTENCIL");
+      //Logger::debug("DDrawCommonSurface::InitializeD3D9: Usage: D3DUSAGE_DEPTHSTENCIL");
       pool  = d3d9::D3DPOOL_DEFAULT;
       usage |= D3DUSAGE_DEPTHSTENCIL;
     }
@@ -227,18 +226,17 @@ namespace dxvk {
     // General usage flags
     if (IsTextureOrCubeMap()) {
       if (pool == d3d9::D3DPOOL_DEFAULT) {
-        Logger::debug("DDrawCommonSurface::InitializeD3D9: Usage: D3DUSAGE_DYNAMIC");
+        //Logger::debug("DDrawCommonSurface::InitializeD3D9: Usage: D3DUSAGE_DYNAMIC");
         usage |= D3DUSAGE_DYNAMIC;
       }
       if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps)) {
-        Logger::debug("DDrawCommonSurface::InitializeD3D9: Usage: D3DUSAGE_AUTOGENMIPMAP");
+        //Logger::debug("DDrawCommonSurface::InitializeD3D9: Usage: D3DUSAGE_AUTOGENMIPMAP");
         usage |= D3DUSAGE_AUTOGENMIPMAP;
       }
     }
 
     const char* poolPlacement = pool == d3d9::D3DPOOL_DEFAULT ? "D3DPOOL_DEFAULT" :
                                 pool == d3d9::D3DPOOL_SYSTEMMEM ? "D3DPOOL_SYSTEMMEM" : "D3DPOOL_MANAGED";
-
     Logger::debug(str::format("DDrawCommonSurface::InitializeD3D9: Placing in: ", poolPlacement));
 
     // Use the MSAA type that was determined to be supported during device creation
@@ -249,7 +247,7 @@ namespace dxvk {
 
     // Primary Surface
     if (IsPrimarySurface()) {
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing primary surface...");
+      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing primary surface");
 
       hr = d3d9Device->GetBackBuffer(0, m_backBufferIndex, d3d9::D3DBACKBUFFER_TYPE_MONO, &m_surface9);
 
@@ -259,10 +257,9 @@ namespace dxvk {
       }
 
       MarkAsD3D9BackBuffer();
-
     // Front Buffer
     } else if (IsFrontBuffer()) {
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing front buffer...");
+      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing front buffer");
 
       hr = d3d9Device->GetBackBuffer(0, m_backBufferIndex, d3d9::D3DBACKBUFFER_TYPE_MONO, &m_surface9);
 
@@ -272,10 +269,9 @@ namespace dxvk {
       }
 
       MarkAsD3D9BackBuffer();
-
     // Back Buffer
     } else if (IsBackBufferOrFlippable()) {
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing back buffer...");
+      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing back buffer");
 
       hr = d3d9Device->GetBackBuffer(0, m_backBufferIndex, d3d9::D3DBACKBUFFER_TYPE_MONO, &m_surface9);
 
@@ -285,10 +281,9 @@ namespace dxvk {
       }
 
       MarkAsD3D9BackBuffer();
-
     // Cube maps
     } else if (IsCubeMap()) {
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing cube map...");
+      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing cube map");
 
       hr = d3d9Device->CreateCubeTexture(
         dwWidth, m_mipCount, usage,
@@ -301,12 +296,9 @@ namespace dxvk {
 
       // Always attach the positive X face to this surface
       m_cubeMap9->GetCubeMapSurface(d3d9::D3DCUBEMAP_FACE_POSITIVE_X, 0, &m_surface9);
-
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Created cube map");
-
     // Textures
     } else if (IsTexture()) {
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing texture...");
+      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing texture");
 
       hr = d3d9Device->CreateTexture(
         dwWidth, dwHeight, m_mipCount, usage,
@@ -319,12 +311,9 @@ namespace dxvk {
 
       // Attach level 0 to this surface
       m_texture9->GetSurfaceLevel(0, &m_surface9);
-
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Created texture");
-
     // Depth Stencil
     } else if (IsDepthStencil()) {
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing depth stencil...");
+      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing depth stencil");
 
       hr = d3d9Device->CreateDepthStencilSurface(
         dwWidth, dwHeight, m_format9,
@@ -334,16 +323,11 @@ namespace dxvk {
         Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to create depth stencil");
         return hr;
       }
-
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Created depth stencil surface");
-
     // Offscreen Plain Surfaces
     } else if (IsOffScreenPlainSurface()) {
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing offscreen plain surface...");
+      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing offscreen plain surface");
 
       if (unlikely(initRenderTarget)) {
-        Logger::debug("DDrawCommonSurface::InitializeD3D9: Offscreen plain surface is the render target");
-
         hr = d3d9Device->GetBackBuffer(0, m_backBufferIndex, d3d9::D3DBACKBUFFER_TYPE_MONO, &m_surface9);
 
         if (unlikely(unlikely(FAILED(hr)))) {
@@ -362,26 +346,22 @@ namespace dxvk {
           Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to create offscreen plain surface");
           return hr;
         }
-
-        Logger::debug("DDrawCommonSurface::InitializeD3D9: Created offscreen plain surface");
       }
-    // Overlays (haven't seen any actual use of overlays in the wild)
+    // Overlays
     } else if (IsOverlay()) {
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing overlay...");
+      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing overlay");
 
-      // Always link overlays to the back buffer
-      hr = d3d9Device->GetBackBuffer(0, m_backBufferIndex, d3d9::D3DBACKBUFFER_TYPE_MONO, &m_surface9);
+      hr = d3d9Device->CreateOffscreenPlainSurface(
+        dwWidth, dwHeight, m_format9,
+        pool, &m_surface9, nullptr);
 
       if (unlikely(FAILED(hr))) {
-        Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to retrieve overlay surface");
+        Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to create offscreen plain surface");
         return hr;
       }
-
-      MarkAsD3D9BackBuffer();
-
     // Generic render target
     } else if (IsRenderTarget()) {
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing render target...");
+      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing render target");
 
       // Must be lockable for blitting to work. Note that
       // D3D9 does not allow the creation of lockable RTs when
@@ -394,12 +374,9 @@ namespace dxvk {
         Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to create render target");
         return hr;
       }
-
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Created render target");
-
     // We sometimes get generic surfaces, with only dimensions, format and placement info
     } else if (!IsNotKnown()) {
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing generic surface...");
+      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing generic surface");
 
       hr = d3d9Device->CreateOffscreenPlainSurface(
           dwWidth, dwHeight, m_format9,
@@ -409,8 +386,6 @@ namespace dxvk {
         Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to create offscreen plain surface");
         return hr;
       }
-
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Created offscreen plain surface");
     } else {
       Logger::warn("DDrawCommonSurface::InitializeD3D9: Skipping initialization of unknown surface");
     }

--- a/src/ddraw/ddraw_common_surface.h
+++ b/src/ddraw/ddraw_common_surface.h
@@ -495,10 +495,9 @@ namespace dxvk {
       Logger::debug(str::format("   IsComplex:   ", IsComplex() ? "yes" : "no"));
       Logger::debug(str::format("   HasMipMaps:  ", mipMapCount ? "yes" : "no"));
       Logger::debug(str::format("   IsAttached:  ", IsAttached() ? "yes" : "no"));
+      Logger::debug(str::format("   ColorKey:    ", HasColorKey() ? "yes" : "no"));
       if (IsFrontBuffer())
         Logger::debug(str::format("   BackBuffers: ", backBuferCount));
-      if (HasColorKey())
-        Logger::debug(str::format("   ColorKey:    ", GetColorKey()->dwColorSpaceLowValue));
     }
 
   private:

--- a/src/ddraw/ddraw_format.h
+++ b/src/ddraw/ddraw_format.h
@@ -627,12 +627,7 @@ namespace dxvk {
     desc.dwSize = sizeof(DDSURFACEDESC2);
     surface->GetSurfaceDesc(&desc);
     const d3d9::D3DCUBEMAP_FACES face = GetCubemapFace(&desc);
-
-    Logger::debug(str::format("BlitToD3D9CubeMap: Blitting face ", face));
-
     IDirectDrawSurface7* mipMap = surface;
-
-    Logger::debug(str::format("BlitToD3D9CubeMap: Blitting ", mipLevels, " mip map(s)"));
 
     for (uint16_t i = 0; i < mipLevels; i++) {
       // Should never occur normally, but acts as a last ditch safety check
@@ -653,9 +648,9 @@ namespace dxvk {
           if (isDXTFormat) {
             const size_t size = static_cast<size_t>(descMip.lPitch);
             memcpy(rect9mip.pBits, descMip.lpSurface, size);
-            Logger::debug(str::format("BlitToD3D9CubeMap: Done blitting DXT mip ", i));
+            //Logger::debug(str::format("BlitToD3D9CubeMap: Done blitting DXT mip ", i));
           } else if (descMip.lPitch != rect9mip.Pitch) {
-            Logger::debug(str::format("BlitToD3D9CubeMap: Incompatible mip map ", i, " pitch"));
+            //Logger::debug(str::format("BlitToD3D9CubeMap: Incompatible mip map ", i, " pitch"));
 
             uint8_t* data9 = reinterpret_cast<uint8_t*>(rect9mip.pBits);
             uint8_t* data7 = reinterpret_cast<uint8_t*>(descMip.lpSurface);
@@ -664,11 +659,11 @@ namespace dxvk {
             for (uint32_t h = 0; h < descMip.dwHeight; h++)
               memcpy(&data9[h * rect9mip.Pitch], &data7[h * descMip.lPitch], copyPitch);
 
-            Logger::debug(str::format("BlitToD3D9CubeMap: Done blitting mip ", i, " row by row"));
+            //Logger::debug(str::format("BlitToD3D9CubeMap: Done blitting mip ", i, " row by row"));
           } else {
             const size_t size = static_cast<size_t>(descMip.dwHeight * descMip.lPitch);
             memcpy(rect9mip.pBits, descMip.lpSurface, size);
-            Logger::debug(str::format("BlitToD3D9CubeMap: Done blitting mip ", i));
+            //Logger::debug(str::format("BlitToD3D9CubeMap: Done blitting mip ", i));
           }
           mipMap->Unlock(NULL);
         } else {
@@ -694,8 +689,6 @@ namespace dxvk {
         const bool isDXTFormat) {
     SurfaceType* mipMap = surface;
 
-    Logger::debug(str::format("BlitToD3D9Texture: Blitting ", mipLevels, " mip map(s)"));
-
     for (uint16_t i = 0; i < mipLevels; i++) {
       // Should never occur normally, but acts as a last ditch safety check
       if (unlikely(mipMap == nullptr)) {
@@ -715,9 +708,9 @@ namespace dxvk {
           if (isDXTFormat) {
             const size_t size = static_cast<size_t>(descMip.lPitch);
             memcpy(rect9mip.pBits, descMip.lpSurface, size);
-            Logger::debug(str::format("BlitToD3D9Texture: Done blitting DXT mip ", i));
+            //Logger::debug(str::format("BlitToD3D9Texture: Done blitting DXT mip ", i));
           } else if (descMip.lPitch != rect9mip.Pitch) {
-            Logger::debug(str::format("BlitToD3D9Texture: Incompatible mip map ", i, " pitch"));
+            //Logger::debug(str::format("BlitToD3D9Texture: Incompatible mip map ", i, " pitch"));
 
             uint8_t* data9 = reinterpret_cast<uint8_t*>(rect9mip.pBits);
             uint8_t* data7 = reinterpret_cast<uint8_t*>(descMip.lpSurface);
@@ -726,11 +719,11 @@ namespace dxvk {
             for (uint32_t h = 0; h < descMip.dwHeight; h++)
               memcpy(&data9[h * rect9mip.Pitch], &data7[h * descMip.lPitch], copyPitch);
 
-            Logger::debug(str::format("BlitToD3D9Texture: Done blitting mip ", i, " row by row"));
+            //Logger::debug(str::format("BlitToD3D9Texture: Done blitting mip ", i, " row by row"));
           } else {
             const size_t size = static_cast<size_t>(descMip.dwHeight * descMip.lPitch);
             memcpy(rect9mip.pBits, descMip.lpSurface, size);
-            Logger::debug(str::format("BlitToD3D9Texture: Done blitting mip ", i));
+            //Logger::debug(str::format("BlitToD3D9Texture: Done blitting mip ", i));
           }
           mipMap->Unlock(NULL);
         } else {
@@ -773,9 +766,9 @@ namespace dxvk {
         if (isDXTFormat) {
           const size_t size = static_cast<size_t>(desc.lPitch);
           memcpy(rect9.pBits, desc.lpSurface, size);
-          Logger::debug("BlitToD3D9Surface: Done blitting DXT surface");
+          //Logger::debug("BlitToD3D9Surface: Done blitting DXT surface");
         } else if (desc.lPitch != rect9.Pitch) {
-          Logger::debug("BlitToD3D9Surface: Incompatible surface pitch");
+          //Logger::debug("BlitToD3D9Surface: Incompatible surface pitch");
 
           uint8_t* data9 = reinterpret_cast<uint8_t*>(rect9.pBits);
           uint8_t* data7 = reinterpret_cast<uint8_t*>(desc.lpSurface);
@@ -784,11 +777,11 @@ namespace dxvk {
           for (uint32_t h = 0; h < desc.dwHeight; h++)
             memcpy(&data9[h * rect9.Pitch], &data7[h * desc.lPitch], copyPitch);
 
-          Logger::debug("BlitToD3D9Surface: Done blitting surface row by row");
+          //Logger::debug("BlitToD3D9Surface: Done blitting surface row by row");
         } else {
           const size_t size = static_cast<size_t>(desc.dwHeight * desc.lPitch);
           memcpy(rect9.pBits, desc.lpSurface, size);
-          Logger::debug("BlitToD3D9Surface: Done blitting surface");
+          //Logger::debug("BlitToD3D9Surface: Done blitting surface");
         }
         surface->Unlock(NULL);
       } else {
@@ -816,9 +809,9 @@ namespace dxvk {
         if (unlikely(isDXTFormat)) {
           const size_t size = static_cast<size_t>(desc.lPitch);
           memcpy(desc.lpSurface, rect9.pBits, size);
-          Logger::debug("BlitToDDrawSurface: Done blitting DXT surface");
+          //Logger::debug("BlitToDDrawSurface: Done blitting DXT surface");
         } else if (desc.lPitch != rect9.Pitch) {
-          Logger::debug("BlitToDDrawSurface: Incompatible surface pitch");
+          //Logger::debug("BlitToDDrawSurface: Incompatible surface pitch");
 
           uint8_t* data7 = reinterpret_cast<uint8_t*>(desc.lpSurface);
           uint8_t* data9 = reinterpret_cast<uint8_t*>(rect9.pBits);
@@ -827,11 +820,11 @@ namespace dxvk {
           for (uint32_t h = 0; h < desc.dwHeight; h++)
             memcpy(&data7[h * desc.lPitch], &data9[h * rect9.Pitch], copyPitch);
 
-          Logger::debug("BlitToDDrawSurface: Done blitting surface row by row");
+          //Logger::debug("BlitToDDrawSurface: Done blitting surface row by row");
         } else {
           const size_t size = static_cast<size_t>(desc.dwHeight * desc.lPitch);
           memcpy(desc.lpSurface, rect9.pBits, size);
-          Logger::debug("BlitToDDrawSurface: Done blitting surface");
+          //Logger::debug("BlitToDDrawSurface: Done blitting surface");
         }
         surface9->UnlockRect();
       } else {

--- a/src/ddraw/ddraw_gamma.cpp
+++ b/src/ddraw/ddraw_gamma.cpp
@@ -18,8 +18,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawGammaControl::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> DDrawGammaControl::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
@@ -27,31 +25,24 @@ namespace dxvk {
 
     if (unlikely(riid == __uuidof(IUnknown)
               || riid == __uuidof(IDirectDrawSurface))) {
-      Logger::debug("DDrawGammaControl::QueryInterface: Query for IDirectDrawSurface");
       return m_parent->QueryInterface(riid, ppvObject);
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface2))) {
-      Logger::debug("DDrawGammaControl::QueryInterface: Query for IDirectDrawSurface2");
       return m_parent->QueryInterface(riid, ppvObject);
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface3))) {
-      Logger::debug("DDrawGammaControl::QueryInterface: Query for IDirectDrawSurface3");
       return m_parent->QueryInterface(riid, ppvObject);
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface4))) {
-      Logger::debug("DDrawGammaControl::QueryInterface: Query for IDirectDrawSurface4");
       return m_parent->QueryInterface(riid, ppvObject);
     }
     if (unlikely(riid == __uuidof(IDirectDrawSurface7))) {
-      Logger::debug("DDrawGammaControl::QueryInterface: Query for IDirectDrawSurface7");
       return m_parent->QueryInterface(riid, ppvObject);
     }
     if (unlikely(riid == __uuidof(IDirect3DTexture))) {
-      Logger::debug("DDrawGammaControl::QueryInterface: Query for IDirect3DTexture");
       return m_parent->QueryInterface(riid, ppvObject);
     }
     if (unlikely(riid == __uuidof(IDirect3DTexture2))) {
-      Logger::debug("DDrawGammaControl::QueryInterface: Query for IDirect3DTexture2");
       return m_parent->QueryInterface(riid, ppvObject);
     }
 
@@ -66,8 +57,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawGammaControl::GetGammaRamp(DWORD dwFlags, LPDDGAMMARAMP lpRampData) {
-    Logger::debug(">>> DDrawGammaControl::GetGammaRamp");
-
     if (unlikely(lpRampData == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -76,8 +65,6 @@ namespace dxvk {
     D3DCommonDevice* commonDevice = commonIntf->GetCommonD3DDevice();
 
     if (likely(commonDevice != nullptr)) {
-      Logger::debug("DDrawGammaControl::GetGammaRamp: Getting gamma ramp via D3D9");
-
       d3d9::IDirect3DDevice9* d3d9Device = commonDevice->GetD3D9Device();
 
       d3d9::D3DGAMMARAMP rampData = { };
@@ -86,7 +73,6 @@ namespace dxvk {
       // Both gamma structs are identical in content/size
       memcpy(static_cast<void*>(lpRampData), static_cast<const void*>(&rampData), sizeof(DDGAMMARAMP));
     } else {
-      Logger::debug("DDrawGammaControl::GetGammaRamp: Getting gamma ramp via DDraw");
       return m_proxy->GetGammaRamp(dwFlags, lpRampData);
     }
 
@@ -94,8 +80,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawGammaControl::SetGammaRamp(DWORD dwFlags, LPDDGAMMARAMP lpRampData) {
-    Logger::debug(">>> DDrawGammaControl::SetGammaRamp");
-
     if (unlikely(lpRampData == nullptr))
       return DDERR_INVALIDPARAMS;
 
@@ -105,14 +89,11 @@ namespace dxvk {
       D3DCommonDevice* commonDevice = commonIntf->GetCommonD3DDevice();
 
       if (likely(commonDevice != nullptr)) {
-        Logger::debug("DDrawGammaControl::SetGammaRamp: Setting gamma ramp via D3D9");
-
         d3d9::IDirect3DDevice9* d3d9Device = commonDevice->GetD3D9Device();
 
         d3d9Device->SetGammaRamp(0, D3DSGR_NO_CALIBRATION,
                                  reinterpret_cast<const d3d9::D3DGAMMARAMP*>(lpRampData));
       } else {
-        Logger::debug("DDrawGammaControl::SetGammaRamp: Setting gamma ramp via DDraw");
         return m_proxy->SetGammaRamp(dwFlags, lpRampData);
       }
     } else {

--- a/src/ddraw/ddraw_main.cpp
+++ b/src/ddraw/ddraw_main.cpp
@@ -102,11 +102,8 @@ namespace dxvk {
 
       LPVOID lplpDDProxied = nullptr;
       HRESULT hr = ProxiedDirectDrawCreateEx(lpGUID, &lplpDDProxied, iid, pUnkOuter);
-
-      if (unlikely(FAILED(hr))) {
-        Logger::warn("CreateDirectDrawEx: Failed call to proxied interface");
+      if (unlikely(FAILED(hr)))
         return hr;
-      }
 
       Com<IDirectDraw7> DDraw7IntfProxied = static_cast<IDirectDraw7*>(lplpDDProxied);
       *lplpDD = ref(new DDraw7Interface(nullptr, std::move(DDraw7IntfProxied)));
@@ -146,11 +143,8 @@ namespace dxvk {
 
       LPVOID lplpDDProxied = nullptr;
       HRESULT hr = ProxiedDirectDrawCreate(lpGUID, &lplpDDProxied, pUnkOuter);
-
-      if (unlikely(FAILED(hr))) {
-        Logger::warn("CreateDirectDraw: Failed call to proxied interface");
+      if (unlikely(FAILED(hr)))
         return hr;
-      }
 
       Com<IDirectDraw> DDrawIntfProxied = static_cast<IDirectDraw*>(lplpDDProxied);
       *lplpDD = ref(new DDrawInterface(nullptr, std::move(DDrawIntfProxied)));
@@ -189,11 +183,8 @@ namespace dxvk {
 
     Com<IDirectDrawClipper> lplpDDClipperProxy;
     HRESULT hr = ProxiedDirectDrawCreateClipper(dwFlags, &lplpDDClipperProxy, pUnkOuter);
-
-    if (unlikely(FAILED(hr))) {
-      Logger::warn("DirectDrawCreateClipper: Failed call to proxied interface");
+    if (unlikely(FAILED(hr)))
       return hr;
-    }
 
     *lplpDDClipper = ref(new DDrawClipper(nullptr, std::move(lplpDDClipperProxy), nullptr));
 
@@ -201,8 +192,6 @@ namespace dxvk {
   }
 
   HRESULT ClassFactoryCreateDirectDraw(IUnknown *pUnkOuter, REFIID riid, void **ppvObject) {
-    Logger::debug(">>> ClassFactoryCreateDirectDraw");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
@@ -219,7 +208,6 @@ namespace dxvk {
     // ClassFactoryCreateDirectDraw can be used to construct objects
     // ranging from IDirectDraw to IDirectDraw2 and IDirectDraw4
     if (riid == __uuidof(IDirectDraw)) {
-      Logger::debug(">>> ClassFactoryCreateDirectDraw: Returning IDirectDraw");
       *ppvObject = static_cast<void*>(ppvObjectProxy);
     } else if (riid == __uuidof(IDirectDraw2)) {
       void* directDraw2 = nullptr;
@@ -228,7 +216,6 @@ namespace dxvk {
         ppvObjectProxy->Release();
         return hr;
       }
-      Logger::debug(">>> ClassFactoryCreateDirectDraw: Returning IDirectDraw2");
       *ppvObject = directDraw2;
       ppvObjectProxy->Release();
     } else if (riid == __uuidof(IDirectDraw4)) {
@@ -238,13 +225,11 @@ namespace dxvk {
         ppvObjectProxy->Release();
         return hr;
       }
-      Logger::debug(">>> ClassFactoryCreateDirectDraw: Returning IDirectDraw4");
       *ppvObject = directDraw4;
       ppvObjectProxy->Release();
     // Apparently this also works, but I doubt is ever used in practice,
     // since IDirectDraw7 can be requested directly in DllGetClassObject
     } else if (riid == __uuidof(IDirectDraw7)) {
-      Logger::debug(">>> ClassFactoryCreateDirectDraw: Returning IDirectDraw7");
       ppvObjectProxy->Release();
       return CreateDirectDrawEx(NULL, ppvObject, riid, NULL);
     } else {
@@ -256,8 +241,6 @@ namespace dxvk {
   }
 
   HRESULT ClassFactoryCreateDirectDrawEx(IUnknown *pUnkOuter, REFIID riid, void **ppvObject) {
-    Logger::debug(">>> ClassFactoryCreateDirectDrawEx");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
@@ -271,13 +254,10 @@ namespace dxvk {
       return CLASS_E_CLASSNOTAVAILABLE;
     }
 
-    Logger::debug(">>> ClassFactoryCreateDirectDrawEx: Returning IDirectDraw7");
     return CreateDirectDrawEx(NULL, ppvObject, riid, NULL);
   }
 
   HRESULT ClassFactoryCreateDirectDrawClipper(IUnknown *pUnkOuter, REFIID riid, void **ppvObject) {
-    Logger::debug(">>> ClassFactoryCreateDirectDrawClipper");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
@@ -297,8 +277,6 @@ namespace dxvk {
 extern "C" {
 
   DLLEXPORT HRESULT __stdcall AcquireDDThreadLock() {
-    dxvk::Logger::debug("<<< AcquireDDThreadLock: Proxy");
-
     typedef HRESULT (__stdcall *AcquireDDThreadLock_t)();
     static AcquireDDThreadLock_t ProxiedAcquireDDThreadLock = nullptr;
 
@@ -352,24 +330,19 @@ extern "C" {
   }
 
   DLLEXPORT HRESULT __stdcall DirectDrawCreate(GUID *lpGUID, LPDIRECTDRAW *lplpDD, IUnknown *pUnkOuter) {
-    dxvk::Logger::debug(">>> DirectDrawCreate");
     return dxvk::CreateDirectDraw(lpGUID, lplpDD, pUnkOuter);
   }
 
   // Mostly unused, except for Sea Dogs (D3D6)
   DLLEXPORT HRESULT __stdcall DirectDrawCreateClipper(DWORD dwFlags, LPDIRECTDRAWCLIPPER *lplpDDClipper, IUnknown *pUnkOuter) {
-    dxvk::Logger::debug(">>> DirectDrawCreateClipper");
     return dxvk::CreateDirectDrawClipper(dwFlags, lplpDDClipper, pUnkOuter);
   }
 
   DLLEXPORT HRESULT __stdcall DirectDrawCreateEx(GUID *lpGUID, LPVOID *lplpDD, REFIID iid, IUnknown *pUnkOuter) {
-    dxvk::Logger::debug(">>> DirectDrawCreateEx");
     return dxvk::CreateDirectDrawEx(lpGUID, lplpDD, iid, pUnkOuter);
   }
 
   DLLEXPORT HRESULT __stdcall DirectDrawEnumerateA(LPDDENUMCALLBACKA lpCallback, LPVOID lpContext) {
-    dxvk::Logger::debug("<<< DirectDrawEnumerateA: Proxy");
-
     typedef HRESULT (__stdcall *DirectDrawEnumerateA_t)(LPDDENUMCALLBACKA lpCallback, LPVOID lpContext);
     static DirectDrawEnumerateA_t ProxiedDirectDrawEnumerateA = nullptr;
 
@@ -393,8 +366,6 @@ extern "C" {
   }
 
   DLLEXPORT HRESULT __stdcall DirectDrawEnumerateExA(LPDDENUMCALLBACKEXA lpCallback, LPVOID lpContext, DWORD dwFlags) {
-    dxvk::Logger::debug("<<< DirectDrawEnumerateExA: Proxy");
-
     typedef HRESULT (__stdcall *DirectDrawEnumerateExA_t)(LPDDENUMCALLBACKEXA lpCallback, LPVOID lpContext, DWORD dwFlags);
     static DirectDrawEnumerateExA_t ProxiedDirectDrawEnumerateExA = nullptr;
 
@@ -418,8 +389,6 @@ extern "C" {
   }
 
   DLLEXPORT HRESULT __stdcall DirectDrawEnumerateExW(LPDDENUMCALLBACKEXW lpCallback, LPVOID lpContext, DWORD dwFlags) {
-    dxvk::Logger::debug("<<< DirectDrawEnumerateExW: Proxy");
-
     typedef HRESULT (__stdcall *DirectDrawEnumerateExW_t)(LPDDENUMCALLBACKEXW lpCallback, LPVOID lpContext, DWORD dwFlags);
     static DirectDrawEnumerateExW_t ProxiedDirectDrawEnumerateExW = nullptr;
 
@@ -443,8 +412,6 @@ extern "C" {
   }
 
   DLLEXPORT HRESULT __stdcall DirectDrawEnumerateW(LPDDENUMCALLBACKW lpCallback, LPVOID lpContext) {
-    dxvk::Logger::debug("<<< DirectDrawEnumerateW: Proxy");
-
     typedef HRESULT (__stdcall *DirectDrawEnumerateW_t)(LPDDENUMCALLBACKW lpCallback, LPVOID lpContext);
     static DirectDrawEnumerateW_t ProxiedDirectDrawEnumerateW = nullptr;
 
@@ -468,8 +435,6 @@ extern "C" {
   }
 
   DLLEXPORT HRESULT __stdcall DllCanUnloadNow() {
-    dxvk::Logger::debug("<<< DllCanUnloadNow: Proxy");
-
     typedef HRESULT (__stdcall *DllCanUnloadNow_t)();
     static DllCanUnloadNow_t ProxiedDllCanUnloadNow = nullptr;
 
@@ -493,12 +458,10 @@ extern "C" {
   }
 
   DLLEXPORT HRESULT __stdcall DllGetClassObject(REFCLSID rclsid, REFIID riid, LPVOID *ppv) {
-    dxvk::Logger::debug(">>> DllGetClassObject");
-
     if (unlikely(ppv == nullptr))
       return E_POINTER;
 
-    dxvk::Logger::debug(dxvk::str::format("DllGetClassObject: Call for rclsid: ", rclsid));
+    //dxvk::Logger::debug(dxvk::str::format("DllGetClassObject: Call for rclsid: ", rclsid));
 
     if (unlikely(riid != __uuidof(IClassFactory) && riid != __uuidof(IUnknown)))
       return E_NOINTERFACE;
@@ -557,8 +520,6 @@ extern "C" {
   }
 
   DLLEXPORT HRESULT __stdcall ReleaseDDThreadLock() {
-    dxvk::Logger::debug("<<< ReleaseDDThreadLock: Proxy");
-
     typedef HRESULT (__stdcall *ReleaseDDThreadLock_t)();
     static ReleaseDDThreadLock_t ProxiedReleaseDDThreadLock = nullptr;
 

--- a/src/ddraw/ddraw_options.cpp
+++ b/src/ddraw/ddraw_options.cpp
@@ -6,19 +6,21 @@ namespace dxvk {
     // D3D7/6/5/3/DDraw options
     this->forceMultiThreaded     = config.getOption<bool>   ("ddraw.forceMultiThreaded",     false);
     this->forceSWVP              = config.getOption<bool>   ("ddraw.forceSWVP",              false);
+    this->managedVertexBuffers   = config.getOption<bool>   ("ddraw.managedVertexBuffers",   false);
     this->supportR3G3B2          = config.getOption<bool>   ("ddraw.supportR3G3B2",          false);
     this->supportD16             = config.getOption<bool>   ("ddraw.supportD16",              true);
     this->support32BitDepth      = config.getOption<bool>   ("ddraw.support32BitDepth",       true);
     this->useD24X8forD32         = config.getOption<bool>   ("ddraw.useD24X8forD32",         false);
+    this->useD16forD24X8         = config.getOption<bool>   ("ddraw.useD16forD24X8",         false);
     this->mask8BitModes          = config.getOption<bool>   ("ddraw.mask8BitModes",          false);
     this->viewportZCorrection    = config.getOption<bool>   ("ddraw.viewportZCorrection",    false);
-    this->forcePOW2Textures      = config.getOption<bool>   ("ddraw.forcePOW2Textures",      false);
     this->forceLegacyDiscard     = config.getOption<bool>   ("ddraw.forceLegacyDiscard",     false);
     this->cpuProcessVertices     = config.getOption<bool>   ("ddraw.cpuProcessVertices",      true);
     this->vertexOffset           = config.getOption<float>  ("ddraw.vertexOffset",            0.0f);
     this->backBufferResize       = config.getOption<bool>   ("ddraw.backBufferResize",        true);
     this->forceLegacyPresent     = config.getOption<bool>   ("ddraw.forceLegacyPresent",     false);
     this->forceRTFlip            = config.getOption<bool>   ("ddraw.forceRTFlip",            false);
+    this->forceDCForwarding      = config.getOption<bool>   ("ddraw.forceDCForwarding",      false);
     this->emulateFrontBuffer     = config.getOption<bool>   ("ddraw.emulateFrontBuffer",     false);
     this->ignoreGammaRamp        = config.getOption<bool>   ("ddraw.ignoreGammaRamp",        false);
     this->autoGenMipMaps         = config.getOption<bool>   ("ddraw.autoGenMipMaps",         false);

--- a/src/ddraw/ddraw_options.h
+++ b/src/ddraw/ddraw_options.h
@@ -30,6 +30,9 @@ namespace dxvk {
     /// Use SWVP mode for all D3D9 devices
     bool forceSWVP;
 
+    /// Use MANAGED vertex buffers instead of DEFAULT vertex buffers
+    bool managedVertexBuffers;
+
     /// Advertise support for R3G3B2
     bool supportR3G3B2;
 
@@ -42,14 +45,14 @@ namespace dxvk {
     /// Replaces any use of D32 with D24X8
     bool useD24X8forD32;
 
+    /// Replaces any use of D24X8 with D16
+    bool useD16forD24X8;
+
     /// Report any 8-bit display modes as being 16-bit
     bool mask8BitModes;
 
     /// Always use 0.0f and 1.0f as viewport Z values
     bool viewportZCorrection;
-
-    /// Report POW2 texture dimension restrictions
-    bool forcePOW2Textures;
 
     /// Respect DISCARD only on DYNAMIC + WRITEONLY buffers
     bool forceLegacyDiscard;
@@ -68,6 +71,9 @@ namespace dxvk {
 
     /// Explicitly flip the RT swapchain, even if the primary surface is not part of it
     bool forceRTFlip;
+
+    /// Forwards all DC operations to D3D9 surfaces
+    bool forceDCForwarding;
 
     /// Emulate an explicit D3D9 front buffer by uploading its content from DDraw
     bool emulateFrontBuffer;

--- a/src/ddraw/ddraw_palette.cpp
+++ b/src/ddraw/ddraw_palette.cpp
@@ -29,8 +29,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawPalette::QueryInterface(REFIID riid, void** ppvObject) {
-    Logger::debug(">>> DDrawPalette::QueryInterface");
-
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
@@ -50,22 +48,18 @@ namespace dxvk {
   // Docs state: "Because the DirectDrawPalette object is initialized when
   // it is created, this method always returns DDERR_ALREADYINITIALIZED."
   HRESULT STDMETHODCALLTYPE DDrawPalette::Initialize(LPDIRECTDRAW lpDD, DWORD dwFlags, LPPALETTEENTRY lpDDColorTable) {
-    Logger::debug(">>> DDrawPalette::Initialize");
     return DDERR_ALREADYINITIALIZED;
   }
 
   HRESULT STDMETHODCALLTYPE DDrawPalette::GetCaps(LPDWORD lpdwCaps) {
-    Logger::debug("<<< DDrawPalette::GetCaps: Proxy");
     return m_proxy->GetCaps(lpdwCaps);
   }
 
   HRESULT STDMETHODCALLTYPE DDrawPalette::GetEntries(DWORD dwFlags, DWORD dwBase, DWORD dwNumEntries, LPPALETTEENTRY lpEntries) {
-    Logger::debug("<<< DDrawPalette::GetEntries: Proxy");
     return m_proxy->GetEntries(dwFlags, dwBase, dwNumEntries, lpEntries);
   }
 
   HRESULT STDMETHODCALLTYPE DDrawPalette::SetEntries(DWORD dwFlags, DWORD dwStartingEntry, DWORD dwCount, LPPALETTEENTRY lpEntries) {
-    Logger::debug("<<< DDrawPalette::SetEntries: Proxy");
     return m_proxy->SetEntries(dwFlags, dwStartingEntry, dwCount, lpEntries);
   }
 

--- a/src/ddraw/ddraw_util.h
+++ b/src/ddraw/ddraw_util.h
@@ -136,7 +136,7 @@ namespace dxvk {
     return lockFlagsD3D9;
   }
 
-  inline DWORD ConvertD3D6UsageFlags(DWORD usageFlags, DWORD creationFlags) {
+  inline DWORD ConvertD3D6UsageFlags(DWORD usageFlags, DWORD creationFlags, d3d9::D3DPOOL pool) {
     DWORD usageFlagsD3D9 = 0;
 
     // The D3D6 docs do not mention the presence of a D3DVBCAPS_DONOTCLIP flag,
@@ -147,14 +147,17 @@ namespace dxvk {
     if (usageFlags & D3DVBCAPS_WRITEONLY) {
       usageFlagsD3D9 |= (DWORD)D3DUSAGE_WRITEONLY;
     }
+    if (pool != d3d9::D3DPOOL_MANAGED) {
+      // D3D6 does not use DDLOCK_DISCARDCONTENTS or
+      // DDLOCK_NOOVERWRITE, however, still mark all non-MANAGED
+      // buffers as DYNAMIC to handle any potential CPU read-backs
+      usageFlagsD3D9 |= D3DUSAGE_DYNAMIC;
+    }
 
-    // D3D6 does not use DDLOCK_DISCARDCONTENTS or
-    // DDLOCK_NOOVERWRITE, however, still mark all buffers
-    // as DYNAMIC to handle any potential CPU read-backs
-    return usageFlagsD3D9 | D3DUSAGE_DYNAMIC;
+    return usageFlagsD3D9;
   }
 
-  inline DWORD ConvertD3D7UsageFlags(DWORD usageFlags) {
+  inline DWORD ConvertD3D7UsageFlags(DWORD usageFlags, d3d9::D3DPOOL pool) {
     DWORD usageFlagsD3D9 = 0;
 
     if (usageFlags & D3DVBCAPS_DONOTCLIP) {
@@ -163,11 +166,14 @@ namespace dxvk {
     if (usageFlags & D3DVBCAPS_WRITEONLY) {
       usageFlagsD3D9 |= (DWORD)D3DUSAGE_WRITEONLY;
     }
+    if (pool != d3d9::D3DPOOL_MANAGED) {
+      // Though D3D7 does not specify it, all non-MANAGED buffers
+      // need to be DYNAMIC, either due to some lock flags not
+      // working properly otherwise, or for performance reasons
+      usageFlagsD3D9 |= D3DUSAGE_DYNAMIC;
+    }
 
-    // Though D3D7 does not specify it, all buffers need
-    // to be DYNAMIC, either due to some lock flags not
-    // working properly otherwise, or for performance reasons
-    return usageFlagsD3D9 | D3DUSAGE_DYNAMIC;
+    return usageFlagsD3D9;
   }
 
   inline size_t GetFVFPositionSize(DWORD fvf) {
@@ -437,7 +443,6 @@ namespace dxvk {
       if (unlikely(isOnePixelWider || isOnePixelTaller)) {
         Logger::debug("ValidateViewportRT: Viewport exceeds render target dimensions by one pixel");
       } else {
-        Logger::debug("ValidateViewportRT: Viewport exceeds render target dimensions");
         return DDERR_INVALIDPARAMS;
       }
     }
@@ -476,7 +481,7 @@ namespace dxvk {
                    | D3DDEVCAPS_TLVERTEXVIDEOMEMORY;
 
     // Also advertised in D3D3
-    if (rclsid == IID_IDirect3DHALDevice || rclsid == IID_WineD3DDevice) {
+    if (rclsid == IID_IDirect3DHALDevice) {
       desc.dwDevCaps |= D3DDEVCAPS_HWRASTERIZATION
                       | D3DDEVCAPS_HWTRANSFORMANDLIGHT
                       | D3DDEVCAPS_DRAWPRIMITIVES2
@@ -493,11 +498,11 @@ namespace dxvk {
 
     D3DLIGHTINGCAPS lightingCaps;
     lightingCaps.dwSize  = sizeof(D3DLIGHTINGCAPS);
-    lightingCaps.dwCaps  = D3DLIGHTCAPS_DIRECTIONAL
-                      // | D3DLIGHTCAPS_GLSPOT
-                         | D3DLIGHTCAPS_PARALLELPOINT // Not supported by D3D9
-                         | D3DLIGHTCAPS_POINT
-                         | D3DLIGHTCAPS_SPOT;
+    lightingCaps.dwCaps  = D3DLIGHTCAPS_POINT
+                         | D3DLIGHTCAPS_SPOT
+                         | D3DLIGHTCAPS_DIRECTIONAL
+                         | D3DLIGHTCAPS_PARALLELPOINT; // Not supported by D3D9
+                      // | D3DLIGHTCAPS_GLSPOT; // Specific to D3D3
     lightingCaps.dwLightingModel = D3DLIGHTINGMODEL_RGB;
     lightingCaps.dwNumLights = ddrawCaps::MaxEnabledLights;
 
@@ -510,16 +515,16 @@ namespace dxvk {
                               | D3DPMISCCAPS_CULLCW
                               | D3DPMISCCAPS_CULLNONE
                            // | D3DPMISCCAPS_CONFORMANT
-                           // | D3DPMISCCAPS_LINEPATTERNREP // Not implemented in D3D9
+                           // | D3DPMISCCAPS_LINEPATTERNREP
                            // | D3DPMISCCAPS_MASKPLANES
                               | D3DPMISCCAPS_MASKZ;
 
     prim.dwRasterCaps         = D3DPRASTERCAPS_DITHER
                               | D3DPRASTERCAPS_FOGTABLE
                               | D3DPRASTERCAPS_FOGVERTEX
-                           // | D3DPRASTERCAPS_PAT // Not implemented in D3D9
+                           // | D3DPRASTERCAPS_PAT
                            // | D3DPRASTERCAPS_ROP2
-                              | D3DPRASTERCAPS_STIPPLE // Technically not implemented
+                           // | D3DPRASTERCAPS_STIPPLE
                               | D3DPRASTERCAPS_SUBPIXEL
                            // | D3DPRASTERCAPS_SUBPIXELX
                            // | D3DPRASTERCAPS_XOR
@@ -577,12 +582,10 @@ namespace dxvk {
     prim.dwTextureCaps        = D3DPTEXTURECAPS_ALPHA
                               | D3DPTEXTURECAPS_BORDER
                               | D3DPTEXTURECAPS_PERSPECTIVE
+                              | D3DPTEXTURECAPS_POW2 // Always reported on early D3D cards
+                              | D3DPTEXTURECAPS_NONPOW2CONDITIONAL // Reported only on later (D3D7/8) D3D cards
                            // | D3DPTEXTURECAPS_SQUAREONLY
                               | D3DPTEXTURECAPS_TRANSPARENCY;
-
-    if (unlikely(options->forcePOW2Textures)) {
-      prim.dwTextureCaps |= D3DPTEXTURECAPS_POW2;
-    }
 
     prim.dwTextureFilterCaps  = D3DPTFILTERCAPS_LINEAR
                               | D3DPTFILTERCAPS_LINEARMIPLINEAR
@@ -603,8 +606,8 @@ namespace dxvk {
                               | D3DPTADDRESSCAPS_MIRROR
                               | D3DPTADDRESSCAPS_WRAP;
 
-    prim.dwStippleWidth       = 32;
-    prim.dwStippleHeight      = 32;
+    prim.dwStippleWidth       = 0;
+    prim.dwStippleHeight      = 0;
 
     desc.dpcLineCaps          = prim;
     desc.dpcTriCaps           = prim;
@@ -645,7 +648,7 @@ namespace dxvk {
                 // | D3DDEVCAPS_SORTDECREASINGZ
                 // | D3DDEVCAPS_SORTEXACT
                 // | D3DDEVCAPS_SORTINCREASINGZ
-                // | D3DDEVCAPS_TEXTURENONLOCALVIDMEM // Exposed though a config option
+                // | D3DDEVCAPS_TEXTURENONLOCALVIDMEM // Exposed through a config option
                 // | D3DDEVCAPS_TEXTURESYSTEMMEMORY
                    | D3DDEVCAPS_TEXTUREVIDEOMEMORY
                    | D3DDEVCAPS_TLVERTEXSYSTEMMEMORY
@@ -657,7 +660,7 @@ namespace dxvk {
     }
 
     // Also advertised in D3D5
-    if (rclsid == IID_IDirect3DHALDevice || rclsid == IID_WineD3DDevice) {
+    if (rclsid == IID_IDirect3DHALDevice) {
       desc.dwDevCaps |= D3DDEVCAPS_HWRASTERIZATION
                       | D3DDEVCAPS_HWTRANSFORMANDLIGHT
                       | D3DDEVCAPS_DRAWPRIMITIVES2
@@ -674,11 +677,10 @@ namespace dxvk {
 
     D3DLIGHTINGCAPS lightingCaps;
     lightingCaps.dwSize  = sizeof(D3DLIGHTINGCAPS);
-    lightingCaps.dwCaps  = D3DLIGHTCAPS_DIRECTIONAL
-                      // | D3DLIGHTCAPS_GLSPOT
-                         | D3DLIGHTCAPS_PARALLELPOINT // Not supported by D3D9
-                         | D3DLIGHTCAPS_POINT
-                         | D3DLIGHTCAPS_SPOT;
+    lightingCaps.dwCaps  = D3DLIGHTCAPS_POINT
+                         | D3DLIGHTCAPS_SPOT
+                         | D3DLIGHTCAPS_DIRECTIONAL
+                         | D3DLIGHTCAPS_PARALLELPOINT; // Not supported by D3D9
     lightingCaps.dwLightingModel = D3DLIGHTINGMODEL_RGB;
     lightingCaps.dwNumLights = ddrawCaps::MaxEnabledLights;
 
@@ -691,7 +693,7 @@ namespace dxvk {
                               | D3DPMISCCAPS_CULLCW
                               | D3DPMISCCAPS_CULLNONE
                            // | D3DPMISCCAPS_CONFORMANT
-                           // | D3DPMISCCAPS_LINEPATTERNREP // Not implemented in D3D9
+                           // | D3DPMISCCAPS_LINEPATTERNREP
                            // | D3DPMISCCAPS_MASKPLANES
                               | D3DPMISCCAPS_MASKZ;
 
@@ -704,9 +706,9 @@ namespace dxvk {
                               | D3DPRASTERCAPS_FOGTABLE
                               | D3DPRASTERCAPS_FOGVERTEX
                               | D3DPRASTERCAPS_MIPMAPLODBIAS
-                           // | D3DPRASTERCAPS_PAT // Not implemented in D3D9
+                           // | D3DPRASTERCAPS_PAT
                            // | D3DPRASTERCAPS_ROP2
-                              | D3DPRASTERCAPS_STIPPLE // Technically not implemented
+                           // | D3DPRASTERCAPS_STIPPLE
                               | D3DPRASTERCAPS_SUBPIXEL
                            // | D3DPRASTERCAPS_SUBPIXELX
                            // | D3DPRASTERCAPS_TRANSLUCENTSORTINDEPENDENT
@@ -714,13 +716,12 @@ namespace dxvk {
                               | D3DPRASTERCAPS_WFOG
                            // | D3DPRASTERCAPS_XOR
                               | D3DPRASTERCAPS_ZBIAS
-                           // | D3DPRASTERCAPS_ZBUFFERLESSHSR // Easy footgun to not get a z-buffer
+                           // | D3DPRASTERCAPS_ZBUFFERLESSHSR
                               | D3DPRASTERCAPS_ZFOG
                               | D3DPRASTERCAPS_ZTEST;
 
     if (unlikely(options->emulateFSAA != FSAAEmulation::Disabled)) {
-      prim.dwRasterCaps |= D3DPRASTERCAPS_ANTIALIASSORTDEPENDENT
-                        |  D3DPRASTERCAPS_ANTIALIASSORTINDEPENDENT;
+      prim.dwRasterCaps |= D3DPRASTERCAPS_ANTIALIASSORTINDEPENDENT;
     }
 
     prim.dwZCmpCaps           = D3DPCMPCAPS_ALWAYS
@@ -775,12 +776,10 @@ namespace dxvk {
     prim.dwTextureCaps        = D3DPTEXTURECAPS_ALPHA
                               | D3DPTEXTURECAPS_BORDER
                               | D3DPTEXTURECAPS_PERSPECTIVE
+                              | D3DPTEXTURECAPS_POW2 // Always reported on early D3D cards
+                              | D3DPTEXTURECAPS_NONPOW2CONDITIONAL // Reported only on later (D3D7/8) D3D cards
                            // | D3DPTEXTURECAPS_SQUAREONLY
                               | D3DPTEXTURECAPS_TRANSPARENCY;
-
-    if (unlikely(options->forcePOW2Textures)) {
-      prim.dwTextureCaps |= D3DPTEXTURECAPS_POW2;
-    }
 
     prim.dwTextureFilterCaps  = D3DPTFILTERCAPS_LINEAR
                               | D3DPTFILTERCAPS_LINEARMIPLINEAR
@@ -804,8 +803,8 @@ namespace dxvk {
                               | D3DPTADDRESSCAPS_MIRROR
                               | D3DPTADDRESSCAPS_WRAP;
 
-    prim.dwStippleWidth       = 32;
-    prim.dwStippleHeight      = 32;
+    prim.dwStippleWidth       = 0;
+    prim.dwStippleHeight      = 0;
 
     desc.dpcLineCaps          = prim;
     desc.dpcTriCaps           = prim;
@@ -854,7 +853,7 @@ namespace dxvk {
                 // | D3DDEVCAPS_SORTDECREASINGZ
                 // | D3DDEVCAPS_SORTEXACT
                 // | D3DDEVCAPS_SORTINCREASINGZ
-                // | D3DDEVCAPS_TEXTURENONLOCALVIDMEM // Exposed though a config option
+                // | D3DDEVCAPS_TEXTURENONLOCALVIDMEM // Exposed through a config option
                 // | D3DDEVCAPS_TEXTURESYSTEMMEMORY
                    | D3DDEVCAPS_TEXTUREVIDEOMEMORY
                    | D3DDEVCAPS_TLVERTEXSYSTEMMEMORY
@@ -866,7 +865,7 @@ namespace dxvk {
     }
 
     // Also advertised in D3D6
-    if (rclsid == IID_IDirect3DHALDevice || rclsid == IID_WineD3DDevice) {
+    if (rclsid == IID_IDirect3DHALDevice) {
       desc.dwDevCaps |= D3DDEVCAPS_HWRASTERIZATION
                       | D3DDEVCAPS_HWTRANSFORMANDLIGHT
                       | D3DDEVCAPS_DRAWPRIMITIVES2
@@ -883,11 +882,10 @@ namespace dxvk {
 
     D3DLIGHTINGCAPS lightingCaps;
     lightingCaps.dwSize  = sizeof(D3DLIGHTINGCAPS);
-    lightingCaps.dwCaps  = D3DLIGHTCAPS_DIRECTIONAL
-                      // | D3DLIGHTCAPS_GLSPOT
-                         | D3DLIGHTCAPS_PARALLELPOINT // Not supported by D3D9
-                         | D3DLIGHTCAPS_POINT
-                         | D3DLIGHTCAPS_SPOT;
+    lightingCaps.dwCaps  = D3DLIGHTCAPS_POINT
+                         | D3DLIGHTCAPS_SPOT
+                         | D3DLIGHTCAPS_DIRECTIONAL
+                         | D3DLIGHTCAPS_PARALLELPOINT; // Not supported by D3D9
     lightingCaps.dwLightingModel = D3DLIGHTINGMODEL_RGB;
     lightingCaps.dwNumLights = ddrawCaps::MaxEnabledLights;
 
@@ -900,7 +898,7 @@ namespace dxvk {
                               | D3DPMISCCAPS_CULLCW
                               | D3DPMISCCAPS_CULLNONE
                            // | D3DPMISCCAPS_CONFORMANT
-                           // | D3DPMISCCAPS_LINEPATTERNREP // Not implemented in D3D9
+                           // | D3DPMISCCAPS_LINEPATTERNREP
                            // | D3DPMISCCAPS_MASKPLANES
                               | D3DPMISCCAPS_MASKZ;
 
@@ -913,9 +911,9 @@ namespace dxvk {
                               | D3DPRASTERCAPS_FOGTABLE
                               | D3DPRASTERCAPS_FOGVERTEX
                               | D3DPRASTERCAPS_MIPMAPLODBIAS
-                           // | D3DPRASTERCAPS_PAT // Not implemented in D3D9
+                           // | D3DPRASTERCAPS_PAT
                            // | D3DPRASTERCAPS_ROP2
-                              | D3DPRASTERCAPS_STIPPLE // Technically not implemented
+                           // | D3DPRASTERCAPS_STIPPLE
                               | D3DPRASTERCAPS_SUBPIXEL
                            // | D3DPRASTERCAPS_SUBPIXELX
                            // | D3DPRASTERCAPS_TRANSLUCENTSORTINDEPENDENT
@@ -923,13 +921,12 @@ namespace dxvk {
                               | D3DPRASTERCAPS_WFOG
                            // | D3DPRASTERCAPS_XOR
                               | D3DPRASTERCAPS_ZBIAS
-                           // | D3DPRASTERCAPS_ZBUFFERLESSHSR // Easy footgun to not get a z-buffer
+                           // | D3DPRASTERCAPS_ZBUFFERLESSHSR
                               | D3DPRASTERCAPS_ZFOG
                               | D3DPRASTERCAPS_ZTEST;
 
     if (unlikely(options->emulateFSAA != FSAAEmulation::Disabled)) {
-      prim.dwRasterCaps |= D3DPRASTERCAPS_ANTIALIASSORTDEPENDENT
-                        |  D3DPRASTERCAPS_ANTIALIASSORTINDEPENDENT;
+      prim.dwRasterCaps |= D3DPRASTERCAPS_ANTIALIASSORTINDEPENDENT;
     }
 
     prim.dwZCmpCaps           = D3DPCMPCAPS_ALWAYS
@@ -985,14 +982,11 @@ namespace dxvk {
                               | D3DPTEXTURECAPS_ALPHAPALETTE
                               | D3DPTEXTURECAPS_BORDER
                               | D3DPTEXTURECAPS_PERSPECTIVE
+                              | D3DPTEXTURECAPS_POW2 // Always reported on early D3D cards
+                              | D3DPTEXTURECAPS_NONPOW2CONDITIONAL // Reported only on later (D3D7/8) D3D cards
                            // | D3DPTEXTURECAPS_SQUAREONLY
                               | D3DPTEXTURECAPS_TEXREPEATNOTSCALEDBYSIZE
                               | D3DPTEXTURECAPS_TRANSPARENCY;
-
-    if (unlikely(options->forcePOW2Textures)) {
-      prim.dwTextureCaps |= D3DPTEXTURECAPS_NONPOW2CONDITIONAL
-                          | D3DPTEXTURECAPS_POW2;
-    }
 
     prim.dwTextureFilterCaps  = D3DPTFILTERCAPS_LINEAR
                               | D3DPTFILTERCAPS_LINEARMIPLINEAR
@@ -1026,8 +1020,8 @@ namespace dxvk {
                               | D3DPTADDRESSCAPS_MIRROR
                               | D3DPTADDRESSCAPS_WRAP;
 
-    prim.dwStippleWidth       = 32;
-    prim.dwStippleHeight      = 32;
+    prim.dwStippleWidth       = 0;
+    prim.dwStippleHeight      = 0;
 
     desc.dpcLineCaps          = prim;
     desc.dpcTriCaps           = prim;
@@ -1114,7 +1108,7 @@ namespace dxvk {
                  // | D3DDEVCAPS_SORTEXACT
                  // | D3DDEVCAPS_SORTINCREASINGZ
                  // | D3DDEVCAPS_STRIDEDVERTICES // Mentioned in the docs, but apparently is a ghost
-                 // | D3DDEVCAPS_TEXTURENONLOCALVIDMEM // Exposed though a config option
+                 // | D3DDEVCAPS_TEXTURENONLOCALVIDMEM // Exposed through a config option
                  // | D3DDEVCAPS_TEXTURESYSTEMMEMORY
                     | D3DDEVCAPS_TEXTUREVIDEOMEMORY
                     | D3DDEVCAPS_TLVERTEXSYSTEMMEMORY
@@ -1131,7 +1125,7 @@ namespace dxvk {
                        | D3DDEVCAPS_DRAWPRIMITIVES2
                        | D3DDEVCAPS_DRAWPRIMITIVES2EX;
     }
-    else if (rclsid == IID_IDirect3DHALDevice || rclsid == IID_WineD3DDevice) {
+    else if (rclsid == IID_IDirect3DHALDevice) {
       desc7.dwDevCaps |= D3DDEVCAPS_HWRASTERIZATION
                        | D3DDEVCAPS_DRAWPRIMITIVES2
                        | D3DDEVCAPS_DRAWPRIMITIVES2EX;
@@ -1144,7 +1138,7 @@ namespace dxvk {
                               | D3DPMISCCAPS_CULLCW
                               | D3DPMISCCAPS_CULLNONE
                            // | D3DPMISCCAPS_CONFORMANT
-                           // | D3DPMISCCAPS_LINEPATTERNREP // Not implemented in D3D9
+                           // | D3DPMISCCAPS_LINEPATTERNREP
                            // | D3DPMISCCAPS_MASKPLANES
                               | D3DPMISCCAPS_MASKZ;
 
@@ -1157,9 +1151,9 @@ namespace dxvk {
                               | D3DPRASTERCAPS_FOGTABLE
                               | D3DPRASTERCAPS_FOGVERTEX
                               | D3DPRASTERCAPS_MIPMAPLODBIAS
-                           // | D3DPRASTERCAPS_PAT // Not implemented in D3D9
+                           // | D3DPRASTERCAPS_PAT
                            // | D3DPRASTERCAPS_ROP2
-                              | D3DPRASTERCAPS_STIPPLE // Technically not implemented
+                           // | D3DPRASTERCAPS_STIPPLE
                               | D3DPRASTERCAPS_SUBPIXEL
                            // | D3DPRASTERCAPS_SUBPIXELX
                            // | D3DPRASTERCAPS_TRANSLUCENTSORTINDEPENDENT
@@ -1167,13 +1161,12 @@ namespace dxvk {
                               | D3DPRASTERCAPS_WFOG
                            // | D3DPRASTERCAPS_XOR
                               | D3DPRASTERCAPS_ZBIAS
-                           // | D3DPRASTERCAPS_ZBUFFERLESSHSR // Easy footgun to not get a z-buffer
+                           // | D3DPRASTERCAPS_ZBUFFERLESSHSR
                               | D3DPRASTERCAPS_ZFOG
                               | D3DPRASTERCAPS_ZTEST;
 
     if (unlikely(options->emulateFSAA != FSAAEmulation::Disabled)) {
-      prim.dwRasterCaps |= D3DPRASTERCAPS_ANTIALIASSORTDEPENDENT
-                        |  D3DPRASTERCAPS_ANTIALIASSORTINDEPENDENT;
+      prim.dwRasterCaps |= D3DPRASTERCAPS_ANTIALIASSORTINDEPENDENT;
     }
 
     prim.dwZCmpCaps           = D3DPCMPCAPS_ALWAYS
@@ -1232,14 +1225,11 @@ namespace dxvk {
                               | D3DPTEXTURECAPS_CUBEMAP
                               | D3DPTEXTURECAPS_PERSPECTIVE
                               | D3DPTEXTURECAPS_PROJECTED
+                              | D3DPTEXTURECAPS_POW2 // Always reported on early D3D cards
+                              | D3DPTEXTURECAPS_NONPOW2CONDITIONAL // Reported only on later (D3D7/8) D3D cards
                            // | D3DPTEXTURECAPS_SQUAREONLY
                               | D3DPTEXTURECAPS_TEXREPEATNOTSCALEDBYSIZE
                               | D3DPTEXTURECAPS_TRANSPARENCY;
-
-    if (unlikely(options->forcePOW2Textures)) {
-      prim.dwTextureCaps |= D3DPTEXTURECAPS_NONPOW2CONDITIONAL
-                          | D3DPTEXTURECAPS_POW2;
-    }
 
     prim.dwTextureFilterCaps  = D3DPTFILTERCAPS_LINEAR
                               | D3DPTFILTERCAPS_LINEARMIPLINEAR
@@ -1275,8 +1265,8 @@ namespace dxvk {
                               | D3DPTADDRESSCAPS_MIRROR
                               | D3DPTADDRESSCAPS_WRAP;
 
-    prim.dwStippleWidth       = 32;
-    prim.dwStippleHeight      = 32;
+    prim.dwStippleWidth       = 0;
+    prim.dwStippleHeight      = 0;
 
     desc7.dpcLineCaps         = prim;
     desc7.dpcTriCaps          = prim;

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1483,12 +1483,14 @@ namespace dxvk {
     { R"(\\SCP - Containment Breach\.exe$)", {{
       { "ddraw.forceLegacyPresent",         "True" },
       { "ddraw.forceMultiThreaded",         "True" },
+      { "ddraw.managedVertexBuffers",       "True" },
     }} },
     /* SCP - Nine-Tailed Fox                      *
      * Same engine as Containment Breach          */
     { R"(\\SCP Nine-Tailed Fox\.exe$)", {{
       { "ddraw.forceLegacyPresent",         "True" },
       { "ddraw.forceMultiThreaded",         "True" },
+      { "ddraw.managedVertexBuffers",       "True" },
     }} },
     /* Unreal                                     *
      * Fixes missing mip map uploads and physics  */
@@ -1603,9 +1605,11 @@ namespace dxvk {
       { "ddraw.legacyPresentGuard",       "Strict" },
     }} },
     /* Need for Speed: Porsche Unleashed          *
-     * Fixes missing mip maps on car models       */
+     * Fixes missing mip maps on car models       *
+     * and Z-fighting with projected lights       */
     { R"(\\(Porsche|nfs5)\.exe$)", {{
       { "ddraw.autoGenMipMaps",             "True" },
+      { "ddraw.useD16forD24X8",             "True" },
     }} },
     /* Star Trek: Deep Space Nine - The Fallen    *
      * Fixes missing mip map uploads              */
@@ -1774,12 +1778,8 @@ namespace dxvk {
       { "ddraw.legacyPresentGuard",       "Strict" },
     }} },
     /* Expendable                                 */
-    { R"(\\Expendable\\go_start\.exe$)", {{
+    { R"(\\Expendable\\go(_start)?\.exe$)", {{
       { "ddraw.support32BitDepth",         "False" },
-    }} },
-    /* Total Annihilation: Kingdoms               */
-    { R"(\\KINGDOMS\.icd$)", {{
-      { "ddraw.forcePOW2Textures",          "True" },
     }} },
     /* Gorky 17                                   */
     { R"(\\gorky17\.exe$)", {{
@@ -1790,7 +1790,6 @@ namespace dxvk {
      * too dark in-game gamma/brightness          */
     { R"(\\Revenant\.exe$)", {{
       { "ddraw.forceLegacyPresent",         "True" },
-      { "ddraw.forcePOW2Textures",          "True" },
       { "ddraw.ignoreGammaRamp",            "True" },
     }} },
     /* Slave Zero - will not start in 32-bit      *
@@ -1816,6 +1815,7 @@ namespace dxvk {
     { R"(\\tomb4\.exe$)", {{
       { "ddraw.forceLegacyPresent",         "True" },
       { "ddraw.emulateFrontBuffer",         "True" },
+      { "ddraw.managedVertexBuffers",       "True" },
     }} },
     /* Tomb Raider Chronicles                     *
      * Fixes missing pause screen background      */
@@ -1847,8 +1847,10 @@ namespace dxvk {
       { "ddraw.colorKeyMasking",            "True" },
     }} },
     /* Dungeon Keeper 2                           *
-     * Fixes missing HW acceleration option       */
-    { R"(\\DKII(-DX)?\.exe$)", {{
+     * Fixes fast animation speed at high FPS     *
+     * and missing HW acceleration option         */
+    { R"(\\DKII\.EXE$)", {{
+      { "d3d9.maxFrameRate",                 "-60" },
       { "ddraw.legacyDeviceNames",          "True" },
     }} },
     /* Might and Magic VII: For Blood and Honor   *
@@ -1875,7 +1877,7 @@ namespace dxvk {
     /* Half-Life (: Opposing Force/: Blue Shift)  */
     { R"(\\hl\.exe$)", {{
       { "ddraw.forceLegacyPresent",         "True" },
-      { "ddraw.forceSWVP",                  "True" },
+      { "ddraw.managedVertexBuffers",       "True" },
     }} },
     /* The Sims (& DLCs/Expansion Packs)          */
     { R"(\\Sims\.(exe|icd)$)", {{
@@ -1888,9 +1890,10 @@ namespace dxvk {
     { R"(\\midtown\.(exe|icd)$)", {{
       { "ddraw.legacyDeviceNames",          "True" },
     }} },
-    /* Matrox G400 TechDemo - prevents crashing   */
-    { R"(\\Matrox\.exe$)", {{
-      { "ddraw.forcePOW2Textures",          "True" },
+    /* Toy Story 2: Buzz Lightyear to the Rescue  */
+    { R"(\\toy2\.exe$)", {{
+      { "d3d9.maxFrameRate",                  "30" },
+      { "ddraw.managedVertexBuffers",       "True" },
     }} },
 
     /**********************************************/
@@ -1971,6 +1974,10 @@ namespace dxvk {
     }} },
     /* Tex Murtphy: Overseer                      */
     { R"(\\OVERSEER\.exe$)", {{
+      { "ddraw.forceLegacyPresent",         "True" },
+    }} },
+    /* Resident Evil 2                            */
+    { R"(\\(ClaireU|LeonU)\.exe$)", {{
       { "ddraw.forceLegacyPresent",         "True" },
     }} },
 


### PR DESCRIPTION
As the title says, this backports D7VK's v2.0 codebase to Sarek, providing a significant performance boost to early D3D, as well as various other fixes.