### PR TITLE
[d3d7] Backport D7VK v2.1 and the D3D9 bridge rework

### DIFF
--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -24,7 +24,7 @@ namespace dxvk {
     , m_behaviorFlags(BehaviorFlags)
     , m_multithread(BehaviorFlags & D3DCREATE_MULTITHREADED) {
     // Get the bridge interface to D3D9.
-    if (unlikely(FAILED(GetD3D9()->QueryInterface(__uuidof(IDxvkD3D8Bridge), reinterpret_cast<void**>(&m_bridge))))) {
+    if (unlikely(FAILED(GetD3D9()->QueryInterface(__uuidof(IDxvkLegacyD3DDeviceBridge), reinterpret_cast<void**>(&m_bridge))))) {
       throw DxvkError("D3D8Device: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
     }
 
@@ -41,8 +41,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::GetInfo(DWORD DevInfoID, void* pDevInfoStruct, DWORD DevInfoStructSize) {
-    Logger::debug(str::format("D3D8Device::GetInfo: ", DevInfoID));
-
     if (unlikely(pDevInfoStruct == nullptr || DevInfoStructSize == 0))
       return D3DERR_INVALIDCALL;
 
@@ -727,7 +725,6 @@ namespace dxvk {
     }
 
     for (uint32_t i = 0; i < cRects; i++) {
-
       RECT srcRect, dstRect;
       srcRect = pSourceRectsArray[i];
 
@@ -752,20 +749,6 @@ namespace dxvk {
 
       POINT dstPt = { dstRect.left, dstRect.top };
 
-      auto unsupported = [&] {
-        Logger::err(str::format("D3D8Device::CopyRects: Unsupported case from src pool ", srcDesc.Pool, " to dst pool ", dstDesc.Pool));
-        return D3DERR_INVALIDCALL;
-      };
-
-      auto logError = [&] (HRESULT res) {
-        if (FAILED(res)) {
-          // Only a debug message because some games mess up CopyRects every frame in a way
-          // that fails on native too but are perfectly fine with it.
-          Logger::debug(str::format("D3D8Device::CopyRects: Failed to copy from src pool ", srcDesc.Pool, " to dst pool ", dstDesc.Pool));
-        }
-        return res;
-      };
-
       switch (dstDesc.Pool) {
 
         // Dest: DEFAULT
@@ -773,31 +756,31 @@ namespace dxvk {
           switch (srcDesc.Pool) {
             case d3d9::D3DPOOL_DEFAULT: {
               // DEFAULT -> DEFAULT: use StretchRect
-              return logError(GetD3D9()->StretchRect(
+              return GetD3D9()->StretchRect(
                 src->GetD3D9(),
                 &srcRect,
                 dst->GetD3D9(),
                 &dstRect,
                 d3d9::D3DTEXF_NONE
-              ));
+              );
             }
             case d3d9::D3DPOOL_MANAGED: {
               // MANAGED -> DEFAULT: UpdateTextureFromBuffer
-              return logError(m_bridge->UpdateTextureFromBuffer(
+              return m_bridge->UpdateTextureFromBuffer(
                 src->GetD3D9(),
                 dst->GetD3D9(),
                 &srcRect,
                 &dstPt
-              ));
+              );
             }
             case d3d9::D3DPOOL_SYSTEMMEM: {
               // SYSTEMMEM -> DEFAULT: use UpdateSurface
-              return logError(GetD3D9()->UpdateSurface(
+              return GetD3D9()->UpdateSurface(
                 src->GetD3D9(),
                 &srcRect,
                 dst->GetD3D9(),
                 &dstPt
-              ));
+              );
             }
             case d3d9::D3DPOOL_SCRATCH: {
               // SCRATCH -> DEFAULT: memcpy to a SYSTEMMEM temporary buffer and use UpdateSurface
@@ -805,7 +788,7 @@ namespace dxvk {
               const bool isSupportedSurfaceFormat = m_bridge->IsSupportedSurfaceFormat(srcDesc.Format);
               // UpdateSurface will not work on surface formats unsupported by D3DPOOL_DEFAULT
               if (unlikely(!isSupportedSurfaceFormat))
-                return logError(D3DERR_INVALIDCALL);
+                return D3DERR_INVALIDCALL;
 
               Com<IDirect3DSurface8> pTempImageSurface;
               // The temporary image surface is guaranteed to end up in SYSTEMMEM for supported formats
@@ -815,28 +798,24 @@ namespace dxvk {
                 D3DFORMAT(srcDesc.Format),
                 &pTempImageSurface
               );
-
-              if (FAILED(res)) {
-                return logError(res);
-              }
+              if (unlikely(FAILED(res)))
+                return res;
 
               Com<D3D8Surface> pBlitImage = static_cast<D3D8Surface*>(pTempImageSurface.ptr());
               // Temporary image surface dimensions are identical, so we can reuse srcDesc/Rect
               res = copyTextureBuffers(src.ptr(), pBlitImage.ptr(), srcDesc, srcDesc, srcRect, srcRect);
+              if (unlikely(FAILED(res)))
+                return res;
 
-              if (FAILED(res)) {
-                return logError(res);
-              }
-
-              return logError(GetD3D9()->UpdateSurface(
+              return GetD3D9()->UpdateSurface(
                 pBlitImage->GetD3D9(),
                 &srcRect,
                 dst->GetD3D9(),
                 &dstPt
-              ));
+              );
             }
             default: {
-              return unsupported();
+              return D3DERR_INVALIDCALL;
             }
           } break;
 
@@ -855,27 +834,24 @@ namespace dxvk {
                 pBlitImage.ptr(),
                 &dstRect,
                 d3d9::D3DTEXF_NONE);
-
-              if (FAILED(res)) {
-                return logError(res);
-              }
+              if (unlikely(FAILED(res)))
+                return res;
 
               // Now sync the rendertarget data into main memory.
-              return logError(GetD3D9()->GetRenderTargetData(pBlitImage.ptr(), dst->GetD3D9()));
+              return GetD3D9()->GetRenderTargetData(pBlitImage.ptr(), dst->GetD3D9());
             }
             case d3d9::D3DPOOL_MANAGED:
             case d3d9::D3DPOOL_SYSTEMMEM:
             case d3d9::D3DPOOL_SCRATCH: {
               // MANAGED/SYSMEM/SCRATCH -> MANAGED: LockRect / memcpy
 
-              if (stretch) {
-                return logError(D3DERR_INVALIDCALL);
-              }
+              if (unlikely(stretch))
+                return D3DERR_INVALIDCALL;
 
-              return logError(copyTextureBuffers(src.ptr(), dst.ptr(), srcDesc, dstDesc, srcRect, dstRect));
+              return copyTextureBuffers(src.ptr(), dst.ptr(), srcDesc, dstDesc, srcRect, dstRect);
             }
             default: {
-              return unsupported();
+              return D3DERR_INVALIDCALL;
             }
           } break;
 
@@ -891,7 +867,7 @@ namespace dxvk {
                 && srcDesc.Height == dstDesc.Height
                 && srcDesc.Format == dstDesc.Format
                 && !asymmetric) {
-              return logError(GetD3D9()->GetRenderTargetData(src->GetD3D9(), dst->GetD3D9()));
+              return GetD3D9()->GetRenderTargetData(src->GetD3D9(), dst->GetD3D9());
             }
           }
 
@@ -907,26 +883,23 @@ namespace dxvk {
                 pBlitImage.ptr(),
                 &dstRect,
                 d3d9::D3DTEXF_NONE);
-
-              if (FAILED(res)) {
-                return logError(res);
-              }
+              if (unlikely(FAILED(res)))
+                return res;
 
               // Now sync the rendertarget data into main memory.
-              return logError(GetD3D9()->GetRenderTargetData(pBlitImage.ptr(), dst->GetD3D9()));
+              return GetD3D9()->GetRenderTargetData(pBlitImage.ptr(), dst->GetD3D9());
             }
             // MANAGED/SYSMEM/SCRATCH -> SYSMEM: LockRect / memcpy
             case d3d9::D3DPOOL_MANAGED:
             case d3d9::D3DPOOL_SYSTEMMEM:
             case d3d9::D3DPOOL_SCRATCH: {
-              if (stretch) {
-                return logError(D3DERR_INVALIDCALL);
-              }
+              if (unlikely(stretch))
+                return D3DERR_INVALIDCALL;
 
-              return logError(copyTextureBuffers(src.ptr(), dst.ptr(), srcDesc, dstDesc, srcRect, dstRect));
+              return copyTextureBuffers(src.ptr(), dst.ptr(), srcDesc, dstDesc, srcRect, dstRect);
             }
             default: {
-              return unsupported();
+              return D3DERR_INVALIDCALL;
             }
           } break;
         }
@@ -943,7 +916,7 @@ namespace dxvk {
                 && srcDesc.Height == dstDesc.Height
                 && srcDesc.Format == dstDesc.Format
                 && !asymmetric) {
-              return logError(GetD3D9()->GetRenderTargetData(src->GetD3D9(), dst->GetD3D9()));
+              return GetD3D9()->GetRenderTargetData(src->GetD3D9(), dst->GetD3D9());
             }
           }
 
@@ -959,31 +932,28 @@ namespace dxvk {
                 pBlitImage.ptr(),
                 &dstRect,
                 d3d9::D3DTEXF_NONE);
-
-              if (FAILED(res)) {
-                return logError(res);
-              }
+              if (unlikely(FAILED(res)))
+                return res;
 
               // Now sync the rendertarget data into main memory.
-              return logError(GetD3D9()->GetRenderTargetData(pBlitImage.ptr(), dst->GetD3D9()));
+              return GetD3D9()->GetRenderTargetData(pBlitImage.ptr(), dst->GetD3D9());
             }
             // MANAGED/SYSMEM/SCRATCH -> SCRATCH: LockRect / memcpy
             case d3d9::D3DPOOL_MANAGED:
             case d3d9::D3DPOOL_SYSTEMMEM:
             case d3d9::D3DPOOL_SCRATCH: {
-              if (stretch) {
-                return logError(D3DERR_INVALIDCALL);
-              }
+              if (unlikely(stretch))
+                return D3DERR_INVALIDCALL;
 
-              return logError(copyTextureBuffers(src.ptr(), dst.ptr(), srcDesc, dstDesc, srcRect, dstRect));
+              return copyTextureBuffers(src.ptr(), dst.ptr(), srcDesc, dstDesc, srcRect, dstRect);
             }
             default: {
-              return unsupported();
+              return D3DERR_INVALIDCALL;
             }
           } break;
         }
         default: {
-          return unsupported();
+          return D3DERR_INVALIDCALL;
         }
       }
     }
@@ -1888,13 +1858,13 @@ namespace dxvk {
   inline D3D8VertexShaderInfo* getVertexShaderInfo(D3D8Device* device, DWORD Handle) {
     Handle = getShaderIndex(Handle);
     if (unlikely(Handle >= device->m_vertexShaders.size())) {
-      Logger::debug(str::format("D3D8: Invalid vertex shader index ", std::hex, Handle));
+      Logger::warn(str::format("D3D8Device: Invalid vertex shader handle ", std::hex, Handle));
       return nullptr;
     }
 
     D3D8VertexShaderInfo& info = device->m_vertexShaders[Handle];
     if (unlikely(info.pVertexDecl == nullptr && info.pVertexShader == nullptr)) {
-      Logger::debug(str::format("D3D8: Application provided deleted vertex shader ", std::hex, Handle));
+      Logger::warn(str::format("D3D8Device: Application provided deleted vertex shader ", std::hex, Handle));
       return nullptr;
     }
 
@@ -1914,7 +1884,7 @@ namespace dxvk {
     if (!isFVF(Handle)) {
       D3D8VertexShaderInfo* info = getVertexShaderInfo(this, Handle);
 
-      if (!info)
+      if (unlikely(!info))
         return D3DERR_INVALIDCALL;
 
       StateChange();
@@ -1980,7 +1950,7 @@ namespace dxvk {
     if (!isFVF(Handle)) {
       D3D8VertexShaderInfo* info = getVertexShaderInfo(this, Handle);
 
-      if (!info)
+      if (unlikely(!info))
         return D3DERR_INVALIDCALL;
 
       info->pVertexDecl = nullptr;
@@ -2082,14 +2052,14 @@ namespace dxvk {
     Handle = getShaderIndex(Handle);
 
     if (unlikely(Handle >= device->m_pixelShaders.size())) {
-      Logger::debug(str::format("D3D8: Invalid pixel shader index ", std::hex, Handle));
+      Logger::warn(str::format("D3D8Device: Invalid pixel shader handle ", std::hex, Handle));
       return nullptr;
     }
 
     d3d9::IDirect3DPixelShader9* pPixelShader = device->m_pixelShaders[Handle].ptr();
 
     if (unlikely(pPixelShader == nullptr)) {
-      Logger::debug(str::format("D3D8: Application provided deleted pixel shader ", std::hex, Handle));
+      Logger::warn(str::format("D3D8Device: Application provided deleted pixel shader ", std::hex, Handle));
       return nullptr;
     }
 
@@ -2103,17 +2073,16 @@ namespace dxvk {
       return m_recorder->SetPixelShader(Handle);
     }
 
-    if (Handle == DWORD(NULL)) {
+    if (!Handle) {
       StateChange();
-      m_currentPixelShader = DWORD(NULL);
+      m_currentPixelShader = 0;
       return GetD3D9()->SetPixelShader(nullptr);
     }
 
     d3d9::IDirect3DPixelShader9* pPixelShader = getPixelShaderPtr(this, Handle);
 
-    if (unlikely(!pPixelShader)) {
+    if (unlikely(!pPixelShader))
       return D3DERR_INVALIDCALL;
-    }
 
     StateChange();
     HRESULT res = GetD3D9()->SetPixelShader(pPixelShader);
@@ -2143,9 +2112,8 @@ namespace dxvk {
 
     d3d9::IDirect3DPixelShader9* pPixelShader = getPixelShaderPtr(this, Handle);
 
-    if (unlikely(!pPixelShader)) {
+    if (unlikely(!pPixelShader))
       return D3DERR_INVALIDCALL;
-    }
 
     m_pixelShaders[getShaderIndex(Handle)] = nullptr;
 

--- a/src/d3d8/d3d8_device.h
+++ b/src/d3d8/d3d8_device.h
@@ -432,19 +432,19 @@ namespace dxvk {
 
   private:
 
-    Com<IDxvkD3D8Bridge>  m_bridge;
-    const D3D8Options&    m_d3d8Options;
+    Com<IDxvkLegacyD3DDeviceBridge> m_bridge;
+    const D3D8Options&              m_d3d8Options;
 
-    Com<D3D8Interface>    m_parent;
+    Com<D3D8Interface>              m_parent;
 
-    D3DPRESENT_PARAMETERS m_presentParams;
+    D3DPRESENT_PARAMETERS           m_presentParams;
     
     // Value of D3DRS_LINEPATTERN
-    D3DLINEPATTERN        m_linePattern = { };
+    D3DLINEPATTERN                  m_linePattern = { };
     // Value of D3DRS_ZVISIBLE (although the RS is not supported, its value is stored)
-    DWORD                 m_zVisible    = 0;
+    DWORD                           m_zVisible    = 0;
 
-    bool                  m_shadowPerspectiveDivide = false;
+    bool                            m_shadowPerspectiveDivide = false;
 
     D3D8StateBlock*                           m_recorder = nullptr;
     DWORD                                     m_recorderToken = 0;
@@ -453,8 +453,8 @@ namespace dxvk {
     D3D8Batcher*                              m_batcher  = nullptr;
 
     struct D3D8VBO {
-      Com<D3D8VertexBuffer, false>   buffer = nullptr;
-      UINT                           stride = 0;
+      Com<D3D8VertexBuffer, false>  buffer = nullptr;
+      UINT                          stride = 0;
     };
 
     std::array<Com<D3D8Texture2D, false>, d8caps::MAX_TEXTURE_STAGES> m_textures;

--- a/src/d3d8/d3d8_interface.cpp
+++ b/src/d3d8/d3d8_interface.cpp
@@ -10,11 +10,11 @@ namespace dxvk {
   D3D8Interface::D3D8Interface()
     : m_d3d9(d3d9::Direct3DCreate9(D3D_SDK_VERSION)) {
     // Get the bridge interface to D3D9.
-    if (unlikely(FAILED(m_d3d9->QueryInterface(__uuidof(IDxvkD3D8InterfaceBridge), reinterpret_cast<void**>(&m_bridge))))) {
+    if (unlikely(FAILED(m_d3d9->QueryInterface(__uuidof(IDxvkLegacyD3DInterfaceBridge), reinterpret_cast<void**>(&m_bridge))))) {
       throw DxvkError("D3D8Interface: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
     }
 
-    m_bridge->EnableD3D8CompatibilityMode();
+    m_bridge->SetD3DCompatibility(D3DCompatibility::D3D8);
 
     m_d3d8Options = D3D8Options(*m_bridge->GetConfig());
 

--- a/src/d3d8/d3d8_interface.h
+++ b/src/d3d8/d3d8_interface.h
@@ -183,7 +183,7 @@ namespace dxvk {
     std::vector<std::vector<d3d9::D3DDISPLAYMODE>>  m_adapterModes;
 
     Com<d3d9::IDirect3D9>                           m_d3d9;
-    Com<IDxvkD3D8InterfaceBridge>                   m_bridge;
+    Com<IDxvkLegacyD3DInterfaceBridge>              m_bridge;
     D3D8Options                                     m_d3d8Options;
   };
 

--- a/src/d3d8/d3d8_shader.cpp
+++ b/src/d3d8/d3d8_shader.cpp
@@ -136,8 +136,8 @@ namespace dxvk {
     uint32_t i = 0;
     DWORD token;
 
-    std::stringstream dbg;
-    dbg << "D3D8: Vertex Declaration Tokens:\n\t";
+    //std::stringstream dbg;
+    //dbg << "D3D8: Vertex Declaration Tokens:\n\t";
 
     WORD currentStream = 0;
     WORD currentOffset = 0;
@@ -165,74 +165,89 @@ namespace dxvk {
     if (options.forceVsDecl.size() == 0) do {
       token = pDeclaration[i++];
 
-      D3DVSD_TOKENTYPE tokenType = D3DVSD_TOKENTYPE(VSD_SHIFT_MASK(token, D3DVSD_TOKENTYPE));
+      const D3DVSD_TOKENTYPE tokenType = D3DVSD_TOKENTYPE(VSD_SHIFT_MASK(token, D3DVSD_TOKENTYPE));
 
       switch (tokenType) {
         case D3DVSD_TOKEN_NOP:
-          dbg << "NOP";
+          //dbg << "NOP";
           break;
         case D3DVSD_TOKEN_STREAM: {
-          dbg << "STREAM ";
+          //dbg << "STREAM ";
 
           // TODO: D3DVSD_STREAM_TESS
-          if (token & D3DVSD_STREAMTESSMASK) {
-            dbg << "TESS";
+          if (unlikely(token & D3DVSD_STREAMTESSMASK)) {
+            //dbg << "TESS";
+
+            static bool s_streamTessErrorShown;
+
+            if (!std::exchange(s_streamTessErrorShown, true))
+              Logger::warn("D3D8Device::CreateVertexShader: Unhandled D3DVSD_STREAMTESSMASK");
           }
 
-          DWORD streamNum = VSD_SHIFT_MASK(token, D3DVSD_STREAMNUMBER);
+          const DWORD streamNum = VSD_SHIFT_MASK(token, D3DVSD_STREAMNUMBER);
+          //dbg << ", num=" << streamNum;
 
           currentStream = WORD(streamNum);
           currentOffset = 0; // reset offset
 
-          dbg << ", num=" << streamNum;
           break;
         }
         case D3DVSD_TOKEN_STREAMDATA: {
-
-          dbg << "STREAMDATA ";
+          //dbg << "STREAMDATA ";
 
           // D3DVSD_SKIP
           if (token & VSD_SKIP_FLAG) {
-            auto skipCount = VSD_SHIFT_MASK(token, D3DVSD_SKIPCOUNT);
-            dbg << "SKIP " << " count=" << skipCount;
+            const DWORD skipCount = VSD_SHIFT_MASK(token, D3DVSD_SKIPCOUNT);
+            //dbg << "SKIP " << " count=" << skipCount;
             currentOffset += WORD(skipCount) * sizeof(DWORD);
             break;
           }
 
           // D3DVSD_REG
-          DWORD dataLoadType = VSD_SHIFT_MASK(token, D3DVSD_DATALOADTYPE);
+          const DWORD dataLoadType = VSD_SHIFT_MASK(token, D3DVSD_DATALOADTYPE);
 
-          if ( dataLoadType == 0 ) { // vertex
+          if (likely(dataLoadType == 0)) { // vertex
             D3DVSDT_TYPE     type = D3DVSDT_TYPE(VSD_SHIFT_MASK(token, D3DVSD_DATATYPE));
             D3DVSDE_REGISTER reg  = D3DVSDE_REGISTER(VSD_SHIFT_MASK(token, D3DVSD_VERTEXREG));
+            //dbg << "type=" << type << ", register=" << reg;
 
             // FVF normals are expected to only have 3 components
             if (unlikely(pFunction == nullptr && reg == D3DVSDE_NORMAL && type != D3DVSDT_FLOAT3)) {
-              Logger::err("D3D8Device::CreateVertexShader: Invalid FVF declaration: D3DVSDE_NORMAL must use D3DVSDT_FLOAT3");
+              Logger::warn("D3D8Device::CreateVertexShader: Invalid FVF declaration: D3DVSDE_NORMAL must use D3DVSDT_FLOAT3");
               return D3DERR_INVALIDCALL;
             }
 
             addVertexElement(reg, type);
-
-            dbg << "type=" << type << ", register=" << reg;
+          // TODO: When would this bit be 1?
           } else {
-            // TODO: When would this bit be 1?
-            dbg << "D3DVSD_DATALOADTYPE " << dataLoadType;
+            //dbg << "D3DVSD_DATALOADTYPE " << dataLoadType;
+
+            static bool s_dataLoadTypeErrorShown;
+
+            if (!std::exchange(s_dataLoadTypeErrorShown, true))
+              Logger::warn("D3D8Device::CreateVertexShader: Unhandled non-zero D3DVSD_DATALOADTYPE");
           }
           break;
         }
-        case D3DVSD_TOKEN_TESSELLATOR:
-          dbg << "TESSELLATOR " << std::hex << token;
-          // TODO: D3DVSD_TOKEN_TESSELLATOR
-          break;
-        case D3DVSD_TOKEN_CONSTMEM: {
-          dbg << "CONSTMEM ";
-          DWORD count     = VSD_SHIFT_MASK(token, D3DVSD_CONSTCOUNT);
-          DWORD regCount  = count * 4;
-          DWORD addr      = VSD_SHIFT_MASK(token, D3DVSD_CONSTADDRESS);
-          DWORD rs        = VSD_SHIFT_MASK(token, D3DVSD_CONSTRS);
+        // TODO: D3DVSD_TOKEN_TESSELLATOR
+        case D3DVSD_TOKEN_TESSELLATOR: {
+          //dbg << "TESSELLATOR " << std::hex << token;
 
-          dbg << "count=" << count << ", addr=" << addr << ", rs=" << rs;
+          static bool s_tesselatorErrorShown;
+
+          if (!std::exchange(s_tesselatorErrorShown, true))
+            Logger::warn("D3D8Device::CreateVertexShader: Unhandled D3DVSD_TOKEN_TESSELLATOR");
+
+          break;
+        }
+        case D3DVSD_TOKEN_CONSTMEM: {
+          //dbg << "CONSTMEM ";
+
+          const DWORD count    = VSD_SHIFT_MASK(token, D3DVSD_CONSTCOUNT);
+          const DWORD regCount = count * 4;
+          //const DWORD rs       = VSD_SHIFT_MASK(token, D3DVSD_CONSTRS);
+          DWORD addr           = VSD_SHIFT_MASK(token, D3DVSD_CONSTADDRESS);
+          //dbg << "count=" << count << ", rs=" << rs << ", addr=" << addr;
 
           // Add a DEF instruction for each constant
           for (uint32_t j = 0; j < regCount; j += 4) {
@@ -248,26 +263,29 @@ namespace dxvk {
           break;
         }
         case D3DVSD_TOKEN_EXT: {
-          dbg << "EXT " << std::hex << token << " ";
-          DWORD extInfo = VSD_SHIFT_MASK(token, D3DVSD_EXTINFO);
-          DWORD extCount = VSD_SHIFT_MASK(token, D3DVSD_EXTCOUNT);
-          dbg << "info=" << extInfo << ", count=" << extCount;
+          //dbg << "EXT " << std::hex << token << " ";
+
+          /*const DWORD extInfo = VSD_SHIFT_MASK(token, D3DVSD_EXTINFO);
+          const DWORD extCount = VSD_SHIFT_MASK(token, D3DVSD_EXTCOUNT);
+          dbg << "info=" << extInfo << ", count=" << extCount;*/
+
           break;
         }
         case D3DVSD_TOKEN_END: {
+          //dbg << "END";
           vertexElements[elementIdx++] = D3DDECL_END();
-          dbg << "END";
           break;
         }
         default:
-          dbg << "UNKNOWN TYPE";
+          //dbg << "UNKNOWN TYPE " << std::hex << token << " ";
+          Logger::warn(str::format("D3D8Device::CreateVertexShader: Unhandled token type ", std::hex, token));
           break;
       }
-      dbg << "\n\t";
-      //dbg << std::hex << token << " ";
+
+      //dbg << "\n\t";
     } while (token != D3DVSD_END());
 
-    Logger::debug(dbg.str());
+    //Logger::debug(dbg.str());
 
     // If forceVsDecl is set, use that decl instead.
     if (options.forceVsDecl.size() > 0) {
@@ -283,20 +301,18 @@ namespace dxvk {
       // Copy first token (version)
       tokens.push_back(pFunction[0]);
 
-      DWORD vsMajor = D3DSHADER_VERSION_MAJOR(pFunction[0]);
-      DWORD vsMinor = D3DSHADER_VERSION_MINOR(pFunction[0]);
-      Logger::debug(str::format("VS version: ", vsMajor, ".", vsMinor));
+      /*const DWORD vsMajor = D3DSHADER_VERSION_MAJOR(pFunction[0]);
+      const DWORD vsMinor = D3DSHADER_VERSION_MINOR(pFunction[0]);
+      Logger::debug(str::format("VS version: ", vsMajor, ".", vsMinor));*/
 
       // Insert dcl instructions
       for (UINT vn = 0; vn < D3D8_NUM_VERTEX_INPUT_REGISTERS; vn++) {
-
         // If bit N is set then we need to dcl register vN
         if ((shaderInputRegisters & (1 << vn)) != 0) {
+          //Logger::debug(str::format("\tShader Input Regsiter: v", vn));
 
-          Logger::debug(str::format("\tShader Input Regsiter: v", vn));
-
-          DWORD usage = D3D8_VERTEX_INPUT_REGISTERS[vn][0];
-          DWORD index = D3D8_VERTEX_INPUT_REGISTERS[vn][1];
+          const DWORD usage = D3D8_VERTEX_INPUT_REGISTERS[vn][0];
+          const DWORD index = D3D8_VERTEX_INPUT_REGISTERS[vn][1];
 
           tokens.push_back(encodeInstruction(d3d9::D3DSIO_DCL));                  // dcl opcode
           tokens.push_back(encodeDeclaration(d3d9::D3DDECLUSAGE(usage), index));  // usage token
@@ -315,18 +331,17 @@ namespace dxvk {
       do {
         token = pFunction[i++];
 
-        DWORD opcode = token & D3DSI_OPCODE_MASK;
+        const DWORD opcode = token & D3DSI_OPCODE_MASK;
 
         // Instructions
         if ((token & VS_BIT_PARAM) == 0) {
-
           // Swizzle fixup for opcodes that require explicit use of a replicate swizzle.
           if (opcode == D3DSIO_RSQ  || opcode == D3DSIO_RCP
            || opcode == D3DSIO_EXP  || opcode == D3DSIO_LOG
            || opcode == D3DSIO_EXPP || opcode == D3DSIO_LOGP) {
-            tokens.push_back(token);                            // instr
-            tokens.push_back(token = pFunction[i++]);           // dest
-            token = pFunction[i++];                             // src0
+            tokens.push_back(token);                   // instr
+            tokens.push_back(token = pFunction[i++]);  // dest
+            token = pFunction[i++];                    // src0
 
             // If no swizzling is done, then use the w-component.
             // See d8vk#43 for more information as this may need to change in some cases.

--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -140,12 +140,14 @@ namespace dxvk {
     copyToStringArray(pIdentifier->DeviceName,  device.DeviceName); // The GDI device name. Not the actual device name.
     copyToStringArray(pIdentifier->Driver,      driver);            // This is the driver's dll.
 
+    const bool isExtended = m_parent->IsD3DCompatibile(D3DCompatibility::D3D9Ex);
+
     pIdentifier->DeviceIdentifier       = guid;
     pIdentifier->DeviceId               = deviceId;
     pIdentifier->VendorId               = vendorId;
     pIdentifier->Revision               = 0;
     pIdentifier->SubSysId               = 0;
-    pIdentifier->WHQLLevel              = m_parent->IsExtended() ? 1 : 0; // This doesn't check with the driver on Direct3D9Ex and is always 1.
+    pIdentifier->WHQLLevel              = isExtended ? 1 : 0; // This doesn't check with the driver on Direct3D9Ex and is always 1.
     pIdentifier->DriverVersion.QuadPart = INT64_MAX;
 
     return D3D_OK;
@@ -352,8 +354,10 @@ namespace dxvk {
     if (unlikely(pCaps == nullptr))
       return D3DERR_INVALIDCALL;
 
+    const bool isD3D8Compatible = m_parent->IsD3DCompatibile(D3DCompatibility::D3D8);
+
     if (unlikely(DeviceType == D3DDEVTYPE_SW)) {
-      if (m_parent->IsD3D8Compatible())
+      if (isD3D8Compatible)
         return D3DERR_INVALIDCALL;
       else
         return D3DERR_NOTAVAILABLE;
@@ -361,7 +365,7 @@ namespace dxvk {
 
     auto& options = m_parent->GetOptions();
 
-    const uint32_t maxShaderModel = m_parent->IsD3D8Compatible() ? std::min(1u, options.shaderModel) : options.shaderModel;
+    const uint32_t maxShaderModel = isD3D8Compatible ? std::min(1u, options.shaderModel) : options.shaderModel;
 
     // TODO: Actually care about what the adapter supports here.
     // ^ For Intel and older cards most likely here.
@@ -479,7 +483,7 @@ namespace dxvk {
                                     | D3DPBLENDCAPS_BLENDFACTOR;
 
     // Only 9Ex devices advertise D3DPBLENDCAPS_SRCCOLOR2 and D3DPBLENDCAPS_INVSRCCOLOR2
-    if (m_parent->IsExtended())
+    if (m_parent->IsD3DCompatibile(D3DCompatibility::D3D9Ex))
       pCaps->SrcBlendCaps          |= D3DPBLENDCAPS_SRCCOLOR2
                                     | D3DPBLENDCAPS_INVSRCCOLOR2;
 
@@ -829,6 +833,16 @@ namespace dxvk {
       *pLUID = dxvk::GetAdapterLUID(m_ordinal);
 
     return D3D_OK;
+  }
+
+
+  void D3D9Adapter::RefreshFormatsTable() const {
+    m_d3d9Formats.RefreshFormatSupport(this);
+  }
+
+
+  bool D3D9Adapter::IsD3DCompatibile(D3DCompatibility d3dCompatibility) const {
+    return m_parent->IsD3DCompatibile(d3dCompatibility);
   }
 
 

--- a/src/d3d9/d3d9_adapter.h
+++ b/src/d3d9/d3d9_adapter.h
@@ -4,6 +4,7 @@
 
 #include "d3d9_options.h"
 #include "d3d9_format.h"
+#include "d3d9_bridge.h"
 
 #include "../dxvk/dxvk_adapter.h"
 
@@ -87,9 +88,9 @@ namespace dxvk {
       return m_d3d9Formats.GetUnsupportedFormatInfo(Format);
     }
 
-    void RefreshFormatsTable(bool isD3D8Compatible) const {
-        m_d3d9Formats.RefreshFormatSupport(isD3D8Compatible);
-      }
+    void RefreshFormatsTable() const;
+
+    bool IsD3DCompatibile(D3DCompatibility d3dCompatibility) const;
 
   private:
 

--- a/src/d3d9/d3d9_bridge.cpp
+++ b/src/d3d9/d3d9_bridge.cpp
@@ -8,49 +8,28 @@
 
 namespace dxvk {
 
-  DxvkD3D8Bridge::DxvkD3D8Bridge(D3D9DeviceEx* pDevice)
+  DxvkLegacyD3DDeviceBridge::DxvkLegacyD3DDeviceBridge(D3D9DeviceEx* pDevice)
     : m_device(pDevice) {
   }
 
-  DxvkD3D8Bridge::~DxvkD3D8Bridge() {
+  DxvkLegacyD3DDeviceBridge::~DxvkLegacyD3DDeviceBridge() {
   }
 
-  ULONG STDMETHODCALLTYPE DxvkD3D8Bridge::AddRef() {
+  ULONG STDMETHODCALLTYPE DxvkLegacyD3DDeviceBridge::AddRef() {
     return m_device->AddRef();
   }
 
-  ULONG STDMETHODCALLTYPE DxvkD3D8Bridge::Release() {
+  ULONG STDMETHODCALLTYPE DxvkLegacyD3DDeviceBridge::Release() {
     return m_device->Release();
   }
 
-  HRESULT STDMETHODCALLTYPE DxvkD3D8Bridge::QueryInterface(
+  HRESULT STDMETHODCALLTYPE DxvkLegacyD3DDeviceBridge::QueryInterface(
           REFIID  riid,
           void** ppvObject) {
     return m_device->QueryInterface(riid, ppvObject);
   }
 
-  uint32_t DxvkD3D8Bridge::DetermineInitialTextureMemory() {
-    const int64_t initialTextureMemory = m_device->DetermineInitialTextureMemory();
-    return initialTextureMemory > 0 ? static_cast<uint32_t>(initialTextureMemory) : 0;
-  }
-
-  HRESULT DxvkD3D8Bridge::ResetSwapChain(D3DPRESENT_PARAMETERS* Params) {
-    return m_device->ResetSwapChain(Params, nullptr);
-  }
-
-  HRESULT DxvkD3D8Bridge::SetColorKeyState(bool colorKeyState) {
-    return D3D_OK; //m_device->SetColorKeyState(colorKeyState);
-  }
-
-  HRESULT DxvkD3D8Bridge::SetColorKey(DWORD colorKeyLow, DWORD colorKeyHigh) {
-    return D3D_OK; //m_device->SetColorKey(colorKeyLow, colorKeyHigh);
-  }
-
-  HRESULT DxvkD3D8Bridge::SetLegacyLightsState(bool legacyLightsState) {
-    return m_device->SetLegacyLightsState(legacyLightsState);
-  }
-
-  HRESULT DxvkD3D8Bridge::UpdateTextureFromBuffer(
+  HRESULT DxvkLegacyD3DDeviceBridge::UpdateTextureFromBuffer(
         IDirect3DSurface9*  pDestSurface,
         IDirect3DSurface9*  pSrcSurface,
         const RECT*         pSrcRect,
@@ -110,53 +89,71 @@ namespace dxvk {
     return D3D_OK;
   }
 
-  bool DxvkD3D8Bridge::IsSupportedSurfaceFormat(D3DFORMAT Format) {
+  bool DxvkLegacyD3DDeviceBridge::IsSupportedSurfaceFormat(D3DFORMAT Format) {
     auto mapping = m_device->LookupFormat(EnumerateFormat(Format));
     return mapping.IsValid();
   }
 
-  DxvkD3D8InterfaceBridge::DxvkD3D8InterfaceBridge(D3D9InterfaceEx* pObject)
+  uint32_t DxvkLegacyD3DDeviceBridge::DetermineInitialTextureMemory() {
+    const int64_t initialTextureMemory = m_device->DetermineInitialTextureMemory();
+
+    return initialTextureMemory > 0 ? static_cast<uint32_t>(initialTextureMemory) : 0;
+  }
+
+  HRESULT DxvkLegacyD3DDeviceBridge::ResetSwapChain(D3DPRESENT_PARAMETERS* Params) {
+    return m_device->ResetSwapChain(Params, nullptr);
+  }
+
+  HRESULT DxvkLegacyD3DDeviceBridge::SetColorKeyState(bool colorKeyState) {
+    //return m_device->SetColorKeyState(colorKeyState);
+    return D3D_OK;
+  }
+
+  HRESULT DxvkLegacyD3DDeviceBridge::SetColorKey(DWORD colorKeyLow, DWORD colorKeyHigh) {
+    //return m_device->SetColorKey(colorKeyLow, colorKeyHigh);
+    return D3D_OK;
+  }
+
+  HRESULT DxvkLegacyD3DDeviceBridge::SetLegacyLightsState(bool legacyLightsState) {
+    return m_device->SetLegacyLightsState(legacyLightsState);
+  }
+
+  HRESULT DxvkLegacyD3DDeviceBridge::SetAlternatePixelCenter(bool alternatePixelCenter) {
+    //return m_device->SetAlternatePixelCenter(alternatePixelCenter);
+    return D3D_OK;
+  }
+
+  DxvkLegacyD3DInterfaceBridge::DxvkLegacyD3DInterfaceBridge(D3D9InterfaceEx* pObject)
     : m_interface(pObject) {
   }
 
-  DxvkD3D8InterfaceBridge::~DxvkD3D8InterfaceBridge() {
+  DxvkLegacyD3DInterfaceBridge::~DxvkLegacyD3DInterfaceBridge() {
   }
 
-  ULONG STDMETHODCALLTYPE DxvkD3D8InterfaceBridge::AddRef() {
+  ULONG STDMETHODCALLTYPE DxvkLegacyD3DInterfaceBridge::AddRef() {
     return m_interface->AddRef();
   }
 
-  ULONG STDMETHODCALLTYPE DxvkD3D8InterfaceBridge::Release() {
+  ULONG STDMETHODCALLTYPE DxvkLegacyD3DInterfaceBridge::Release() {
     return m_interface->Release();
   }
 
-  HRESULT STDMETHODCALLTYPE DxvkD3D8InterfaceBridge::QueryInterface(
+  HRESULT STDMETHODCALLTYPE DxvkLegacyD3DInterfaceBridge::QueryInterface(
           REFIID  riid,
           void** ppvObject) {
     return m_interface->QueryInterface(riid, ppvObject);
   }
 
-  void DxvkD3D8InterfaceBridge::EnableD3D3CompatibilityMode() {
-    m_interface->EnableD3D3CompatibilityMode();
+  void DxvkLegacyD3DInterfaceBridge::SetD3DCompatibility(D3DCompatibility d3dCompatibility) const {
+    // The D3D9Ex compatibility flag is internal only, and can't be set by the bridge
+    if (likely(d3dCompatibility != D3DCompatibility::D3D9Ex)) {
+      m_interface->SetD3DCompatibility(d3dCompatibility);
+    } else {
+      Logger::err("DxvkLegacyD3DInterfaceBridge::SetD3DCompatibility: Invalid compatibility level: D3D9Ex");
+    }
   }
 
-  void DxvkD3D8InterfaceBridge::EnableD3D5CompatibilityMode() {
-    m_interface->EnableD3D5CompatibilityMode();
-  }
-
-  void DxvkD3D8InterfaceBridge::EnableD3D6CompatibilityMode() {
-    m_interface->EnableD3D6CompatibilityMode();
-  }
-
-  void DxvkD3D8InterfaceBridge::EnableD3D7CompatibilityMode() {
-    m_interface->EnableD3D7CompatibilityMode();
-  }
-
-  void DxvkD3D8InterfaceBridge::EnableD3D8CompatibilityMode() {
-    m_interface->EnableD3D8CompatibilityMode();
-  }
-
-  const Config* DxvkD3D8InterfaceBridge::GetConfig() const {
+  const Config* DxvkLegacyD3DInterfaceBridge::GetConfig() const {
     return &m_interface->GetInstance()->config();
   }
 

--- a/src/d3d9/d3d9_bridge.h
+++ b/src/d3d9/d3d9_bridge.h
@@ -1,8 +1,17 @@
 #pragma once
 
 #include <windows.h>
-#include <d3d9.h>
 #include "../util/config/config.h"
+#include "../util/util_flags.h"
+
+enum class DxvkD3DCompatibility : uint8_t {
+  D3D9Ex,
+  D3D8,
+  D3D7,
+  D3D6,
+  D3D5,
+  D3D3
+};
 
 /**
  * The D3D9 bridge allows D3D8 to access DXVK internals.
@@ -14,8 +23,8 @@
 /**
  * \brief D3D9 device interface for D3D8 interop
  */
-MIDL_INTERFACE("D3D9D3D8-42A9-4C1E-AA97-BEEFCAFE2000")
-IDxvkD3D8Bridge : public IUnknown {
+MIDL_INTERFACE("D3D0D3D9-42A9-4C1E-AA97-BEEFCAFE2000")
+IDxvkLegacyD3DDeviceBridge : public IUnknown {
 
   // D3D8 keeps D3D9 objects contained in a namespace.
   #ifdef DXVK_D3D9_NAMESPACE
@@ -31,6 +40,22 @@ IDxvkD3D8Bridge : public IUnknown {
    * \param [in] pSrcSurface  Source surface (typically in system memory)
    * \param [in] pSrcRect     Source rectangle
    * \param [in] pDestPoint   Destination (top-left) point
+   */
+  virtual HRESULT UpdateTextureFromBuffer(
+      IDirect3DSurface9*        pDestSurface,
+      IDirect3DSurface9*        pSrcSurface,
+      const RECT*               pSrcRect,
+      const POINT*              pDestPoint) = 0;
+
+  /**
+   * \brief Checks if a particular surface format is supported by D3D9
+   *
+   * \param [in] Format D3DFORMAT value to be checked
+   */
+  virtual bool IsSupportedSurfaceFormat(D3DFORMAT Format) = 0;
+
+  /**
+   * \brief Determines the initial amount of texture memory for a device
    */
   virtual uint32_t DetermineInitialTextureMemory() = 0;
 
@@ -62,49 +87,25 @@ IDxvkD3D8Bridge : public IUnknown {
    */
   virtual HRESULT SetLegacyLightsState(bool legacyLightsState) = 0;
 
-  virtual HRESULT UpdateTextureFromBuffer(
-      IDirect3DSurface9*        pDestSurface,
-      IDirect3DSurface9*        pSrcSurface,
-      const RECT*               pSrcRect,
-      const POINT*              pDestPoint) = 0;
-
   /**
-   * \brief Checks if a particular surface format is supported by D3D9
+   * \brief Updates the alternate pixel center state in D3D9
    *
-   * \param [in] Format D3DFORMAT value to be checked
+   * \param [in] Params bool value to be used
    */
-  virtual bool IsSupportedSurfaceFormat(D3DFORMAT Format) = 0;
+  virtual HRESULT SetAlternatePixelCenter(bool alternatePixelCenter) = 0;
 };
 
 /**
  * \brief D3D9 instance interface for D3D8 interop
  */
-MIDL_INTERFACE("D3D9D3D8-A407-773E-18E9-CAFEBEEF3000")
-IDxvkD3D8InterfaceBridge : public IUnknown {
+MIDL_INTERFACE("D3D0D3D9-A407-773E-18E9-CAFEBEEF3000")
+IDxvkLegacyD3DInterfaceBridge : public IUnknown {
   /**
-   * \brief Enforces D3D3-specific features and validations
+   * \brief Enforces legacy D3D features and validations
+   *
+   * \param [in] d3dCompatibility D3D compatibility level to be set
    */
-  virtual void EnableD3D3CompatibilityMode() = 0;
-
-  /**
-   * \brief Enforces D3D5-specific features and validations
-   */
-  virtual void EnableD3D5CompatibilityMode() = 0;
-
-  /**
-   * \brief Enforces D3D6-specific features and validations
-   */
-  virtual void EnableD3D6CompatibilityMode() = 0;
-
-  /**
-   * \brief Enforces D3D7-specific features and validations
-   */
-  virtual void EnableD3D7CompatibilityMode() = 0;
-
-  /**
-   * \brief Enforces D3D8-specific features and validations
-   */
-  virtual void EnableD3D8CompatibilityMode() = 0;
+  virtual void SetD3DCompatibility(DxvkD3DCompatibility d3dCompatibility) const = 0;
 
   /**
    * \brief Retrieves the DXVK configuration
@@ -115,28 +116,39 @@ IDxvkD3D8InterfaceBridge : public IUnknown {
 };
 
 #ifndef _MSC_VER
-__CRT_UUID_DECL(IDxvkD3D8Bridge, 0xD3D9D3D8, 0x42A9, 0x4C1E, 0xAA, 0x97, 0xBE, 0xEF, 0xCA, 0xFE, 0x20, 0x00);
-__CRT_UUID_DECL(IDxvkD3D8InterfaceBridge, 0xD3D9D3D8, 0xA407, 0x773E, 0x18, 0xE9, 0xCA, 0xFE, 0xBE, 0xEF, 0x30, 0x00);
+__CRT_UUID_DECL(IDxvkLegacyD3DDeviceBridge,    0xD3D0D3D9, 0x42A9, 0x4C1E, 0xAA, 0x97, 0xBE, 0xEF, 0xCA, 0xFE, 0x20, 0x00);
+__CRT_UUID_DECL(IDxvkLegacyD3DInterfaceBridge, 0xD3D0D3D9, 0xA407, 0x773E, 0x18, 0xE9, 0xCA, 0xFE, 0xBE, 0xEF, 0x30, 0x00);
 #endif
 
 namespace dxvk {
 
+  using D3DCompatibility = DxvkD3DCompatibility;
+  using D3DCompatibilityFlags = Flags<D3DCompatibility>;
+
   class D3D9DeviceEx;
   class D3D9InterfaceEx;
 
-  class DxvkD3D8Bridge : public IDxvkD3D8Bridge {
+  class DxvkLegacyD3DDeviceBridge : public IDxvkLegacyD3DDeviceBridge {
 
   public:
 
-    DxvkD3D8Bridge(D3D9DeviceEx* pDevice);
+    DxvkLegacyD3DDeviceBridge(D3D9DeviceEx* pDevice);
 
-    ~DxvkD3D8Bridge();
+    ~DxvkLegacyD3DDeviceBridge();
 
     ULONG STDMETHODCALLTYPE AddRef();
     ULONG STDMETHODCALLTYPE Release();
     HRESULT STDMETHODCALLTYPE QueryInterface(
             REFIID  riid,
             void** ppvObject);
+
+    HRESULT UpdateTextureFromBuffer(
+        IDirect3DSurface9*        pDestSurface,
+        IDirect3DSurface9*        pSrcSurface,
+        const RECT*               pSrcRect,
+        const POINT*              pDestPoint);
+
+    bool IsSupportedSurfaceFormat(D3DFORMAT Format);
 
     uint32_t DetermineInitialTextureMemory();
 
@@ -148,13 +160,7 @@ namespace dxvk {
 
     HRESULT SetLegacyLightsState(bool legacyLightsState);
 
-    HRESULT UpdateTextureFromBuffer(
-        IDirect3DSurface9*        pDestSurface,
-        IDirect3DSurface9*        pSrcSurface,
-        const RECT*               pSrcRect,
-        const POINT*              pDestPoint);
-
-    bool IsSupportedSurfaceFormat(D3DFORMAT Format);
+    HRESULT SetAlternatePixelCenter(bool alternatePixelCenter);
 
   private:
 
@@ -162,13 +168,13 @@ namespace dxvk {
 
   };
 
-  class DxvkD3D8InterfaceBridge : public IDxvkD3D8InterfaceBridge {
+  class DxvkLegacyD3DInterfaceBridge : public IDxvkLegacyD3DInterfaceBridge {
 
   public:
 
-    DxvkD3D8InterfaceBridge(D3D9InterfaceEx* pObject);
+    DxvkLegacyD3DInterfaceBridge(D3D9InterfaceEx* pObject);
 
-    ~DxvkD3D8InterfaceBridge();
+    ~DxvkLegacyD3DInterfaceBridge();
 
     ULONG STDMETHODCALLTYPE AddRef();
     ULONG STDMETHODCALLTYPE Release();
@@ -176,15 +182,7 @@ namespace dxvk {
             REFIID  riid,
             void** ppvObject);
 
-    void EnableD3D3CompatibilityMode();
-
-    void EnableD3D5CompatibilityMode();
-
-    void EnableD3D6CompatibilityMode();
-
-    void EnableD3D7CompatibilityMode();
-
-    void EnableD3D8CompatibilityMode();
+    void SetD3DCompatibility(D3DCompatibility d3dCompatibility) const;
 
     const Config* GetConfig() const;
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -49,14 +49,10 @@ namespace dxvk {
     , m_d3d9Options        ( dxvkDevice, pParent->GetInstance()->config() )
     , m_multithread        ( BehaviorFlags & D3DCREATE_MULTITHREADED )
     , m_isSWVP             ( (BehaviorFlags & D3DCREATE_SOFTWARE_VERTEXPROCESSING) != 0 )
-    , m_isD3D3Compatible   ( pParent->IsD3D3Compatible() )
-    , m_isD3D5Compatible   ( pParent->IsD3D5Compatible() )
-    , m_isD3D6Compatible   ( pParent->IsD3D6Compatible() )
-    , m_isD3D7Compatible   ( pParent->IsD3D7Compatible() )
-    , m_isD3D8Compatible   ( pParent->IsD3D8Compatible() )
     , m_csThread           ( dxvkDevice, dxvkDevice->createContext() )
     , m_csChunk            ( AllocCsChunk() )
-    , m_d3d8Bridge         ( this ) {
+    , m_legacyD3DBridge    ( this )
+    , m_d3dCompatibility   ( pParent->GetD3DCompatibilityFlags() ) {
     // If we can SWVP, then we use an extended constant set
     // as SWVP has many more slots available than HWVP.
     bool canSWVP = CanSWVP();
@@ -175,18 +171,16 @@ namespace dxvk {
 
     *ppvObject = nullptr;
 
-    bool extended = m_parent->IsExtended()
-                 && riid == __uuidof(IDirect3DDevice9Ex);
-
     if (riid == __uuidof(IUnknown)
      || riid == __uuidof(IDirect3DDevice9)
-     || extended) {
+     || (m_d3dCompatibility.test(D3DCompatibility::D3D9Ex) &&
+         riid == __uuidof(IDirect3DDevice9Ex))) {
       *ppvObject = ref(this);
       return S_OK;
     }
 
-    if (riid == __uuidof(IDxvkD3D8Bridge)) {
-      *ppvObject = ref(&m_d3d8Bridge);
+    if (riid == __uuidof(IDxvkLegacyD3DDeviceBridge)) {
+      *ppvObject = ref(&m_legacyD3DBridge);
       return S_OK;
     }
 
@@ -373,7 +367,7 @@ namespace dxvk {
   }
 
 
-  void    STDMETHODCALLTYPE D3D9DeviceEx::SetCursorPosition(int X, int Y, DWORD Flags) {
+  void STDMETHODCALLTYPE D3D9DeviceEx::SetCursorPosition(int X, int Y, DWORD Flags) {
     D3D9DeviceLock lock = LockDevice();
 
     // I was not able to find an instance
@@ -388,7 +382,7 @@ namespace dxvk {
   }
 
 
-  BOOL    STDMETHODCALLTYPE D3D9DeviceEx::ShowCursor(BOOL bShow) {
+  BOOL STDMETHODCALLTYPE D3D9DeviceEx::ShowCursor(BOOL bShow) {
     D3D9DeviceLock lock = LockDevice();
 
     return m_cursor.ShowCursor(bShow);
@@ -421,7 +415,7 @@ namespace dxvk {
   }
 
 
-  UINT    STDMETHODCALLTYPE D3D9DeviceEx::GetNumberOfSwapChains() {
+  UINT STDMETHODCALLTYPE D3D9DeviceEx::GetNumberOfSwapChains() {
     // This only counts the implicit swapchain...
 
     return 1;
@@ -3039,8 +3033,8 @@ namespace dxvk {
     const uint32_t minorVersion = D3DSHADER_VERSION_MINOR(pFunction[0]);
 
     // Late fixed-function capable hardware exposed support for VS 1.1
-    const uint32_t shaderModelVS = m_isD3D8Compatible ? 1u : std::max(1u, m_d3d9Options.shaderModel);
-
+    const uint32_t shaderModelVS = m_d3dCompatibility.test(D3DCompatibility::D3D8) ? 1u
+                                                                                   : std::max(1u, m_d3d9Options.shaderModel);
     if (unlikely(majorVersion > shaderModelVS
               || (majorVersion == 1 && minorVersion > 1)
               // Skip checking the SM2 minor version, as it has a 2_x mode apparently
@@ -3390,8 +3384,8 @@ namespace dxvk {
     const uint32_t majorVersion = D3DSHADER_VERSION_MAJOR(pFunction[0]);
     const uint32_t minorVersion = D3DSHADER_VERSION_MINOR(pFunction[0]);
 
-    const uint32_t shaderModelPS = m_isD3D8Compatible ? std::min(1u, m_d3d9Options.shaderModel) : m_d3d9Options.shaderModel;
-
+    const uint32_t shaderModelPS = m_d3dCompatibility.test(D3DCompatibility::D3D8) ? std::min(1u, m_d3d9Options.shaderModel)
+                                                                                   : m_d3d9Options.shaderModel;
     if (unlikely(majorVersion > shaderModelPS
               || (majorVersion == 1 && minorVersion > 4)
               // Skip checking the SM2 minor version, as it has a 2_x mode apparently
@@ -4280,11 +4274,6 @@ namespace dxvk {
     }
 
     return D3D_OK;
-  }
-
-
-  bool D3D9DeviceEx::IsExtended() {
-    return m_parent->IsExtended();
   }
 
 
@@ -7599,11 +7588,11 @@ namespace dxvk {
     rs[D3DRS_COLORVERTEX]            = TRUE;
     rs[D3DRS_LOCALVIEWER]            = TRUE;
     rs[D3DRS_RANGEFOGENABLE]         = FALSE;
-    rs[D3DRS_NORMALIZENORMALS]       = m_isD3D6Compatible ? TRUE : FALSE;
+    rs[D3DRS_NORMALIZENORMALS]       = m_d3dCompatibility.test(D3DCompatibility::D3D6) ? TRUE : FALSE;
     m_flags.set(D3D9DeviceFlag::DirtyFFVertexShader);
 
     // PS
-    rs[D3DRS_SPECULARENABLE] = m_isD3D5Compatible ? TRUE : FALSE;
+    rs[D3DRS_SPECULARENABLE] = m_d3dCompatibility.test(D3DCompatibility::D3D5) ? TRUE : FALSE;
 
     rs[D3DRS_AMBIENT]                = 0;
     m_flags.set(D3D9DeviceFlag::DirtyFFVertexData);
@@ -7611,8 +7600,10 @@ namespace dxvk {
     rs[D3DRS_FOGENABLE]                  = FALSE;
     rs[D3DRS_FOGCOLOR]                   = 0;
     rs[D3DRS_FOGTABLEMODE]               = D3DFOG_NONE;
-    rs[D3DRS_FOGSTART]                   = m_isD3D6Compatible ? bit::cast<DWORD>(1.0f)   : bit::cast<DWORD>(0.0f);
-    rs[D3DRS_FOGEND]                     = m_isD3D6Compatible ? bit::cast<DWORD>(100.0f) : bit::cast<DWORD>(1.0f);
+    rs[D3DRS_FOGSTART]                   = m_d3dCompatibility.test(D3DCompatibility::D3D6) ? bit::cast<DWORD>(1.0f)
+                                                                                           : bit::cast<DWORD>(0.0f);
+    rs[D3DRS_FOGEND]                     = m_d3dCompatibility.test(D3DCompatibility::D3D6) ? bit::cast<DWORD>(100.0f)
+                                                                                           : bit::cast<DWORD>(1.0f);
     rs[D3DRS_FOGDENSITY]                 = bit::cast<DWORD>(1.0f);
     rs[D3DRS_FOGVERTEXMODE]              = D3DFOG_NONE;
     m_flags.set(D3D9DeviceFlag::DirtyFogColor);
@@ -7630,7 +7621,8 @@ namespace dxvk {
     rs[D3DRS_POINTSCALE_B]               = bit::cast<DWORD>(0.0f);
     rs[D3DRS_POINTSCALE_C]               = bit::cast<DWORD>(0.0f);
     rs[D3DRS_POINTSIZE]                  = bit::cast<DWORD>(1.0f);
-    rs[D3DRS_POINTSIZE_MIN]              = m_isD3D8Compatible ? bit::cast<DWORD>(0.0f) : bit::cast<DWORD>(1.0f);
+    rs[D3DRS_POINTSIZE_MIN]              = m_d3dCompatibility.test(D3DCompatibility::D3D8) ? bit::cast<DWORD>(0.0f)
+                                                                                           : bit::cast<DWORD>(1.0f);
     rs[D3DRS_POINTSIZE_MAX]              = bit::cast<DWORD>(64.0f);
     UpdatePushConstant<D3D9RenderStateItem::PointSize>();
     UpdatePushConstant<D3D9RenderStateItem::PointSizeMin>();
@@ -7659,7 +7651,7 @@ namespace dxvk {
     rs[D3DRS_WRAP6]                      = 0;
     rs[D3DRS_WRAP7]                      = 0;
     rs[D3DRS_CLIPPING]                   = TRUE;
-    rs[D3DRS_MULTISAMPLEANTIALIAS]       = m_isD3D7Compatible ? FALSE : TRUE;
+    rs[D3DRS_MULTISAMPLEANTIALIAS]       = m_d3dCompatibility.test(D3DCompatibility::D3D7) ? FALSE : TRUE;
     rs[D3DRS_PATCHEDGESTYLE]             = D3DPATCHEDGE_DISCRETE;
     rs[D3DRS_DEBUGMONITORTOKEN]          = D3DDMT_ENABLE;
     rs[D3DRS_POSITIONDEGREE]             = D3DDEGREE_CUBIC;
@@ -7763,7 +7755,7 @@ namespace dxvk {
 
     // In D3D8, this represents the value of D3DRS_PATCHSEGMENTS.
     // It defaults to 1.0f and is reset as any other render state.
-    if (m_isD3D8Compatible)
+    if (m_d3dCompatibility.test(D3DCompatibility::D3D8))
       m_state.nPatchSegments = 1.0f;
 
     return D3D_OK;

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -107,7 +107,7 @@ namespace dxvk {
 
     friend class D3D9SwapChainEx;
     friend class D3D9UserDefinedAnnotation;
-    friend class DxvkD3D8Bridge;
+    friend class DxvkLegacyD3DDeviceBridge;
   public:
 
     D3D9DeviceEx(
@@ -656,8 +656,6 @@ namespace dxvk {
 
     bool SupportsSWVP();
 
-    bool IsExtended();
-
     HWND GetWindow();
 
     Rc<DxvkDevice> GetDXVKDevice() {
@@ -906,7 +904,7 @@ namespace dxvk {
     void FlushImplicit(BOOL StrongHint);
 
     bool ChangeReportedMemory(int64_t delta) {
-      if (IsExtended())
+      if (m_d3dCompatibility.test(D3DCompatibility::D3D9Ex))
         return true;
 
       int64_t availableMemory = m_availableMemory.fetch_add(delta);
@@ -942,24 +940,8 @@ namespace dxvk {
       return m_samplerCount.load();
     }
 
-    bool IsD3D3Compatible() const {
-      return m_isD3D3Compatible;
-    }
-
-    bool IsD3D5Compatible() const {
-      return m_isD3D5Compatible;
-    }
-
-    bool IsD3D6Compatible() const {
-      return m_isD3D6Compatible;
-    }
-
-    bool IsD3D7Compatible() const {
-      return m_isD3D7Compatible;
-    }
-
-    bool IsD3D8Compatible() const {
-      return m_isD3D8Compatible;
+    bool IsD3DCompatibile(D3DCompatibility d3dCompatibility) const {
+      return m_d3dCompatibility.test(d3dCompatibility);
     }
 
   private:
@@ -1296,11 +1278,6 @@ namespace dxvk {
     D3D9ShaderMasks                 m_psShaderMasks = FixedFunctionMask;
 
     bool                            m_isSWVP;
-    bool                            m_isD3D3Compatible;
-    bool                            m_isD3D5Compatible;
-    bool                            m_isD3D6Compatible;
-    bool                            m_isD3D7Compatible;
-    bool                            m_isD3D8Compatible;
 
     // D3D6 and earlier legacy light model state
     bool                            m_useLegacyLights = false;
@@ -1346,7 +1323,8 @@ namespace dxvk {
     // references objects that can call back into the device when freed.
     Direct3DState9                  m_state;
 
-    DxvkD3D8Bridge                  m_d3d8Bridge;
+    DxvkLegacyD3DDeviceBridge       m_legacyD3DBridge;
+    D3DCompatibilityFlags           m_d3dCompatibility;
   };
 
 }

--- a/src/d3d9/d3d9_format.cpp
+++ b/src/d3d9/d3d9_format.cpp
@@ -1,4 +1,5 @@
 #include "d3d9_format.h"
+#include "d3d9_adapter.h"
 #include "d3d9_names.h"
 
 namespace dxvk {
@@ -585,11 +586,6 @@ namespace dxvk {
   }
 
 
-  void D3D9VkFormatTable::RefreshFormatSupport(bool isD3D8Compatible) {
-    m_w11v11u10Support = isD3D8Compatible;
-  }
-
-
   bool D3D9VkFormatTable::CheckImageFormatSupport(
     const Rc<DxvkAdapter>&      Adapter,
           VkFormat              Format,
@@ -598,6 +594,13 @@ namespace dxvk {
 
     return (supported.linearTilingFeatures  & Features) == Features
         || (supported.optimalTilingFeatures & Features) == Features;
+  }
+
+
+  void D3D9VkFormatTable::RefreshFormatSupport(
+    const D3D9Adapter*          pParent) {
+    // W11V11U10 is only supported by D3D8
+    m_w11v11u10Support = pParent->IsD3DCompatibile(D3DCompatibility::D3D8);
   }
 
 }

--- a/src/d3d9/d3d9_format.h
+++ b/src/d3d9/d3d9_format.h
@@ -178,6 +178,8 @@ namespace dxvk {
 
   D3D9_VK_FORMAT_MAPPING ConvertFormatUnfixed(D3D9Format Format);
 
+  class D3D9Adapter;
+
   /**
    * \brief Format table
    *
@@ -212,7 +214,8 @@ namespace dxvk {
     const DxvkFormatInfo* GetUnsupportedFormatInfo(
       D3D9Format            Format) const;
 
-    void RefreshFormatSupport(bool isD3D8Compatible);
+    void RefreshFormatSupport(
+      const D3D9Adapter*          pParent);
 
   private:
 

--- a/src/d3d9/d3d9_interface.cpp
+++ b/src/d3d9/d3d9_interface.cpp
@@ -10,10 +10,9 @@
 namespace dxvk {
 
   D3D9InterfaceEx::D3D9InterfaceEx(bool bExtended)
-    : m_instance    ( new DxvkInstance() )
-    , m_d3d8Bridge  ( this )
-    , m_extended    ( bExtended ) 
-    , m_d3d9Options ( nullptr, m_instance->config() ) {
+    : m_instance        ( new DxvkInstance() )
+    , m_legacyD3DBridge ( this )
+    , m_d3d9Options     ( nullptr, m_instance->config() ) {
     // D3D9 doesn't enumerate adapters like physical adapters...
     // only as connected displays.
 
@@ -63,8 +62,13 @@ namespace dxvk {
     }
 #endif
 
+    if (bExtended) {
+      m_d3dCompatibility.set(D3DCompatibility::D3D9Ex);
+      Logger::info("The D3D9 interface is operating in D3D9Ex mode.");
+    }
+
     if (unlikely(m_d3d9Options.shaderModel == 0))
-      Logger::warn("D3D9InterfaceEx: WARNING! Fixed-function exclusive mode is enabled.");
+      Logger::warn("WARNING! Fixed-function exclusive mode is enabled.");
   }
 
 
@@ -76,13 +80,14 @@ namespace dxvk {
 
     if (riid == __uuidof(IUnknown)
      || riid == __uuidof(IDirect3D9)
-     || (m_extended && riid == __uuidof(IDirect3D9Ex))) {
+     || (m_d3dCompatibility.test(D3DCompatibility::D3D9Ex) &&
+         riid == __uuidof(IDirect3D9Ex))) {
       *ppvObject = ref(this);
       return S_OK;
     }
 
-    if (riid == __uuidof(IDxvkD3D8InterfaceBridge)) {
-      *ppvObject = ref(&m_d3d8Bridge);
+    if (riid == __uuidof(IDxvkLegacyD3DInterfaceBridge)) {
+      *ppvObject = ref(&m_legacyD3DBridge);
       return S_OK;
     }
 
@@ -119,7 +124,7 @@ namespace dxvk {
     filter.Size             = sizeof(D3DDISPLAYMODEFILTER);
     filter.Format           = Format;
     filter.ScanLineOrdering = D3DSCANLINEORDERING_PROGRESSIVE;
-    
+
     return this->GetAdapterModeCountEx(Adapter, &filter);
   }
 
@@ -183,7 +188,7 @@ namespace dxvk {
           D3DFORMAT           SurfaceFormat,
           BOOL                Windowed,
           D3DMULTISAMPLE_TYPE MultiSampleType,
-          DWORD*              pQualityLevels) { 
+          DWORD*              pQualityLevels) {
     if (auto* adapter = GetAdapter(Adapter))
       return adapter->CheckDeviceMultiSampleType(
         DeviceType, EnumerateFormat(SurfaceFormat),

--- a/src/d3d9/d3d9_interface.h
+++ b/src/d3d9/d3d9_interface.h
@@ -118,7 +118,7 @@ namespace dxvk {
 
     HRESULT STDMETHODCALLTYPE GetAdapterLUID(UINT Adapter, LUID* pLUID);
 
-    const D3D9Options& GetOptions() { return m_d3d9Options; }
+    const D3D9Options& GetOptions() const { return m_d3d9Options; }
 
     D3D9Adapter* GetAdapter(UINT Ordinal) {
       return Ordinal < m_adapters.size()
@@ -126,72 +126,54 @@ namespace dxvk {
         : nullptr;
     }
 
-    bool IsExtended() { return m_extended; }
-
-    bool IsD3D3Compatible() const {
-      return m_isD3D3Compatible;
+    D3DCompatibilityFlags GetD3DCompatibilityFlags() const {
+      return m_d3dCompatibility;
     }
 
-    bool IsD3D5Compatible() const {
-      return m_isD3D5Compatible;
+    bool IsD3DCompatibile(D3DCompatibility d3dCompatibility) const {
+      return m_d3dCompatibility.test(d3dCompatibility);
     }
 
-    bool IsD3D6Compatible() const {
-      return m_isD3D6Compatible;
-    }
+    void SetD3DCompatibility(D3DCompatibility d3dCompatibility) {
+      m_d3dCompatibility.set(d3dCompatibility);
 
-    bool IsD3D7Compatible() const {
-      return m_isD3D7Compatible;
-    }
+      switch (d3dCompatibility) {
+        case D3DCompatibility::D3D8:
+          Logger::info("The D3D9 interface is now operating in D3D8 compatibility mode.");
+          break;
+        case D3DCompatibility::D3D7:
+          m_d3dCompatibility.set(D3DCompatibility::D3D8);
+          m_d3dCompatibility.clr(D3DCompatibility::D3D6);
+          m_d3dCompatibility.clr(D3DCompatibility::D3D5);
+          m_d3dCompatibility.clr(D3DCompatibility::D3D3);
+          Logger::info("The D3D9 interface is now operating in D3D7 compatibility mode.");
+          break;
+        case D3DCompatibility::D3D6:
+          m_d3dCompatibility.set(D3DCompatibility::D3D8);
+          m_d3dCompatibility.set(D3DCompatibility::D3D7);
+          m_d3dCompatibility.clr(D3DCompatibility::D3D5);
+          m_d3dCompatibility.clr(D3DCompatibility::D3D3);
+          Logger::info("The D3D9 interface is now operating in D3D6 compatibility mode.");
+          break;
+        case D3DCompatibility::D3D5:
+          m_d3dCompatibility.set(D3DCompatibility::D3D8);
+          m_d3dCompatibility.set(D3DCompatibility::D3D7);
+          m_d3dCompatibility.set(D3DCompatibility::D3D6);
+          m_d3dCompatibility.clr(D3DCompatibility::D3D3);
+          Logger::info("The D3D9 interface is now operating in D3D5 compatibility mode.");
+          break;
+        case D3DCompatibility::D3D3:
+          m_d3dCompatibility.set(D3DCompatibility::D3D8);
+          m_d3dCompatibility.set(D3DCompatibility::D3D7);
+          m_d3dCompatibility.set(D3DCompatibility::D3D6);
+          m_d3dCompatibility.set(D3DCompatibility::D3D5);
+          Logger::info("The D3D9 interface is now operating in D3D3 compatibility mode.");
+          break;
+        default:
+          break;
+      }
 
-    bool IsD3D8Compatible() const {
-      return m_isD3D8Compatible;
-    }
-
-    void EnableD3D3CompatibilityMode() {
-      m_isD3D3Compatible = true;
-      m_isD3D5Compatible = true;
-      m_isD3D6Compatible = true;
-      m_isD3D7Compatible = true;
-      m_isD3D8Compatible = true;
       RefreshAdapterFormatTables();
-      Logger::info("The D3D9 interface is now operating in D3D3 compatibility mode.");
-    }
-
-    void EnableD3D5CompatibilityMode() {
-      m_isD3D3Compatible = false;
-      m_isD3D5Compatible = true;
-      m_isD3D6Compatible = true;
-      m_isD3D7Compatible = true;
-      m_isD3D8Compatible = true;
-      RefreshAdapterFormatTables();
-      Logger::info("The D3D9 interface is now operating in D3D5 compatibility mode.");
-    }
-
-    void EnableD3D6CompatibilityMode() {
-      m_isD3D3Compatible = false;
-      m_isD3D5Compatible = false;
-      m_isD3D6Compatible = true;
-      m_isD3D7Compatible = true;
-      m_isD3D8Compatible = true;
-      RefreshAdapterFormatTables();
-      Logger::info("The D3D9 interface is now operating in D3D6 compatibility mode.");
-    }
-
-    void EnableD3D7CompatibilityMode() {
-      m_isD3D3Compatible = false;
-      m_isD3D5Compatible = false;
-      m_isD3D6Compatible = false;
-      m_isD3D7Compatible = true;
-      m_isD3D8Compatible = true;
-      RefreshAdapterFormatTables();
-      Logger::info("The D3D9 interface is now operating in D3D7 compatibility mode.");
-    }
-
-    void EnableD3D8CompatibilityMode() {
-      m_isD3D8Compatible = true;
-      RefreshAdapterFormatTables();
-      Logger::info("The D3D9 interface is now operating in D3D8 compatibility mode.");
     }
 
     Rc<DxvkInstance> GetInstance() { return m_instance; }
@@ -202,22 +184,15 @@ namespace dxvk {
 
     static const char* GetDriverDllName(DxvkGpuVendor vendor);
 
-    Rc<DxvkInstance>              m_instance;
-
-    DxvkD3D8InterfaceBridge       m_d3d8Bridge;
-
-    bool                          m_extended;
-
-    bool                          m_isD3D3Compatible = false;
-    bool                          m_isD3D5Compatible = false;
-    bool                          m_isD3D6Compatible = false;
-    bool                          m_isD3D7Compatible = false;
-    bool                          m_isD3D8Compatible = false;
-
     inline void RefreshAdapterFormatTables() {
       for (auto& adapter : m_adapters)
-        adapter.RefreshFormatsTable(IsD3D8Compatible());
+        adapter.RefreshFormatsTable();
     }
+
+    Rc<DxvkInstance>              m_instance;
+
+    DxvkLegacyD3DInterfaceBridge  m_legacyD3DBridge;
+    D3DCompatibilityFlags         m_d3dCompatibility;
 
     D3D9Options                   m_d3d9Options;
 

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -242,7 +242,8 @@ namespace dxvk {
 
     if (riid == __uuidof(IUnknown)
      || riid == __uuidof(IDirect3DSwapChain9)
-     || (GetParent()->IsExtended() && riid == __uuidof(IDirect3DSwapChain9Ex))) {
+     || (m_parent->IsD3DCompatibile(D3DCompatibility::D3D9Ex) &&
+         riid == __uuidof(IDirect3DSwapChain9Ex))) {
       *ppvObject = ref(this);
       return S_OK;
     }
@@ -776,7 +777,7 @@ namespace dxvk {
     }
 
     // For D3D7 and earlier we always fake windowed mode because of DDraw interop
-    if (!isIdentity && (!m_presentParams.Windowed || m_parent->IsD3D7Compatible()))
+    if (!isIdentity && (!m_presentParams.Windowed || m_parent->IsD3DCompatibile(D3DCompatibility::D3D7)))
       m_blitter->setGammaRamp(NumControlPoints, cp.data());
     else
       m_blitter->setGammaRamp(0, nullptr);
@@ -1441,12 +1442,12 @@ namespace dxvk {
 
 
   std::string D3D9SwapChainEx::GetApiName() {
-    return this->GetParent()->IsD3D3Compatible() ? "D3D3" :
-           this->GetParent()->IsD3D5Compatible() ? "D3D5" :
-           this->GetParent()->IsD3D6Compatible() ? "D3D6" :
-           this->GetParent()->IsD3D7Compatible() ? "D3D7" :
-           this->GetParent()->IsD3D8Compatible() ? "D3D8" :
-           this->GetParent()->IsExtended() ? "D3D9Ex" : "D3D9";
+    return m_parent->IsD3DCompatibile(D3DCompatibility::D3D3) ? "D3D3" :
+           m_parent->IsD3DCompatibile(D3DCompatibility::D3D5) ? "D3D5" :
+           m_parent->IsD3DCompatibile(D3DCompatibility::D3D6) ? "D3D6" :
+           m_parent->IsD3DCompatibile(D3DCompatibility::D3D7) ? "D3D7" :
+           m_parent->IsD3DCompatibile(D3DCompatibility::D3D8) ? "D3D8" :
+           m_parent->IsD3DCompatibile(D3DCompatibility::D3D9Ex) ? "D3D9Ex" : "D3D9";
   }
 
 }

--- a/src/ddraw/d3d3/d3d3_device.cpp
+++ b/src/ddraw/d3d3/d3d3_device.cpp
@@ -16,8 +16,6 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> D3D3Device::s_deviceCount = 0;
-
   D3D3Device::D3D3Device(
         D3DCommonDevice* commonD3DDevice,
         DDrawSurface* pParent,
@@ -37,7 +35,8 @@ namespace dxvk {
 
     const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
     // Retrieve and cache the device capabilities
-    m_desc = GetD3D3Caps(deviceGUID, d3dOptions);
+    m_desc = GetD3D3BaseCaps(d3dOptions);
+    ApplyD3D3DeviceCaps(&m_desc, deviceGUID);
 
     d3d9::IDirect3DDevice9* device9;
 
@@ -58,7 +57,7 @@ namespace dxvk {
     }
 
     // Get the bridge interface to D3D9
-    if (unlikely(FAILED(device9->QueryInterface(__uuidof(IDxvkD3D8Bridge), reinterpret_cast<void**>(&m_bridge))))) {
+    if (unlikely(FAILED(device9->QueryInterface(__uuidof(IDxvkLegacyD3DDeviceBridge), reinterpret_cast<void**>(&m_bridge))))) {
       throw DxvkError("D3D3Device: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
     }
 
@@ -68,14 +67,15 @@ namespace dxvk {
     // Update D3D9 legacy light state
     m_bridge->SetLegacyLightsState(true);
 
+    // Update D3D9 alternate pixel center
+    m_bridge->SetAlternatePixelCenter(d3dOptions->alternatePixelCenter == AlternatePixelCenter::Enabled);
+
     if (m_commonD3DDevice->GetOrigin() == nullptr)
       m_commonD3DDevice->SetOrigin(this);
 
     m_commonD3DDevice->SetD3D3Device(this);
 
-    m_deviceCount = ++s_deviceCount;
-
-    Logger::debug(str::format("D3D3Device: Created a new device nr. ((1-", m_deviceCount, "))"));
+    m_stats.dwSize = sizeof(D3DSTATS);
   }
 
   D3D3Device::~D3D3Device() {
@@ -89,8 +89,6 @@ namespace dxvk {
 
     if (m_commonD3DDevice->GetOrigin() == this)
       m_commonD3DDevice->SetOrigin(nullptr);
-
-    Logger::debug(str::format("D3D3Device: Device nr. ((1-", m_deviceCount, ")) bites the dust"));
   }
 
   // Interlocked refcount with the origin device
@@ -237,10 +235,7 @@ namespace dxvk {
     if (unlikely(stats->dwSize != sizeof(D3DSTATS)))
       return DDERR_INVALIDPARAMS;
 
-    const DWORD dwSize = stats->dwSize;
-
     *stats = m_stats;
-    stats->dwSize = dwSize;
 
     return D3D_OK;
   }
@@ -251,7 +246,15 @@ namespace dxvk {
     if (unlikely(viewport == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    AddViewportInternal(viewport);
+    D3D3Viewport* d3d3Viewport = static_cast<D3D3Viewport*>(viewport);
+
+    auto it = std::find(m_viewports.begin(), m_viewports.end(), d3d3Viewport);
+    if (unlikely(it != m_viewports.end())) {
+      Logger::warn("D3D3Device::AddViewport: Pre-existing viewport found");
+    } else {
+      m_viewports.push_back(d3d3Viewport);
+      d3d3Viewport->GetCommonViewport()->SetD3D3Device(this);
+    }
 
     return D3D_OK;
   }
@@ -262,12 +265,18 @@ namespace dxvk {
     if (unlikely(viewport == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    DeleteViewportInternal(viewport);
-
-    // Clear the current viewport if it is deleted from the device
     D3D3Viewport* d3d3Viewport = static_cast<D3D3Viewport*>(viewport);
-    if (m_currentViewport.ptr() == d3d3Viewport)
-      m_currentViewport = nullptr;
+
+    auto it = std::find(m_viewports.begin(), m_viewports.end(), d3d3Viewport);
+    if (likely(it != m_viewports.end())) {
+      d3d3Viewport->GetCommonViewport()->SetD3D3Device(nullptr);
+      // Clear the current viewport if it is deleted from the device
+      if (m_currentViewport.ptr() == d3d3Viewport)
+        m_currentViewport = nullptr;
+      m_viewports.erase(it);
+    } else {
+      Logger::warn("D3D3Device::DeleteViewport: Viewport not found");
+    }
 
     return D3D_OK;
   }
@@ -341,9 +350,7 @@ namespace dxvk {
     if (unlikely(hr != D3DENUMRET_OK))
       return D3D_OK;
 
-    // Not supported in D3D9, but some games need
-    // it to be advertised (for offscreen plain surfaces?)
-    if (unlikely(d3dOptions->supportR3G3B2)) {
+    if (d3dOptions->supportR3G3B2) {
       textureFormat.ddpfPixelFormat = GetTextureFormat(d3d9::D3DFMT_R3G3B2);
       hr = cb(&textureFormat, ctx);
       if (unlikely(hr != D3DENUMRET_OK))
@@ -453,21 +460,26 @@ namespace dxvk {
     D3D3Viewport* d3d3Viewport = static_cast<D3D3Viewport*>(viewport);
 
     if (unlikely(m_currentViewport != d3d3Viewport)) {
+      D3DCommonViewport* commonViewport = d3d3Viewport->GetCommonViewport();
+
       // Validate that the viewport is attached to this (common) device
-      if (unlikely(m_commonD3DDevice != d3d3Viewport->GetCommonViewport()->GetCommonD3DDevice()))
+      if (unlikely(m_commonD3DDevice != commonViewport->GetCommonD3DDevice()))
         return DDERR_INVALIDPARAMS;
 
       if (likely(m_currentViewport != nullptr)) {
+        D3DCommonViewport* currentCommonViewport = m_currentViewport->GetCommonViewport();
         // Shouldn't be necessary, but play it safe, as there is some potential
         // for improper behavior if we skip deactivation during D3D5/6 interop
-        m_currentViewport->DeactivateLights();
-        m_currentViewport->GetCommonViewport()->SetIsCurrentViewport(false);
+        if (currentCommonViewport->HasLights())
+          currentCommonViewport->DeactivateLights();
+        currentCommonViewport->SetIsCurrentViewport(false);
       }
 
       m_currentViewport = d3d3Viewport;
 
-      m_currentViewport->GetCommonViewport()->SetIsCurrentViewport(true);
-      m_currentViewport->ApplyViewport();
+      commonViewport->SetIsCurrentViewport(true);
+      if (likely(commonViewport->IsViewportSet()))
+        commonViewport->ApplyViewport();
     }
 
     D3DEXECUTEDATA* executeData = d3d3ExecuteBuffer->GetExecuteDataInternal();
@@ -620,7 +632,7 @@ namespace dxvk {
 
                 std::vector<d3d9::D3DLIGHT9> lights9;
                 if (doLighting) {
-                  commonViewport->GetD3D9Lights(&lights9);
+                  commonViewport->GetD3D9ActiveLights(&lights9);
                   pvData.lights = &lights9;
                 } else {
                   pvData.lights = nullptr;
@@ -631,6 +643,8 @@ namespace dxvk {
                 break;
               }
             }
+
+            m_stats.dwVerticesProcessed += pv.dwCount;
           }
 
           ptr += instruction->bSize * instruction->wCount;
@@ -843,40 +857,43 @@ namespace dxvk {
     return D3D_OK;
   }
 
-  // Not called when the device is created from a D3D5/6 device
-  void D3D3Device::InitializeDS() {
-    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
-
-    m_rt->InitializeD3D9RenderTarget();
+  HRESULT D3D3Device::InitializeRTAndDS() {
+    HRESULT hr = m_rt->InitializeD3D9RenderTarget();
+    if (unlikely(FAILED(hr)))
+      return hr;
 
     m_ds = m_rt->GetAttachedDepthStencil();
 
-    if (m_ds != nullptr) {
-      HRESULT hrDS = m_ds->InitializeD3D9DepthStencil();
-      if (unlikely(FAILED(hrDS))) {
-        Logger::err("D3D3Device::InitializeDS: Failed to initialize D3D9 DS");
-      } else {
-        const RECT* dsRect = m_ds->GetCommonSurface()->GetFullSurfaceRect();
-        Logger::info(str::format("D3D3Device::InitializeDS: Depth stencil: ", dsRect->right, "x", dsRect->bottom));
+    if (likely(m_ds != nullptr)) {
+      hr = m_ds->InitializeD3D9DepthStencil();
+      if (unlikely(FAILED(hr)))
+        return hr;
 
-        HRESULT hrDS9 = device9->SetDepthStencilSurface(m_ds->GetCommonSurface()->GetD3D9Surface());
-        if (unlikely(FAILED(hrDS9))) {
-          Logger::err("D3D3Device::InitializeDS: Failed to set D3D9 depth stencil");
-        } else {
-          // This needs to act like an auto depth stencil of sorts, so manually enable z-buffering
-          device9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_TRUE);
-        }
+      const RECT* dsRect = m_ds->GetCommonSurface()->GetFullSurfaceRect();
+      Logger::info(str::format("D3D3Device: Depth stencil: ", dsRect->right, "x", dsRect->bottom));
+
+      d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
+      hr = device9->SetDepthStencilSurface(m_ds->GetCommonSurface()->GetD3D9Surface());
+      if (unlikely(FAILED(hr))) {
+        Logger::err("D3D3Device: Failed to set D3D9 depth stencil");
+        return hr;
       }
-    } else {
-      device9->SetDepthStencilSurface(nullptr);
-      // Should be superfluous, but play it safe
-      device9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_FALSE);
+
+      // The docs state D3DRS_ZENABLE isn't set based on depth stencil attachments in D3D3:
+      // "The default value is FALSE.", however some games apparently depend on it...
+      device9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_TRUE);
     }
+
+    return D3D_OK;
   }
 
   void D3D3Device::UpdateSurfaceDirtyTracking(bool dirtyRenderTarget, bool dirtyDepthStencil, bool dirtyPrimarySurface) {
     if (likely(dirtyRenderTarget))
       m_rt->GetCommonSurface()->DirtyD3D9Surface();
+
+    if (likely(dirtyDepthStencil && m_ds != nullptr))
+      m_ds->GetCommonSurface()->DirtyD3D9Surface();
 
     if (likely(dirtyPrimarySurface)) {
       DDrawCommonSurface* primarySurface = m_commonIntf->GetPrimarySurface();
@@ -885,9 +902,6 @@ namespace dxvk {
       if (likely(primarySurface != nullptr))
         primarySurface->DirtyD3D9Surface();
     }
-
-    if (likely(dirtyDepthStencil && m_ds != nullptr))
-      m_ds->GetCommonSurface()->DirtyD3D9Surface();
   }
 
   inline void D3D3Device::DDrawDirtySurfaceUpload() {
@@ -905,31 +919,7 @@ namespace dxvk {
     }
   }
 
-  inline void D3D3Device::AddViewportInternal(IDirect3DViewport* viewport) {
-    D3D3Viewport* d3d3Viewport = static_cast<D3D3Viewport*>(viewport);
-
-    auto it = std::find(m_viewports.begin(), m_viewports.end(), d3d3Viewport);
-    if (unlikely(it != m_viewports.end())) {
-      Logger::warn("D3D3Device::AddViewportInternal: Pre-existing viewport found");
-    } else {
-      m_viewports.push_back(d3d3Viewport);
-      d3d3Viewport->GetCommonViewport()->SetD3D3Device(this);
-    }
-  }
-
-  inline void D3D3Device::DeleteViewportInternal(IDirect3DViewport* viewport) {
-    D3D3Viewport* d3d3Viewport = static_cast<D3D3Viewport*>(viewport);
-
-    auto it = std::find(m_viewports.begin(), m_viewports.end(), d3d3Viewport);
-    if (likely(it != m_viewports.end())) {
-      m_viewports.erase(it);
-      d3d3Viewport->GetCommonViewport()->SetD3D3Device(nullptr);
-    } else {
-      Logger::warn("D3D3Device::DeleteViewportInternal: Viewport not found");
-    }
-  }
-
-  inline HRESULT STDMETHODCALLTYPE D3D3Device::SetLightStateInternal(D3DLIGHTSTATETYPE dwLightStateType, DWORD dwLightState) {
+  inline HRESULT D3D3Device::SetLightStateInternal(D3DLIGHTSTATETYPE dwLightStateType, DWORD dwLightState) {
     d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     switch (dwLightStateType) {
@@ -977,18 +967,83 @@ namespace dxvk {
     return D3D_OK;
   }
 
-  inline HRESULT STDMETHODCALLTYPE D3D3Device::SetRenderStateInternal(D3DRENDERSTATETYPE dwRenderStateType, DWORD dwRenderState) {
-    // As opposed to D3D7, D3D3 does not error out on
-    // unknown or invalid render states.
-    if (unlikely(!IsValidD3D3RenderStateType(dwRenderStateType)))
-      return D3D_OK;
-
+  inline HRESULT D3D3Device::SetRenderStateInternal(D3DRENDERSTATETYPE dwRenderStateType, DWORD dwRenderState) {
     d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
     d3d9::D3DRENDERSTATETYPE State9 = d3d9::D3DRENDERSTATETYPE(dwRenderStateType);
 
     switch (dwRenderStateType) {
       // Most render states translate 1:1 to D3D9
-      default:
+      //case D3DRENDERSTATE_TEXTUREHANDLE:
+      //case D3DRENDERSTATE_ANTIALIAS:
+      //case D3DRENDERSTATE_TEXTUREADDRESS:
+      //case D3DRENDERSTATE_TEXTUREPERSPECTIVE:
+      //case D3DRENDERSTATE_WRAPU:
+      //case D3DRENDERSTATE_WRAPV:
+      case D3DRENDERSTATE_ZENABLE:
+      case D3DRENDERSTATE_FILLMODE:
+      case D3DRENDERSTATE_SHADEMODE:
+      //case D3DRENDERSTATE_LINEPATTERN:
+      //case D3DRENDERSTATE_MONOENABLE:
+      //case D3DRENDERSTATE_ROP2:
+      //case D3DRENDERSTATE_PLANEMASK:
+      //case D3DRENDERSTATE_ZWRITEENABLE:
+      case D3DRENDERSTATE_ALPHATESTENABLE:
+      case D3DRENDERSTATE_LASTPIXEL:
+      //case D3DRENDERSTATE_TEXTUREMAG:
+      //case D3DRENDERSTATE_TEXTUREMIN:
+      case D3DRENDERSTATE_SRCBLEND:
+      case D3DRENDERSTATE_DESTBLEND:
+      //case D3DRENDERSTATE_TEXTUREMAPBLEND:
+      case D3DRENDERSTATE_CULLMODE:
+      case D3DRENDERSTATE_ZFUNC:
+      case D3DRENDERSTATE_ALPHAREF:
+      case D3DRENDERSTATE_ALPHAFUNC:
+      //case D3DRENDERSTATE_DITHERENABLE:
+      //case D3DRENDERSTATE_BLENDENABLE: // The actual D3DRENDERSTATE_ALPHABLENDENABLE
+      case D3DRENDERSTATE_FOGENABLE:
+      case D3DRENDERSTATE_SPECULARENABLE:
+      //case D3DRENDERSTATE_ZVISIBLE:
+      //case D3DRENDERSTATE_SUBPIXEL:
+      //case D3DRENDERSTATE_SUBPIXELX:
+      //case D3DRENDERSTATE_STIPPLEDALPHA:
+      case D3DRENDERSTATE_FOGCOLOR:
+      case D3DRENDERSTATE_FOGTABLEMODE:
+      case D3DRENDERSTATE_FOGTABLESTART:
+      case D3DRENDERSTATE_FOGTABLEEND:
+      case D3DRENDERSTATE_FOGTABLEDENSITY:
+      //case D3DRENDERSTATE_STIPPLEENABLE:
+      //case D3DRENDERSTATE_STIPPLEPATTERN00:
+      //case D3DRENDERSTATE_STIPPLEPATTERN01:
+      //case D3DRENDERSTATE_STIPPLEPATTERN02:
+      //case D3DRENDERSTATE_STIPPLEPATTERN03:
+      //case D3DRENDERSTATE_STIPPLEPATTERN04:
+      //case D3DRENDERSTATE_STIPPLEPATTERN05:
+      //case D3DRENDERSTATE_STIPPLEPATTERN06:
+      //case D3DRENDERSTATE_STIPPLEPATTERN07:
+      //case D3DRENDERSTATE_STIPPLEPATTERN08:
+      //case D3DRENDERSTATE_STIPPLEPATTERN09:
+      //case D3DRENDERSTATE_STIPPLEPATTERN10:
+      //case D3DRENDERSTATE_STIPPLEPATTERN11:
+      //case D3DRENDERSTATE_STIPPLEPATTERN12:
+      //case D3DRENDERSTATE_STIPPLEPATTERN13:
+      //case D3DRENDERSTATE_STIPPLEPATTERN14:
+      //case D3DRENDERSTATE_STIPPLEPATTERN15:
+      //case D3DRENDERSTATE_STIPPLEPATTERN16:
+      //case D3DRENDERSTATE_STIPPLEPATTERN17:
+      //case D3DRENDERSTATE_STIPPLEPATTERN18:
+      //case D3DRENDERSTATE_STIPPLEPATTERN19:
+      //case D3DRENDERSTATE_STIPPLEPATTERN20:
+      //case D3DRENDERSTATE_STIPPLEPATTERN21:
+      //case D3DRENDERSTATE_STIPPLEPATTERN22:
+      //case D3DRENDERSTATE_STIPPLEPATTERN23:
+      //case D3DRENDERSTATE_STIPPLEPATTERN24:
+      //case D3DRENDERSTATE_STIPPLEPATTERN25:
+      //case D3DRENDERSTATE_STIPPLEPATTERN26:
+      //case D3DRENDERSTATE_STIPPLEPATTERN27:
+      //case D3DRENDERSTATE_STIPPLEPATTERN28:
+      //case D3DRENDERSTATE_STIPPLEPATTERN29:
+      //case D3DRENDERSTATE_STIPPLEPATTERN30:
+      //case D3DRENDERSTATE_STIPPLEPATTERN31:
         break;
 
       // Replacement for later implemented SetTexture calls
@@ -1073,6 +1128,11 @@ namespace dxvk {
       // "This render state is not supported by the software rasterizers, and is often ignored by hardware drivers."
       case D3DRENDERSTATE_PLANEMASK:
         return D3D_OK;
+
+      // Track the depth write state for D3D9 depth stencil surface dirtying
+      case D3DRENDERSTATE_ZWRITEENABLE:
+        m_commonD3DDevice->SetDepthWriteEnabled(static_cast<bool>(dwRenderState));
+        break;
 
       // Docs: "[...]  only the first two (D3DFILTER_NEAREST and
       // D3DFILTER_LINEAR) are valid with D3DRENDERSTATE_TEXTUREMAG."
@@ -1254,6 +1314,11 @@ namespace dxvk {
       case D3DRENDERSTATE_STIPPLEPATTERN30:
       case D3DRENDERSTATE_STIPPLEPATTERN31:
         return D3D_OK;
+
+      // As opposed to D3D7, D3D3 does not error out on
+      // unknown or invalid render states.
+      default:
+        return D3D_OK;
     }
 
     // This call will never fail
@@ -1261,10 +1326,6 @@ namespace dxvk {
   }
 
   inline void D3D3Device::DrawTriangleInternal(D3DTRIANGLE* triangle, uint16_t count, DWORD vertexCount, const D3DTLVERTEX* vertexBuffer) {
-    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
-
-    DDrawDirtySurfaceUpload();
-
     std::vector<D3DTLVERTEX> vertices;
 
     for (uint16_t i = 0; i < count; i++) {
@@ -1283,6 +1344,10 @@ namespace dxvk {
     }
 
     if (likely(!vertices.empty())) {
+      DDrawDirtySurfaceUpload();
+
+      d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
       device9->SetFVF(D3DFVF_TLVERTEX);
       HRESULT hr = device9->DrawPrimitiveUP(
            d3d9::D3DPT_TRIANGLELIST,
@@ -1291,7 +1356,7 @@ namespace dxvk {
            GetFVFSize(D3DFVF_TLVERTEX));
 
       if (SUCCEEDED(hr)) {
-        UpdateSurfaceDirtyTracking(true, true, true);
+        UpdateSurfaceDirtyTracking(true, m_commonD3DDevice->IsDepthWriteEnabled(), true);
         m_stats.dwTrianglesDrawn += std::max<DWORD>(vertices.size() / 3, 0u);
       } else {
         Logger::err(str::format("D3D3Device::Execute: D3DOP_TRIANGLE failed to draw vertices: ", vertices.size()));
@@ -1302,10 +1367,6 @@ namespace dxvk {
   }
 
   inline void D3D3Device::DrawLineInternal(D3DLINE* line, uint16_t count, DWORD vertexCount, const D3DTLVERTEX* vertexBuffer) {
-    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
-
-    DDrawDirtySurfaceUpload();
-
     std::vector<D3DTLVERTEX> vertices;
 
     for (uint16_t i = 0; i < count; i++) {
@@ -1319,6 +1380,10 @@ namespace dxvk {
     }
 
     if (likely(!vertices.empty())) {
+      DDrawDirtySurfaceUpload();
+
+      d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
       device9->SetFVF(D3DFVF_TLVERTEX);
       HRESULT hr = device9->DrawPrimitiveUP(
            d3d9::D3DPT_LINELIST,
@@ -1327,7 +1392,7 @@ namespace dxvk {
            GetFVFSize(D3DFVF_TLVERTEX));
 
       if (SUCCEEDED(hr)) {
-        UpdateSurfaceDirtyTracking(true, true, true);
+        UpdateSurfaceDirtyTracking(true, m_commonD3DDevice->IsDepthWriteEnabled(), true);
         m_stats.dwLinesDrawn += std::max<DWORD>(vertices.size() / 2, 0u);
       } else {
         Logger::err(str::format("D3D3Device::Execute: D3DOP_LINE failed to draw vertices: ", vertices.size()));
@@ -1338,10 +1403,6 @@ namespace dxvk {
   }
 
   inline void D3D3Device::DrawPointInternal(D3DPOINT* point, uint16_t count, DWORD vertexCount, const D3DTLVERTEX* vertexBuffer) {
-    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
-
-    DDrawDirtySurfaceUpload();
-
     std::vector<D3DTLVERTEX> vertices;
 
     for (uint16_t i = 0; i < count; i++) {
@@ -1356,6 +1417,10 @@ namespace dxvk {
     }
 
     if (likely(!vertices.empty())) {
+      DDrawDirtySurfaceUpload();
+
+      d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
       device9->SetFVF(D3DFVF_TLVERTEX);
       HRESULT hr = device9->DrawPrimitiveUP(
            d3d9::D3DPT_POINTLIST,
@@ -1364,20 +1429,17 @@ namespace dxvk {
            GetFVFSize(D3DFVF_TLVERTEX));
 
       if (SUCCEEDED(hr)) {
-        UpdateSurfaceDirtyTracking(true, true, true);
+        UpdateSurfaceDirtyTracking(true, m_commonD3DDevice->IsDepthWriteEnabled(), true);
         m_stats.dwPointsDrawn += static_cast<DWORD>(vertices.size());
       } else {
         Logger::err(str::format("D3D3Device::Execute: D3DOP_POINT failed to draw vertices: ", vertices.size()));
       }
+
       vertices.clear();
     }
   }
 
   inline void D3D3Device::DrawSpanInternal(D3DSPAN* span, uint16_t count, DWORD vertexCount, const D3DTLVERTEX* vertexBuffer) {
-    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
-
-    DDrawDirtySurfaceUpload();
-
     std::vector<D3DTLVERTEX> vertices;
 
     for (uint16_t i = 0; i < count; i++) {
@@ -1392,6 +1454,10 @@ namespace dxvk {
     }
 
     if (likely(!vertices.empty())) {
+      DDrawDirtySurfaceUpload();
+
+      d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
       device9->SetFVF(D3DFVF_TLVERTEX);
       HRESULT hr = device9->DrawPrimitiveUP(
            d3d9::D3DPT_LINESTRIP,
@@ -1400,7 +1466,7 @@ namespace dxvk {
            GetFVFSize(D3DFVF_TLVERTEX));
 
       if (SUCCEEDED(hr)) {
-        UpdateSurfaceDirtyTracking(true, true, true);
+        UpdateSurfaceDirtyTracking(true, m_commonD3DDevice->IsDepthWriteEnabled(), true);
         m_stats.dwSpansDrawn += std::max<DWORD>(vertices.size() - 1, 0u);
       } else {
         Logger::err(str::format("D3D3Device::Execute: D3DOP_SPAN failed to draw vertices: ", vertices.size()));
@@ -1443,10 +1509,12 @@ namespace dxvk {
       return D3D_OK;
     }
 
+    DDrawCommonSurface* commonSurface = surface->GetCommonSurface();
+
     // If textures have been used on a different device, they
     // will get their D3D9 object reinitialized at this point
-    if (unlikely(surface->GetCommonSurface()->GetCommonD3DDevice() != m_commonD3DDevice.ptr()))
-      surface->GetCommonSurface()->DirtyDDrawSurface();
+    if (unlikely(commonSurface->GetCommonD3DDevice() != m_commonD3DDevice.ptr()))
+      commonSurface->DirtyDDrawSurface();
 
     hr = surface->InitializeOrUploadD3D9();
     if (unlikely(FAILED(hr))) {
@@ -1458,7 +1526,7 @@ namespace dxvk {
     //if (unlikely(m_commonD3DDevice->GetCurrentTextureHandle() == textureHandle))
       //return D3D_OK;
 
-    d3d9::IDirect3DTexture9* tex9 = surface->GetCommonSurface()->GetD3D9Texture();
+    d3d9::IDirect3DTexture9* tex9 = commonSurface->GetD3D9Texture();
 
     if (likely(tex9 != nullptr)) {
       hr = device9->SetTexture(0, tex9);
@@ -1471,15 +1539,15 @@ namespace dxvk {
       //  have been used with no texturing; if the texture does not contain an alpha component,
       //  alpha values at the vertices in the source are interpolated between vertices."
       if (m_commonD3DDevice->GetTextureMapBlend() == D3DTBLEND_MODULATE) {
-        const DWORD textureOp = surface->GetCommonSurface()->IsAlphaFormat() ? D3DTOP_SELECTARG1 : D3DTOP_SELECTARG2;
+        const DWORD textureOp = commonSurface->IsAlphaFormat() ? D3DTOP_SELECTARG1 : D3DTOP_SELECTARG2;
         device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP, textureOp);
       }
 
       // D3D3 enables color key transparency globally
-      const bool validColorKey = surface->GetCommonSurface()->HasValidColorKey();
+      const bool validColorKey = commonSurface->HasValidColorKey();
       m_bridge->SetColorKeyState(validColorKey);
       if (validColorKey) {
-        DDCOLORKEY normalizedColorKey = surface->GetCommonSurface()->GetColorKeyNormalized();
+        DDCOLORKEY normalizedColorKey = commonSurface->GetColorKeyNormalized();
         m_bridge->SetColorKey(normalizedColorKey.dwColorSpaceLowValue,
                               normalizedColorKey.dwColorSpaceHighValue);
       }

--- a/src/ddraw/d3d3/d3d3_device.h
+++ b/src/ddraw/d3d3/d3d3_device.h
@@ -82,7 +82,7 @@ namespace dxvk {
 
     HRESULT STDMETHODCALLTYPE DeleteMatrix(D3DMATRIXHANDLE D3DMatHandle);
 
-    void InitializeDS();
+    HRESULT InitializeRTAndDS();
 
     void UpdateSurfaceDirtyTracking(bool dirtyRenderTarget, bool dirtyDepthStencil, bool dirtyPrimarySurface);
 
@@ -92,10 +92,6 @@ namespace dxvk {
 
     D3DDeviceLock LockDevice() {
       return m_multithread.AcquireLock();
-    }
-
-    D3DSTATS GetStatsInternal() const {
-      return m_stats;
     }
 
     DDrawSurface* GetRenderTarget() const {
@@ -114,15 +110,11 @@ namespace dxvk {
 
     inline void DDrawDirtySurfaceUpload();
 
-    inline void AddViewportInternal(IDirect3DViewport* viewport);
-
-    inline void DeleteViewportInternal(IDirect3DViewport* viewport);
-
     inline HRESULT SetTextureInternal(DDrawSurface* surface, DWORD textureHandle);
 
-    inline HRESULT STDMETHODCALLTYPE SetRenderStateInternal(D3DRENDERSTATETYPE dwRenderStateType, DWORD dwRenderState);
+    inline HRESULT SetRenderStateInternal(D3DRENDERSTATETYPE dwRenderStateType, DWORD dwRenderState);
 
-    inline HRESULT STDMETHODCALLTYPE SetLightStateInternal(D3DLIGHTSTATETYPE dwLightStateType, DWORD dwLightState);
+    inline HRESULT SetLightStateInternal(D3DLIGHTSTATETYPE dwLightStateType, DWORD dwLightState);
 
     inline void DrawTriangleInternal(D3DTRIANGLE* triangle, uint16_t count, DWORD vertexCount, const D3DTLVERTEX* vertexBuffer);
 
@@ -139,33 +131,30 @@ namespace dxvk {
         m_commonIntf->SetCommonD3DDevice(m_commonD3DDevice.ptr());
     }
 
-    Com<D3DCommonDevice>           m_commonD3DDevice;
+    Com<D3DCommonDevice>            m_commonD3DDevice;
 
-    DDrawCommonInterface*          m_commonIntf       = nullptr;
+    DDrawCommonInterface*           m_commonIntf       = nullptr;
 
-    Com<DxvkD3D8Bridge>            m_bridge;
+    Com<IDxvkLegacyD3DDeviceBridge> m_bridge;
 
-    D3DMultithread                 m_multithread;
+    D3DMultithread                  m_multithread;
 
-    D3DDEVICEDESC3                 m_desc;
+    D3DDEVICEDESC3                  m_desc;
 
-    Com<DDrawSurface>              m_rt;
-    Com<DDrawSurface, false>       m_ds;
+    Com<DDrawSurface>               m_rt;
+    Com<DDrawSurface, false>        m_ds;
 
-    Com<D3D3Viewport>              m_currentViewport;
-    std::vector<Com<D3D3Viewport>> m_viewports;
+    Com<D3D3Viewport>               m_currentViewport;
+    std::vector<Com<D3D3Viewport>>  m_viewports;
 
-    D3DSTATS                       m_stats            = { };
+    D3DSTATS                        m_stats            = { };
 
-    D3DMATRIXHANDLE                m_worldHandle      = 0;
-    D3DMATRIXHANDLE                m_viewHandle       = 0;
-    D3DMATRIXHANDLE                m_projectionHandle = 0;
+    D3DMATRIXHANDLE                 m_worldHandle      = 0;
+    D3DMATRIXHANDLE                 m_viewHandle       = 0;
+    D3DMATRIXHANDLE                 m_projectionHandle = 0;
 
-    std::atomic<D3DMATRIXHANDLE>   m_matrixHandle     = 0;
+    std::atomic<D3DMATRIXHANDLE>    m_matrixHandle     = 0;
     std::unordered_map<D3DMATRIXHANDLE, D3DMATRIX> m_matrices;
-
-    uint32_t                       m_deviceCount      = 0;
-    static std::atomic<uint32_t>   s_deviceCount;
 
   };
 

--- a/src/ddraw/d3d3/d3d3_execute_buffer.cpp
+++ b/src/ddraw/d3d3/d3d3_execute_buffer.cpp
@@ -4,24 +4,16 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> D3D3ExecuteBuffer::s_buffCount = 0;
-
   D3D3ExecuteBuffer::D3D3ExecuteBuffer(D3D3Device* pParent, D3DEXECUTEBUFFERDESC* pDesc)
     : DDrawChildObject<D3D3Device, IDirect3DExecuteBuffer>(pParent) {
     if (likely(pDesc->dwFlags & D3DDEB_BUFSIZE)) {
       m_buffer.resize(pDesc->dwBufferSize);
-      Logger::debug(str::format("D3D3ExecuteBuffer: Buffer is initialized with size: ", pDesc->dwBufferSize));
     } else {
       Logger::warn("D3D3ExecuteBuffer: No buffer size specified during initialization");
     }
-
-    m_buffCount = ++s_buffCount;
-
-    Logger::debug(str::format("D3D3ExecuteBuffer: Created a new execute buffer nr. {{1-", m_buffCount, "}}:"));
   }
 
   D3D3ExecuteBuffer::~D3D3ExecuteBuffer() {
-    Logger::debug(str::format("D3D3ExecuteBuffer: Execute buffer nr. {{1-", m_buffCount, "}} bites the dust"));
   }
 
   HRESULT STDMETHODCALLTYPE D3D3ExecuteBuffer::QueryInterface(REFIID riid, void** ppvObject) {

--- a/src/ddraw/d3d3/d3d3_execute_buffer.h
+++ b/src/ddraw/d3d3/d3d3_execute_buffer.h
@@ -58,9 +58,6 @@ namespace dxvk {
 
     std::vector<uint8_t> m_buffer;
 
-    uint32_t             m_buffCount  = 0;
-    static std::atomic<uint32_t> s_buffCount;
-
   };
 
 }

--- a/src/ddraw/d3d3/d3d3_interface.cpp
+++ b/src/ddraw/d3d3/d3d3_interface.cpp
@@ -12,8 +12,6 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> D3D3Interface::s_intfCount = 0;
-
   D3D3Interface::D3D3Interface(
         D3DCommonInterface* commonD3DIntf,
         DDrawCommonInterface* commonIntf,
@@ -21,17 +19,17 @@ namespace dxvk {
     : DDrawChildObject<IUnknown, IDirect3D>(pParent)
     , m_commonD3DIntf ( commonD3DIntf )
     , m_commonIntf ( commonIntf ) {
-    if (m_commonD3DIntf == nullptr) {
+    if (m_commonD3DIntf == nullptr)
       m_commonD3DIntf = new D3DCommonInterface();
 
-      Com<d3d9::IDirect3D9> d3d9Intf = d3d9::Direct3DCreate9(D3D_SDK_VERSION);
-      m_commonD3DIntf->SetD3D9Interface(std::move(d3d9Intf));
-    }
+    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
+    // Retrieve and cache the base capabilities
+    m_desc = GetD3D3BaseCaps(d3dOptions);
 
     d3d9::IDirect3D9* d3d9Intf = m_commonD3DIntf->GetD3D9Interface();
 
     // Get the bridge interface to D3D9
-    if (unlikely(FAILED(d3d9Intf->QueryInterface(__uuidof(IDxvkD3D8InterfaceBridge), reinterpret_cast<void**>(&m_bridge))))) {
+    if (unlikely(FAILED(d3d9Intf->QueryInterface(__uuidof(IDxvkLegacyD3DInterfaceBridge), reinterpret_cast<void**>(&m_bridge))))) {
       throw DxvkError("D3D3Interface: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
     }
 
@@ -40,12 +38,8 @@ namespace dxvk {
     // Don't enable D3D3 compatibility mode when coming from a higher interface
     if (likely(m_commonD3DIntf->GetD3D5Interface() == nullptr
             && m_commonD3DIntf->GetD3D6Interface() == nullptr)) {
-      m_bridge->EnableD3D3CompatibilityMode();
+      m_bridge->SetD3DCompatibility(D3DCompatibility::D3D3);
     }
-
-    m_intfCount = ++s_intfCount;
-
-    Logger::debug(str::format("D3D3Interface: Created a new interface nr. ((1-", m_intfCount, "))"));
   }
 
   D3D3Interface::~D3D3Interface() {
@@ -55,8 +49,6 @@ namespace dxvk {
     // Needed for D3D3 device creation from an IDirectDrawSurface object
     if (m_commonIntf->GetD3D3Interface() == this)
       m_commonIntf->SetD3D3Interface(nullptr);
-
-    Logger::debug(str::format("D3D3Interface: Interface nr. ((1-", m_intfCount, ")) bites the dust"));
   }
 
   // Interlocked refcount with the parent IDirectDraw
@@ -154,8 +146,10 @@ namespace dxvk {
     // RAMP device (monochrome), this is expected to be exposed
     GUID guidRAMP = IID_IDirect3DRampDevice;
     // The caps of a RAMP device are mostly identical to an RGB device
-    D3DDEVICEDESC3 desc3RAMP_HAL = GetD3D3Caps(IID_IDirect3DRGBDevice, d3dOptions);
-    D3DDEVICEDESC3 desc3RAMP_HEL = desc3RAMP_HAL;
+    D3DDEVICEDESC3 desc3RAMP_HAL = m_desc;
+    ApplyD3D3DeviceCaps(&desc3RAMP_HAL, guidRAMP);
+    D3DDEVICEDESC3 desc3RAMP_HEL = m_desc;
+    ApplyD3D3DeviceCaps(&desc3RAMP_HEL, guidRAMP);
     D3DDEVICEDESC descRAMP_HAL = { };
     D3DDEVICEDESC descRAMP_HEL = { };
     desc3RAMP_HAL.dwFlags = 0;
@@ -187,8 +181,10 @@ namespace dxvk {
 
     // Software emulation, this is expected to be exposed
     GUID guidRGB = IID_IDirect3DRGBDevice;
-    D3DDEVICEDESC3 desc3RGB_HAL = GetD3D3Caps(IID_IDirect3DRGBDevice, d3dOptions);
-    D3DDEVICEDESC3 desc3RGB_HEL = desc3RGB_HAL;
+    D3DDEVICEDESC3 desc3RGB_HAL = m_desc;
+    ApplyD3D3DeviceCaps(&desc3RGB_HAL, guidRGB);
+    D3DDEVICEDESC3 desc3RGB_HEL = m_desc;
+    ApplyD3D3DeviceCaps(&desc3RGB_HEL, guidRGB);
     D3DDEVICEDESC descRGB_HAL = { };
     D3DDEVICEDESC descRGB_HEL = { };
     desc3RGB_HAL.dwFlags = 0;
@@ -219,8 +215,10 @@ namespace dxvk {
 
     // Hardware acceleration
     GUID guidHAL = IID_IDirect3DHALDevice;
-    D3DDEVICEDESC3 desc3HAL_HAL = GetD3D3Caps(IID_IDirect3DHALDevice, d3dOptions);
-    D3DDEVICEDESC3 desc3HAL_HEL = desc3HAL_HAL;
+    D3DDEVICEDESC3 desc3HAL_HAL = m_desc;
+    ApplyD3D3DeviceCaps(&desc3HAL_HAL, guidHAL);
+    D3DDEVICEDESC3 desc3HAL_HEL = m_desc;
+    ApplyD3D3DeviceCaps(&desc3HAL_HEL, guidHAL);
     D3DDEVICEDESC descHAL_HAL = { };
     D3DDEVICEDESC descHAL_HEL = { };
     desc3HAL_HEL.dcmColorModel = 0;
@@ -294,11 +292,11 @@ namespace dxvk {
     if (unlikely(!IsValidFindDeviceResultSize(lpD3DFDR->dwSize)))
       return DDERR_INVALIDPARAMS;
 
-    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
-
     // Software emulation, this is expected to be exposed
-    D3DDEVICEDESC3 descRGB_HAL = GetD3D3Caps(IID_IDirect3DRGBDevice, d3dOptions);
-    D3DDEVICEDESC3 descRGB_HEL = descRGB_HAL;
+    D3DDEVICEDESC3 descRGB_HAL = m_desc;
+    ApplyD3D3DeviceCaps(&descRGB_HAL, IID_IDirect3DRGBDevice);
+    D3DDEVICEDESC3 descRGB_HEL = m_desc;
+    ApplyD3D3DeviceCaps(&descRGB_HEL, IID_IDirect3DRGBDevice);
     descRGB_HAL.dwFlags = 0;
     descRGB_HAL.dcmColorModel = 0;
     // Some applications apparently care about HAL texture caps
@@ -310,8 +308,10 @@ namespace dxvk {
                                            & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
 
     // Hardware acceleration
-    D3DDEVICEDESC3 descHAL_HAL = GetD3D3Caps(IID_IDirect3DHALDevice, d3dOptions);
-    D3DDEVICEDESC3 descHAL_HEL = descHAL_HAL;
+    D3DDEVICEDESC3 descHAL_HAL = m_desc;
+    ApplyD3D3DeviceCaps(&descHAL_HAL, IID_IDirect3DHALDevice);
+    D3DDEVICEDESC3 descHAL_HEL = m_desc;
+    ApplyD3D3DeviceCaps(&descHAL_HEL, IID_IDirect3DHALDevice);
     descHAL_HEL.dcmColorModel = 0;
     // Some applications apparently care about HEL texture caps
     descHAL_HEL.dpcLineCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE

--- a/src/ddraw/d3d3/d3d3_interface.h
+++ b/src/ddraw/d3d3/d3d3_interface.h
@@ -54,17 +54,16 @@ namespace dxvk {
 
   private:
 
-    Com<IDxvkD3D8InterfaceBridge> m_bridge;
+    Com<IDxvkLegacyD3DInterfaceBridge> m_bridge;
 
-    Com<D3DCommonInterface>       m_commonD3DIntf;
+    Com<D3DCommonInterface>            m_commonD3DIntf;
 
-    DDrawCommonInterface*         m_commonIntf = nullptr;
+    DDrawCommonInterface*              m_commonIntf = nullptr;
 
-    Com<D3D6Interface, false>     m_d3d6Intf;
-    Com<D3D5Interface, false>     m_d3d5Intf;
+    D3DDEVICEDESC3                     m_desc;
 
-    uint32_t                      m_intfCount  = 0;
-    static std::atomic<uint32_t>  s_intfCount;
+    Com<D3D6Interface, false>          m_d3d6Intf;
+    Com<D3D5Interface, false>          m_d3d5Intf;
 
   };
 

--- a/src/ddraw/d3d3/d3d3_material.cpp
+++ b/src/ddraw/d3d3/d3d3_material.cpp
@@ -11,24 +11,16 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> D3D3Material::s_materialCount = 0;
-
   D3D3Material::D3D3Material(
         D3D3Interface* pParent)
     : DDrawChildObject<D3D3Interface, IDirect3DMaterial>(pParent) {
     m_commonMaterial = new D3DCommonMaterial();
 
     m_commonMaterial->SetD3D3Material(this);
-
-    m_materialCount = ++s_materialCount;
-
-    Logger::debug(str::format("D3D3Material: Created a new material nr. [[1-", m_materialCount, "]]"));
   }
 
   D3D3Material::~D3D3Material() {
     m_commonMaterial->SetD3D3Material(nullptr);
-
-    Logger::debug(str::format("D3D3Material: Material nr. [[1-", m_materialCount, "]] bites the dust"));
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Material::QueryInterface(REFIID riid, void** ppvObject) {

--- a/src/ddraw/d3d3/d3d3_material.h
+++ b/src/ddraw/d3d3/d3d3_material.h
@@ -39,9 +39,6 @@ namespace dxvk {
 
     Com<D3DCommonMaterial> m_commonMaterial;
 
-    uint32_t               m_materialCount = 0;
-    static std::atomic<uint32_t> s_materialCount;
-
   };
 
 }

--- a/src/ddraw/d3d3/d3d3_texture.cpp
+++ b/src/ddraw/d3d3/d3d3_texture.cpp
@@ -8,8 +8,6 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> D3D3Texture::s_texCount = 0;
-
   D3D3Texture::D3D3Texture(
         D3DCommonTexture* commonTex,
         DDrawCommonSurface* commonSurf,
@@ -22,16 +20,10 @@ namespace dxvk {
       m_commonTex = new D3DCommonTexture(commonSurf);
 
     m_commonTex->SetD3D3Texture(this);
-
-    m_texCount = ++s_texCount;
-
-    Logger::debug(str::format("D3D3Texture: Created a new texture nr. [[1-", m_texCount, "]]"));
   }
 
   D3D3Texture::~D3D3Texture() {
     m_commonTex->SetD3D3Texture(nullptr);
-
-    Logger::debug(str::format("D3D3Texture: Texture nr. [[1-", m_texCount, "]] bites the dust"));
   }
 
   // Interlocked refcount with the parent IDirectDrawSurface
@@ -138,7 +130,8 @@ namespace dxvk {
       return hr;
 
     DDrawCommonSurface* commonSurf = m_commonTex->GetCommonSurface();
-    hr = commonSurf->RefreshSurfaceDescripton();
+
+    hr = commonSurf->RefreshSurfaceDescripton(true);
     if (unlikely(FAILED(hr))) {
       Logger::err("D3D3Texture::Load: Failed to refresh surface description");
       return hr;

--- a/src/ddraw/d3d3/d3d3_texture.h
+++ b/src/ddraw/d3d3/d3d3_texture.h
@@ -49,9 +49,6 @@ namespace dxvk {
 
     DDrawCommonInterface* m_commonIntf = nullptr;
 
-    uint32_t              m_texCount   = 0;
-    static std::atomic<uint32_t> s_texCount;
-
   };
 
 }

--- a/src/ddraw/d3d3/d3d3_viewport.cpp
+++ b/src/ddraw/d3d3/d3d3_viewport.cpp
@@ -20,8 +20,6 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> D3D3Viewport::s_viewportCount = 0;
-
   D3D3Viewport::D3D3Viewport(
         D3DCommonViewport* commonViewport,
         D3D3Interface* pParent)
@@ -35,10 +33,6 @@ namespace dxvk {
 
     if (m_commonViewport->GetOrigin() == nullptr)
       m_commonViewport->SetOrigin(this);
-
-    m_viewportCount = ++s_viewportCount;
-
-    Logger::debug(str::format("D3D3Viewport: Created a new viewport nr. [[1-", m_viewportCount, "]]"));
   }
 
   D3D3Viewport::~D3D3Viewport() {
@@ -53,8 +47,6 @@ namespace dxvk {
       m_commonViewport->SetOrigin(nullptr);
 
     m_commonViewport->SetD3D3Viewport(nullptr);
-
-    Logger::debug(str::format("D3D3Viewport: Viewport nr. [[1-", m_viewportCount, "]] bites the dust"));
   }
 
   // Interlocked refcount with the origin viewport
@@ -159,10 +151,12 @@ namespace dxvk {
       return D3DERR_VIEWPORTHASNODEVICE;
 
     // These validations aren't performed at all on viewports bound to a D3D3 device
-    if (unlikely(m_commonViewport->GetD3D3Device() == nullptr)) {
+    if (unlikely(!m_commonViewport->IsBoundToD3D3Device())) {
+      D3DCommonDevice* commonD3DDevice = m_commonViewport->GetCommonD3DDevice();
+
       // Use the full surface rect, since it is surface version agnostic
-      const RECT* surfRect = m_commonViewport->GetCommonRenderTarget()->GetFullSurfaceRect();
-      // D3D3 will fail when setting a viewport that's outside of the
+      const RECT* surfRect = commonD3DDevice->GetCommonRenderTarget()->GetFullSurfaceRect();
+      // D3D6/5 will fail when setting a viewport that's outside of the
       // current render target, though that works in D3D9
       HRESULT hr = ValidateViewportRT(data->dwX, data->dwY, data->dwWidth, data->dwHeight,
                                       surfRect->right, surfRect->bottom);
@@ -191,9 +185,8 @@ namespace dxvk {
     legacyClip->z = 0.0f;
 
     m_commonViewport->MarkViewportAsSet();
-
     if (m_commonViewport->IsCurrentViewport())
-      ApplyViewport();
+      m_commonViewport->ApplyViewport();
 
     return D3D_OK;
   }
@@ -206,20 +199,17 @@ namespace dxvk {
 
     // Temporarily activate this viewport, if not already active
     d3d9::D3DVIEWPORT9 currentViewport9;
-    if (!m_commonViewport->IsCurrentViewport()) {
-      D3D3Viewport* currentViewport = m_commonViewport->GetCurrentD3D3Viewport();
-      if (currentViewport != nullptr) {
-        currentViewport9 = *currentViewport->GetCommonViewport()->GetD3D9Viewport();
-      } else {
-        d3d9Device->GetViewport(&currentViewport9);
-      }
+    const bool isCurrentViewport = m_commonViewport->IsCurrentViewport();
+
+    if (!isCurrentViewport) {
+      d3d9Device->GetViewport(&currentViewport9);
       d3d9Device->SetViewport(m_commonViewport->GetD3D9Viewport());
     }
 
     HRESULT hr = m_commonViewport->TransformVertices(vertex_count, data, flags, offscreen);
 
     // Restore the previously active viewport
-    if (!m_commonViewport->IsCurrentViewport()) {
+    if (!isCurrentViewport) {
       d3d9Device->SetViewport(&currentViewport9);
     }
 
@@ -300,8 +290,10 @@ namespace dxvk {
     DDrawCommonSurface* rt = nullptr;
     DDrawCommonSurface* ds = nullptr;
 
+    D3DCommonDevice* commonD3DDevice = m_commonViewport->GetCommonD3DDevice();
+
     if (clearRenderTarget) {
-      rt = m_commonViewport->GetCommonRenderTarget();
+      rt = commonD3DDevice->GetCommonRenderTarget();
       if (likely(rt != nullptr)) {
         // If this isn't a full surface clear, we need to first upload the DDraw surface
         if (unlikely(count > 1 || !rt->IsFullSurfaceLock(reinterpret_cast<RECT*>(rects), nullptr))) {
@@ -313,7 +305,7 @@ namespace dxvk {
       }
     }
     if (clearDepthStencil) {
-      ds = m_commonViewport->GetCommonDepthStencil();
+      ds = commonD3DDevice->GetCommonDepthStencil();
       if (likely(ds != nullptr)) {
         // If this isn't a full surface clear, we need to first upload the DDraw surface
         if (unlikely(count > 1 || !ds->IsFullSurfaceLock(reinterpret_cast<RECT*>(rects), nullptr))) {
@@ -325,18 +317,14 @@ namespace dxvk {
       }
     }
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = commonD3DDevice->GetD3D9Device();
 
     // Temporarily activate this viewport in order to clear it
     d3d9::D3DVIEWPORT9 currentViewport9;
     const bool isCurrentViewport = m_commonViewport->IsCurrentViewport();
+
     if (!isCurrentViewport) {
-      D3D3Viewport* currentViewport = m_commonViewport->GetCurrentD3D3Viewport();
-      if (currentViewport != nullptr) {
-        currentViewport9 = *currentViewport->GetCommonViewport()->GetD3D9Viewport();
-      } else {
-        d3d9Device->GetViewport(&currentViewport9);
-      }
+      d3d9Device->GetViewport(&currentViewport9);
       d3d9Device->SetViewport(m_commonViewport->GetD3D9Viewport());
     }
 
@@ -365,7 +353,7 @@ namespace dxvk {
     if (clearDepthStencil && ds != nullptr)
       ds->UnDirtyDDrawSurface();
 
-    m_commonViewport->UpdateSurfaceDirtyTracking(clearRenderTarget, clearDepthStencil, false);
+    commonD3DDevice->UpdateSurfaceDirtyTracking(clearRenderTarget, clearDepthStencil, false);
 
     return D3D_OK;
   }
@@ -386,7 +374,7 @@ namespace dxvk {
     d3dLight->SetViewport3(this);
 
     if (m_commonViewport->HasDevice() && m_commonViewport->IsCurrentViewport())
-      ApplyAndActivateLight(d3dLight->GetIndex(), d3dLight);
+      m_commonViewport->ApplyAndActivateLight(d3dLight);
 
     return D3D_OK;
   }
@@ -404,14 +392,11 @@ namespace dxvk {
 
     auto it = std::find(lights.begin(), lights.end(), d3dLight);
     if (likely(it != lights.end())) {
-      const DWORD lightIndex = d3dLight->GetIndex();
-      if (m_commonViewport->HasDevice() && m_commonViewport->IsCurrentViewport() && d3dLight->IsActive()) {
-        //Logger::debug(str::format("D3D3Viewport: Disabling light nr. ", lightIndex));
-        d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
-        d3d9Device->LightEnable(lightIndex, FALSE);
-      }
-      lights.erase(it);
+      // Ensure the light is deactivated before deleting it
+      if (m_commonViewport->HasDevice() && m_commonViewport->IsCurrentViewport() && d3dLight->IsActive())
+        m_commonViewport->DeactivateLight(d3dLight);
       d3dLight->SetViewport3(nullptr);
+      lights.erase(it);
     } else {
       Logger::warn("D3D3Viewport::DeleteLight: Light not found");
       return DDERR_INVALIDPARAMS;
@@ -440,76 +425,6 @@ namespace dxvk {
     } else if (flags & D3DNEXT_TAIL) {
       if (likely(lights.size() > 0))
         *lplpDirect3DLight = lights.back().ref();
-    }
-
-    return D3D_OK;
-  }
-
-  HRESULT D3D3Viewport::ApplyViewport() {
-    if (!m_commonViewport->IsViewportSet())
-      return D3D_OK;
-
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
-
-    HRESULT hr = d3d9Device->SetViewport(m_commonViewport->GetD3D9Viewport());
-    if (unlikely(FAILED(hr))) {
-      Logger::err("D3D3Viewport: Failed to set the D3D9 viewport");
-      return hr;
-    }
-
-    return D3D_OK;
-  }
-
-  HRESULT D3D3Viewport::ApplyAndActivateLights() {
-    std::vector<Com<D3DLight>>& lights = m_commonViewport->GetLights();
-
-    if (!lights.size())
-      return D3D_OK;
-
-    for (auto light: lights)
-      ApplyAndActivateLight(light->GetIndex(), light.ptr());
-
-    return D3D_OK;
-  }
-
-  HRESULT D3D3Viewport::DeactivateLights() {
-    std::vector<Com<D3DLight>>& lights = m_commonViewport->GetLights();
-
-    if (!lights.size())
-      return D3D_OK;
-
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
-
-    for (auto light: lights) {
-      const DWORD lightIndex = light->GetIndex();
-      if (m_commonViewport->HasDevice() && m_commonViewport->IsCurrentViewport() && light->IsActive()) {
-        //Logger::debug(str::format("D3D3Viewport: Disabling light nr. ", lightIndex));
-        d3d9Device->LightEnable(lightIndex, FALSE);
-      }
-    }
-
-    return D3D_OK;
-  }
-
-  HRESULT D3D3Viewport::ApplyAndActivateLight(DWORD index, D3DLight* light) {
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
-
-    HRESULT hr = d3d9Device->SetLight(index, light->GetD3D9Light());
-    if (unlikely(FAILED(hr))) {
-      Logger::err("D3D3Viewport: Failed D3D9 SetLight call");
-      return hr;
-    }
-
-    if (light->IsActive()) {
-      //Logger::debug(str::format("D3D3Viewport: Enabling D3D9 light nr. ", index));
-      hr = d3d9Device->LightEnable(index, TRUE);
-      if (unlikely(FAILED(hr)))
-        Logger::err("D3D3Viewport: Failed D3D9 LightEnable call (TRUE)");
-    } else {
-      //Logger::debug(str::format("D3D3Viewport: Disabling D3D9 light nr. ", index));
-      hr = d3d9Device->LightEnable(index, FALSE);
-      if (unlikely(FAILED(hr)))
-        Logger::err("D3D3Viewport: Failed D3D9 LightEnable call (FALSE)");
     }
 
     return D3D_OK;

--- a/src/ddraw/d3d3/d3d3_viewport.h
+++ b/src/ddraw/d3d3/d3d3_viewport.h
@@ -58,14 +58,6 @@ namespace dxvk {
 
     HRESULT STDMETHODCALLTYPE NextLight(IDirect3DLight *lpDirect3DLight, IDirect3DLight **lplpDirect3DLight, DWORD flags);
 
-    HRESULT ApplyViewport();
-
-    HRESULT ApplyAndActivateLights();
-
-    HRESULT DeactivateLights();
-
-    HRESULT ApplyAndActivateLight(DWORD index, D3DLight* light);
-
     D3DCommonViewport* GetCommonViewport() const {
       return m_commonViewport.ptr();
     }
@@ -80,9 +72,6 @@ namespace dxvk {
 
     Com<D3D6Viewport, false> m_viewport6;
     Com<D3D5Viewport, false> m_viewport5;
-
-    uint32_t                 m_viewportCount        = 0;
-    static std::atomic<uint32_t> s_viewportCount;
 
   };
 

--- a/src/ddraw/d3d5/d3d5_device.cpp
+++ b/src/ddraw/d3d5/d3d5_device.cpp
@@ -22,8 +22,6 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> D3D5Device::s_deviceCount = 0;
-
   D3D5Device::D3D5Device(
         D3DCommonDevice* commonD3DDevice,
         D3D5Interface* pParent,
@@ -46,7 +44,8 @@ namespace dxvk {
 
     const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
     // Retrieve and cache the device capabilities
-    m_desc = GetD3D5Caps(deviceGUID, d3dOptions);
+    m_desc = GetD3D5BaseCaps(d3dOptions);
+    ApplyD3D5DeviceCaps(&m_desc, deviceGUID);
 
     d3d9::IDirect3DDevice9* device9;
 
@@ -67,7 +66,7 @@ namespace dxvk {
     }
 
     // Get the bridge interface to D3D9
-    if (unlikely(FAILED(device9->QueryInterface(__uuidof(IDxvkD3D8Bridge), reinterpret_cast<void**>(&m_bridge))))) {
+    if (unlikely(FAILED(device9->QueryInterface(__uuidof(IDxvkLegacyD3DDeviceBridge), reinterpret_cast<void**>(&m_bridge))))) {
       throw DxvkError("D3D5Device: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
     }
 
@@ -77,14 +76,13 @@ namespace dxvk {
     // Update D3D9 legacy light state
     m_bridge->SetLegacyLightsState(true);
 
+    // Update D3D9 alternate pixel center
+    m_bridge->SetAlternatePixelCenter(d3dOptions->alternatePixelCenter == AlternatePixelCenter::Enabled);
+
     if (m_commonD3DDevice->GetOrigin() == nullptr)
       m_commonD3DDevice->SetOrigin(this);
 
     m_commonD3DDevice->SetD3D5Device(this);
-
-    m_deviceCount = ++s_deviceCount;
-
-    Logger::debug(str::format("D3D5Device: Created a new device nr. ((2-", m_deviceCount, "))"));
   }
 
   D3D5Device::~D3D5Device() {
@@ -98,8 +96,6 @@ namespace dxvk {
 
     if (m_commonD3DDevice->GetOrigin() == this)
       m_commonD3DDevice->SetOrigin(nullptr);
-
-    Logger::debug(str::format("D3D5Device: Device nr. ((2-", m_deviceCount, ")) bites the dust"));
   }
 
   // Interlocked refcount with the origin device
@@ -227,21 +223,21 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D5Device::GetStats(D3DSTATS *stats) {
     D3DDeviceLock lock = LockDevice();
 
+    // Forward the call directly to the D3D3 device, if one exists
+    if (likely(m_device3 != nullptr))
+      return m_device3->GetStats(stats);
+
     if (unlikely(stats == nullptr))
       return DDERR_INVALIDPARAMS;
 
     if (unlikely(stats->dwSize != sizeof(D3DSTATS)))
       return DDERR_INVALIDPARAMS;
 
-    D3DSTATS newStats = { };
+    // Otherwise, simply return an empty stats struct
+    D3DSTATS blankStats = { };
+    blankStats.dwSize = sizeof(D3DSTATS);
 
-    if (likely(m_commonD3DDevice->GetD3D3Device() != nullptr))
-      newStats = m_commonD3DDevice->GetD3D3Device()->GetStatsInternal();
-
-    const DWORD dwSize = stats->dwSize;
-
-    *stats = newStats;
-    stats->dwSize = dwSize;
+    *stats = blankStats;
 
     return D3D_OK;
   }
@@ -252,7 +248,15 @@ namespace dxvk {
     if (unlikely(viewport == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    AddViewportInternal(viewport);
+    D3D5Viewport* d3d5Viewport = static_cast<D3D5Viewport*>(viewport);
+
+    auto it = std::find(m_viewports.begin(), m_viewports.end(), d3d5Viewport);
+    if (unlikely(it != m_viewports.end())) {
+      Logger::warn("D3D5Device::AddViewport: Pre-existing viewport found");
+    } else {
+      m_viewports.push_back(d3d5Viewport);
+      d3d5Viewport->GetCommonViewport()->SetD3D5Device(this);
+    }
 
     return D3D_OK;
   }
@@ -263,12 +267,18 @@ namespace dxvk {
     if (unlikely(viewport == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    DeleteViewportInternal(viewport);
-
-    // Clear the current viewport if it is deleted from the device
     D3D5Viewport* d3d5Viewport = static_cast<D3D5Viewport*>(viewport);
-    if (m_currentViewport.ptr() == d3d5Viewport)
-      m_currentViewport = nullptr;
+
+    auto it = std::find(m_viewports.begin(), m_viewports.end(), d3d5Viewport);
+    if (likely(it != m_viewports.end())) {
+      d3d5Viewport->GetCommonViewport()->SetD3D5Device(nullptr);
+      // Clear the current viewport if it is deleted from the device
+      if (m_currentViewport.ptr() == d3d5Viewport)
+        m_currentViewport = nullptr;
+      m_viewports.erase(it);
+    } else {
+      Logger::warn("D3D5Device::DeleteViewport: Viewport not found");
+    }
 
     return D3D_OK;
   }
@@ -343,9 +353,7 @@ namespace dxvk {
     if (unlikely(hr != D3DENUMRET_OK))
       return D3D_OK;
 
-    // Not supported in D3D9, but some games need
-    // it to be advertised (for offscreen plain surfaces?)
-    if (unlikely(d3dOptions->supportR3G3B2)) {
+    if (d3dOptions->supportR3G3B2) {
       textureFormat.ddpfPixelFormat = GetTextureFormat(d3d9::D3DFMT_R3G3B2);
       hr = cb(&textureFormat, ctx);
       if (unlikely(hr != D3DENUMRET_OK))
@@ -422,20 +430,26 @@ namespace dxvk {
     if (unlikely(m_currentViewport == d3d5Viewport))
       return D3D_OK;
 
+    D3DCommonViewport* commonViewport = d3d5Viewport->GetCommonViewport();
+
     // Validate that the viewport is attached to this (common) device
-    if (unlikely(m_commonD3DDevice != d3d5Viewport->GetCommonViewport()->GetCommonD3DDevice()))
+    if (unlikely(m_commonD3DDevice != commonViewport->GetCommonD3DDevice()))
       return DDERR_INVALIDPARAMS;
 
     if (likely(m_currentViewport != nullptr)) {
-      m_currentViewport->DeactivateLights();
-      m_currentViewport->GetCommonViewport()->SetIsCurrentViewport(false);
+      D3DCommonViewport* currentCommonViewport = m_currentViewport->GetCommonViewport();
+      if (currentCommonViewport->HasLights())
+        currentCommonViewport->DeactivateLights();
+      currentCommonViewport->SetIsCurrentViewport(false);
     }
 
     m_currentViewport = d3d5Viewport.ptr();
 
-    m_currentViewport->GetCommonViewport()->SetIsCurrentViewport(true);
-    m_currentViewport->ApplyViewport();
-    m_currentViewport->ApplyAndActivateLights();
+    commonViewport->SetIsCurrentViewport(true);
+    if (likely(commonViewport->IsViewportSet()))
+      commonViewport->ApplyViewport();
+    if (commonViewport->HasLights())
+      commonViewport->ApplyAndActivateLights();
 
     return D3D_OK;
   }
@@ -547,15 +561,19 @@ namespace dxvk {
     if (unlikely(vertex == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    if (m_vertexStreamInfo.d3dvt == D3DVT_VERTEX) {
-      m_vertexStream.push_back(*reinterpret_cast<D3DVERTEX*>(vertex));
-    } else if (m_vertexStreamInfo.d3dvt == D3DVT_LVERTEX) {
-      m_lvertexStream.push_back(*reinterpret_cast<D3DLVERTEX*>(vertex));
-    } else if (m_vertexStreamInfo.d3dvt == D3DVT_TLVERTEX) {
-      m_tlvertexStream.push_back(*reinterpret_cast<D3DTLVERTEX*>(vertex));
-    } else {
-      Logger::warn(">>> D3D5Device::Vertex: Invalid vertex type");
-      return DDERR_INVALIDPARAMS;
+    switch (m_vertexStreamInfo.d3dvt) {
+      case D3DVT_VERTEX:
+        m_vertexStream.push_back(*reinterpret_cast<D3DVERTEX*>(vertex));
+        break;
+      case D3DVT_LVERTEX:
+        m_lvertexStream.push_back(*reinterpret_cast<D3DLVERTEX*>(vertex));
+        break;
+      case D3DVT_TLVERTEX:
+        m_tlvertexStream.push_back(*reinterpret_cast<D3DTLVERTEX*>(vertex));
+        break;
+      default:
+        Logger::warn(">>> D3D5Device::Vertex: Invalid vertex type");
+        return DDERR_INVALIDPARAMS;
     }
 
     return D3D_OK;
@@ -570,25 +588,30 @@ namespace dxvk {
     D3DDeviceLock lock = LockDevice();
 
     HRESULT hr;
-    if (m_vertexStreamInfo.d3dvt == D3DVT_VERTEX) {
-      hr = DrawPrimitive(m_vertexStreamInfo.d3dpt, m_vertexStreamInfo.d3dvt, m_vertexStream.data(),
-                         m_vertexStream.size(), m_vertexStreamInfo.dwFlags);
-      m_vertexStream.clear();
-    } else if (m_vertexStreamInfo.d3dvt == D3DVT_LVERTEX) {
-      hr = DrawPrimitive(m_vertexStreamInfo.d3dpt, m_vertexStreamInfo.d3dvt, m_lvertexStream.data(),
-                         m_lvertexStream.size(), m_vertexStreamInfo.dwFlags);
-      m_lvertexStream.clear();
-    } else if (m_vertexStreamInfo.d3dvt == D3DVT_TLVERTEX) {
-      hr = DrawPrimitive(m_vertexStreamInfo.d3dpt, m_vertexStreamInfo.d3dvt, m_tlvertexStream.data(),
-                         m_tlvertexStream.size(), m_vertexStreamInfo.dwFlags);
-      m_tlvertexStream.clear();
-    } else {
-      Logger::warn(">>> D3D5Device::End: Invalid vertex type");
-      return DDERR_INVALIDPARAMS;
+
+    switch (m_vertexStreamInfo.d3dvt) {
+      case D3DVT_VERTEX:
+        hr = DrawPrimitive(m_vertexStreamInfo.d3dpt, m_vertexStreamInfo.d3dvt, m_vertexStream.data(),
+                           m_vertexStream.size(), m_vertexStreamInfo.dwFlags);
+        m_vertexStream.clear();
+        break;
+      case D3DVT_LVERTEX:
+        hr = DrawPrimitive(m_vertexStreamInfo.d3dpt, m_vertexStreamInfo.d3dvt, m_lvertexStream.data(),
+                           m_lvertexStream.size(), m_vertexStreamInfo.dwFlags);
+        m_lvertexStream.clear();
+        break;
+      case D3DVT_TLVERTEX:
+        hr = DrawPrimitive(m_vertexStreamInfo.d3dpt, m_vertexStreamInfo.d3dvt, m_tlvertexStream.data(),
+                           m_tlvertexStream.size(), m_vertexStreamInfo.dwFlags);
+        m_tlvertexStream.clear();
+        break;
+      default:
+        Logger::warn(">>> D3D5Device::End: Invalid vertex type");
+        return DDERR_INVALIDPARAMS;
     }
 
     if (unlikely(FAILED(hr)))
-      Logger::warn(">>> D3D5Device::End: Failed call to DrawPrimitive");
+      Logger::err(">>> D3D5Device::End: Failed call to DrawPrimitive");
 
     m_vertexStreamInfo = { };
 
@@ -601,20 +624,93 @@ namespace dxvk {
     if (unlikely(lpdwRenderState == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    // As opposed to D3D7, D3D5 does not error out on
-    // unknown or invalid render states.
-    if (unlikely(!IsValidD3D5RenderStateType(dwRenderStateType)
-              && !m_commonIntf->GetOptions()->apitraceMode)) {
-      *lpdwRenderState = 0;
-      return D3D_OK;
-    }
-
     d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
     d3d9::D3DRENDERSTATETYPE State9 = d3d9::D3DRENDERSTATETYPE(dwRenderStateType);
 
     switch (dwRenderStateType) {
       // Most render states translate 1:1 to D3D9
-      default:
+      //case D3DRENDERSTATE_TEXTUREHANDLE:
+      //case D3DRENDERSTATE_ANTIALIAS:
+      //case D3DRENDERSTATE_TEXTUREADDRESS:
+      //case D3DRENDERSTATE_TEXTUREPERSPECTIVE:
+      //case D3DRENDERSTATE_WRAPU:
+      //case D3DRENDERSTATE_WRAPV:
+      case D3DRENDERSTATE_ZENABLE:
+      case D3DRENDERSTATE_FILLMODE:
+      case D3DRENDERSTATE_SHADEMODE:
+      //case D3DRENDERSTATE_LINEPATTERN:
+      //case D3DRENDERSTATE_MONOENABLE:
+      //case D3DRENDERSTATE_ROP2:
+      //case D3DRENDERSTATE_PLANEMASK:
+      case D3DRENDERSTATE_ZWRITEENABLE:
+      case D3DRENDERSTATE_ALPHATESTENABLE:
+      case D3DRENDERSTATE_LASTPIXEL:
+      //case D3DRENDERSTATE_TEXTUREMAG:
+      //case D3DRENDERSTATE_TEXTUREMIN:
+      case D3DRENDERSTATE_SRCBLEND:
+      case D3DRENDERSTATE_DESTBLEND:
+      //case D3DRENDERSTATE_TEXTUREMAPBLEND:
+      case D3DRENDERSTATE_CULLMODE:
+      case D3DRENDERSTATE_ZFUNC:
+      case D3DRENDERSTATE_ALPHAREF:
+      case D3DRENDERSTATE_ALPHAFUNC:
+      case D3DRENDERSTATE_DITHERENABLE:
+      //case D3DRENDERSTATE_BLENDENABLE: // The actual D3DRENDERSTATE_ALPHABLENDENABLE
+      case D3DRENDERSTATE_FOGENABLE:
+      case D3DRENDERSTATE_SPECULARENABLE:
+      //case D3DRENDERSTATE_ZVISIBLE:
+      //case D3DRENDERSTATE_SUBPIXEL:
+      //case D3DRENDERSTATE_SUBPIXELX:
+      //case D3DRENDERSTATE_STIPPLEDALPHA:
+      case D3DRENDERSTATE_FOGCOLOR:
+      case D3DRENDERSTATE_FOGTABLEMODE:
+      case D3DRENDERSTATE_FOGTABLESTART:
+      case D3DRENDERSTATE_FOGTABLEEND:
+      case D3DRENDERSTATE_FOGTABLEDENSITY:
+      //case D3DRENDERSTATE_STIPPLEENABLE:
+      //case D3DRENDERSTATE_EDGEANTIALIAS:
+      //case D3DRENDERSTATE_COLORKEYENABLE:
+      //case D3DRENDERSTATE_ALPHABLENDENABLE_OLD: // Deprecated in D3D6
+      //case D3DRENDERSTATE_BORDERCOLOR:
+      //case D3DRENDERSTATE_TEXTUREADDRESSU:
+      //case D3DRENDERSTATE_TEXTUREADDRESSV:
+      //case D3DRENDERSTATE_MIPMAPLODBIAS:
+      //case D3DRENDERSTATE_ZBIAS:
+      case D3DRENDERSTATE_RANGEFOGENABLE:
+      //case D3DRENDERSTATE_ANISOTROPY:
+      //case D3DRENDERSTATE_FLUSHBATCH: // Not in the docs, but valid in D3D5
+      //case D3DRENDERSTATE_STIPPLEPATTERN00:
+      //case D3DRENDERSTATE_STIPPLEPATTERN01:
+      //case D3DRENDERSTATE_STIPPLEPATTERN02:
+      //case D3DRENDERSTATE_STIPPLEPATTERN03:
+      //case D3DRENDERSTATE_STIPPLEPATTERN04:
+      //case D3DRENDERSTATE_STIPPLEPATTERN05:
+      //case D3DRENDERSTATE_STIPPLEPATTERN06:
+      //case D3DRENDERSTATE_STIPPLEPATTERN07:
+      //case D3DRENDERSTATE_STIPPLEPATTERN08:
+      //case D3DRENDERSTATE_STIPPLEPATTERN09:
+      //case D3DRENDERSTATE_STIPPLEPATTERN10:
+      //case D3DRENDERSTATE_STIPPLEPATTERN11:
+      //case D3DRENDERSTATE_STIPPLEPATTERN12:
+      //case D3DRENDERSTATE_STIPPLEPATTERN13:
+      //case D3DRENDERSTATE_STIPPLEPATTERN14:
+      //case D3DRENDERSTATE_STIPPLEPATTERN15:
+      //case D3DRENDERSTATE_STIPPLEPATTERN16:
+      //case D3DRENDERSTATE_STIPPLEPATTERN17:
+      //case D3DRENDERSTATE_STIPPLEPATTERN18:
+      //case D3DRENDERSTATE_STIPPLEPATTERN19:
+      //case D3DRENDERSTATE_STIPPLEPATTERN20:
+      //case D3DRENDERSTATE_STIPPLEPATTERN21:
+      //case D3DRENDERSTATE_STIPPLEPATTERN22:
+      //case D3DRENDERSTATE_STIPPLEPATTERN23:
+      //case D3DRENDERSTATE_STIPPLEPATTERN24:
+      //case D3DRENDERSTATE_STIPPLEPATTERN25:
+      //case D3DRENDERSTATE_STIPPLEPATTERN26:
+      //case D3DRENDERSTATE_STIPPLEPATTERN27:
+      //case D3DRENDERSTATE_STIPPLEPATTERN28:
+      //case D3DRENDERSTATE_STIPPLEPATTERN29:
+      //case D3DRENDERSTATE_STIPPLEPATTERN30:
+      //case D3DRENDERSTATE_STIPPLEPATTERN31:
         break;
 
       // Replacement for later implemented GetTexture calls
@@ -684,8 +780,9 @@ namespace dxvk {
         *lpdwRenderState = m_commonD3DDevice->GetTextureMapBlend();
         return D3D_OK;
 
-      // Replaced by D3DRENDERSTATE_ALPHABLENDENABLE
+      // Replaced by D3DRENDERSTATE_ALPHABLENDENABLE in D3D6
       case D3DRENDERSTATE_BLENDENABLE:
+      case D3DRENDERSTATE_ALPHABLENDENABLE_OLD: // 42
         State9 = d3d9::D3DRS_ALPHABLENDENABLE;
         break;
 
@@ -713,10 +810,6 @@ namespace dxvk {
       case D3DRENDERSTATE_COLORKEYENABLE:
         *lpdwRenderState = m_commonD3DDevice->GetColorKeyEnable();
         return D3D_OK;
-
-      case D3DRENDERSTATE_ALPHABLENDENABLE_OLD:
-        State9 = d3d9::D3DRS_ALPHABLENDENABLE;
-        break;
 
       case D3DRENDERSTATE_BORDERCOLOR:
         device9->GetSamplerState(0, d3d9::D3DSAMP_BORDERCOLOR, lpdwRenderState);
@@ -787,6 +880,15 @@ namespace dxvk {
       case D3DRENDERSTATE_STIPPLEPATTERN31:
         *lpdwRenderState = 0;
         return D3D_OK;
+
+      // As opposed to D3D7, D3D5 does not error out on
+      // unknown or invalid render states.
+      default:
+        if (likely(!m_commonIntf->GetOptions()->apitraceMode)) {
+          *lpdwRenderState = 0;
+          return D3D_OK;
+        }
+        break;
     }
 
     // This call will never fail
@@ -796,17 +898,93 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D5Device::SetRenderState(D3DRENDERSTATETYPE dwRenderStateType, DWORD dwRenderState) {
     D3DDeviceLock lock = LockDevice();
 
-    // As opposed to D3D7, D3D5 does not error out on
-    // unknown or invalid render states.
-    if (unlikely(!IsValidD3D5RenderStateType(dwRenderStateType)))
-      return D3D_OK;
-
     d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
     d3d9::D3DRENDERSTATETYPE State9 = d3d9::D3DRENDERSTATETYPE(dwRenderStateType);
 
     switch (dwRenderStateType) {
       // Most render states translate 1:1 to D3D9
-      default:
+      //case D3DRENDERSTATE_TEXTUREHANDLE:
+      //case D3DRENDERSTATE_ANTIALIAS:
+      //case D3DRENDERSTATE_TEXTUREADDRESS:
+      //case D3DRENDERSTATE_TEXTUREPERSPECTIVE:
+      //case D3DRENDERSTATE_WRAPU:
+      //case D3DRENDERSTATE_WRAPV:
+      case D3DRENDERSTATE_ZENABLE:
+      case D3DRENDERSTATE_FILLMODE:
+      case D3DRENDERSTATE_SHADEMODE:
+      //case D3DRENDERSTATE_LINEPATTERN:
+      //case D3DRENDERSTATE_MONOENABLE:
+      //case D3DRENDERSTATE_ROP2:
+      //case D3DRENDERSTATE_PLANEMASK:
+      //case D3DRENDERSTATE_ZWRITEENABLE:
+      case D3DRENDERSTATE_ALPHATESTENABLE:
+      case D3DRENDERSTATE_LASTPIXEL:
+      //case D3DRENDERSTATE_TEXTUREMAG:
+      //case D3DRENDERSTATE_TEXTUREMIN:
+      case D3DRENDERSTATE_SRCBLEND:
+      case D3DRENDERSTATE_DESTBLEND:
+      //case D3DRENDERSTATE_TEXTUREMAPBLEND:
+      case D3DRENDERSTATE_CULLMODE:
+      case D3DRENDERSTATE_ZFUNC:
+      case D3DRENDERSTATE_ALPHAREF:
+      case D3DRENDERSTATE_ALPHAFUNC:
+      case D3DRENDERSTATE_DITHERENABLE:
+      //case D3DRENDERSTATE_BLENDENABLE: // The actual D3DRENDERSTATE_ALPHABLENDENABLE
+      case D3DRENDERSTATE_FOGENABLE:
+      case D3DRENDERSTATE_SPECULARENABLE:
+      //case D3DRENDERSTATE_ZVISIBLE:
+      //case D3DRENDERSTATE_SUBPIXEL:
+      //case D3DRENDERSTATE_SUBPIXELX:
+      //case D3DRENDERSTATE_STIPPLEDALPHA:
+      case D3DRENDERSTATE_FOGCOLOR:
+      case D3DRENDERSTATE_FOGTABLEMODE:
+      case D3DRENDERSTATE_FOGTABLESTART:
+      case D3DRENDERSTATE_FOGTABLEEND:
+      case D3DRENDERSTATE_FOGTABLEDENSITY:
+      //case D3DRENDERSTATE_STIPPLEENABLE:
+      //case D3DRENDERSTATE_EDGEANTIALIAS:
+      //case D3DRENDERSTATE_COLORKEYENABLE:
+      //case D3DRENDERSTATE_ALPHABLENDENABLE_OLD: // Deprecated in D3D6
+      //case D3DRENDERSTATE_BORDERCOLOR:
+      //case D3DRENDERSTATE_TEXTUREADDRESSU:
+      //case D3DRENDERSTATE_TEXTUREADDRESSV:
+      //case D3DRENDERSTATE_MIPMAPLODBIAS:
+      //case D3DRENDERSTATE_ZBIAS:
+      case D3DRENDERSTATE_RANGEFOGENABLE:
+      //case D3DRENDERSTATE_ANISOTROPY:
+      //case D3DRENDERSTATE_FLUSHBATCH: // Not in the docs, but valid in D3D5
+      //case D3DRENDERSTATE_STIPPLEPATTERN00:
+      //case D3DRENDERSTATE_STIPPLEPATTERN01:
+      //case D3DRENDERSTATE_STIPPLEPATTERN02:
+      //case D3DRENDERSTATE_STIPPLEPATTERN03:
+      //case D3DRENDERSTATE_STIPPLEPATTERN04:
+      //case D3DRENDERSTATE_STIPPLEPATTERN05:
+      //case D3DRENDERSTATE_STIPPLEPATTERN06:
+      //case D3DRENDERSTATE_STIPPLEPATTERN07:
+      //case D3DRENDERSTATE_STIPPLEPATTERN08:
+      //case D3DRENDERSTATE_STIPPLEPATTERN09:
+      //case D3DRENDERSTATE_STIPPLEPATTERN10:
+      //case D3DRENDERSTATE_STIPPLEPATTERN11:
+      //case D3DRENDERSTATE_STIPPLEPATTERN12:
+      //case D3DRENDERSTATE_STIPPLEPATTERN13:
+      //case D3DRENDERSTATE_STIPPLEPATTERN14:
+      //case D3DRENDERSTATE_STIPPLEPATTERN15:
+      //case D3DRENDERSTATE_STIPPLEPATTERN16:
+      //case D3DRENDERSTATE_STIPPLEPATTERN17:
+      //case D3DRENDERSTATE_STIPPLEPATTERN18:
+      //case D3DRENDERSTATE_STIPPLEPATTERN19:
+      //case D3DRENDERSTATE_STIPPLEPATTERN20:
+      //case D3DRENDERSTATE_STIPPLEPATTERN21:
+      //case D3DRENDERSTATE_STIPPLEPATTERN22:
+      //case D3DRENDERSTATE_STIPPLEPATTERN23:
+      //case D3DRENDERSTATE_STIPPLEPATTERN24:
+      //case D3DRENDERSTATE_STIPPLEPATTERN25:
+      //case D3DRENDERSTATE_STIPPLEPATTERN26:
+      //case D3DRENDERSTATE_STIPPLEPATTERN27:
+      //case D3DRENDERSTATE_STIPPLEPATTERN28:
+      //case D3DRENDERSTATE_STIPPLEPATTERN29:
+      //case D3DRENDERSTATE_STIPPLEPATTERN30:
+      //case D3DRENDERSTATE_STIPPLEPATTERN31:
         break;
 
       // Replacement for later implemented SetTexture calls
@@ -900,6 +1078,11 @@ namespace dxvk {
       // "This render state is not supported by the software rasterizers, and is often ignored by hardware drivers."
       case D3DRENDERSTATE_PLANEMASK:
         return D3D_OK;
+
+      // Track the depth write state for D3D9 depth stencil surface dirtying
+      case D3DRENDERSTATE_ZWRITEENABLE:
+        m_commonD3DDevice->SetDepthWriteEnabled(static_cast<bool>(dwRenderState));
+        break;
 
       // Docs: "[...]  only the first two (D3DFILTER_NEAREST and
       // D3DFILTER_LINEAR) are valid with D3DRENDERSTATE_TEXTUREMAG."
@@ -1021,8 +1204,9 @@ namespace dxvk {
 
         return D3D_OK;
 
-      // Replaced by D3DRENDERSTATE_ALPHABLENDENABLE
+      // Replaced by D3DRENDERSTATE_ALPHABLENDENABLE in D3D6
       case D3DRENDERSTATE_BLENDENABLE:
+      case D3DRENDERSTATE_ALPHABLENDENABLE_OLD: // 42
         State9 = d3d9::D3DRS_ALPHABLENDENABLE;
         break;
 
@@ -1067,10 +1251,6 @@ namespace dxvk {
 
         return D3D_OK;
       }
-
-      case D3DRENDERSTATE_ALPHABLENDENABLE_OLD:
-        State9 = d3d9::D3DRS_ALPHABLENDENABLE;
-        break;
 
       case D3DRENDERSTATE_BORDERCOLOR:
         device9->SetSamplerState(0, d3d9::D3DSAMP_BORDERCOLOR, dwRenderState);
@@ -1137,6 +1317,11 @@ namespace dxvk {
       case D3DRENDERSTATE_STIPPLEPATTERN29:
       case D3DRENDERSTATE_STIPPLEPATTERN30:
       case D3DRENDERSTATE_STIPPLEPATTERN31:
+        return D3D_OK;
+
+      // As opposed to D3D7, D3D5 does not error out on
+      // unknown or invalid render states.
+      default:
         return D3D_OK;
     }
 
@@ -1254,13 +1439,13 @@ namespace dxvk {
     if (unlikely(vertices == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
-
     DDrawDirtySurfaceUpload();
+
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     const DWORD vertex_type5 = ConvertVertexType(vertex_type);
     const bool useLighting = !(flags & D3DDP_DONOTLIGHT) &&
-                              (vertex_type & D3DFVF_NORMAL) &&
+                              (vertex_type5 & D3DFVF_NORMAL) &&
                               m_commonD3DDevice->GetCurrentMaterialHandle() != 0;
 
     if (!useLighting)
@@ -1269,10 +1454,10 @@ namespace dxvk {
 
     device9->SetFVF(vertex_type5);
     HRESULT hr = device9->DrawPrimitiveUP(
-                     d3d9::D3DPRIMITIVETYPE(primitive_type),
-                     GetPrimitiveCount(primitive_type, vertex_count),
-                     vertices,
-                     GetFVFSize(vertex_type5));
+                      d3d9::D3DPRIMITIVETYPE(primitive_type),
+                      GetPrimitiveCount(primitive_type, vertex_count),
+                      vertices,
+                      GetFVFSize(vertex_type5));
 
     if (!useLighting)
       device9->SetRenderState(d3d9::D3DRS_LIGHTING, TRUE);
@@ -1283,7 +1468,7 @@ namespace dxvk {
       return hr;
     }
 
-    UpdateSurfaceDirtyTracking(true, true, true);
+    UpdateSurfaceDirtyTracking(true, m_commonD3DDevice->IsDepthWriteEnabled(), true);
 
     return D3D_OK;
   }
@@ -1299,13 +1484,13 @@ namespace dxvk {
     if (unlikely(vertices == nullptr || indices == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
-
     DDrawDirtySurfaceUpload();
+
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     const DWORD fvf5 = ConvertVertexType(fvf);
     const bool useLighting = !(flags & D3DDP_DONOTLIGHT) &&
-                              (fvf & D3DFVF_NORMAL) &&
+                              (fvf5 & D3DFVF_NORMAL) &&
                               m_commonD3DDevice->GetCurrentMaterialHandle() != 0;
 
     if (!useLighting)
@@ -1332,7 +1517,7 @@ namespace dxvk {
       return hr;
     }
 
-    UpdateSurfaceDirtyTracking(true, true, true);
+    UpdateSurfaceDirtyTracking(true, m_commonD3DDevice->IsDepthWriteEnabled(), true);
 
     return D3D_OK;
   }
@@ -1363,39 +1548,43 @@ namespace dxvk {
     return D3D_OK;
   }
 
-  void D3D5Device::InitializeDS() {
-    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
-
-    m_rt->InitializeD3D9RenderTarget();
+  HRESULT D3D5Device::InitializeRTAndDS() {
+    HRESULT hr = m_rt->InitializeD3D9RenderTarget();
+    if (unlikely(FAILED(hr)))
+      return hr;
 
     m_ds = m_rt->GetAttachedDepthStencil();
 
-    if (m_ds != nullptr) {
-      HRESULT hrDS = m_ds->InitializeD3D9DepthStencil();
-      if (unlikely(FAILED(hrDS))) {
-        Logger::err("D3D5Device::InitializeDS: Failed to initialize D3D9 DS");
-      } else {
-        const RECT* dsRect = m_ds->GetCommonSurface()->GetFullSurfaceRect();
-        Logger::info(str::format("D3D5Device::InitializeDS: Depth stencil: ", dsRect->right, "x", dsRect->bottom));
+    if (likely(m_ds != nullptr)) {
+      hr = m_ds->InitializeD3D9DepthStencil();
+      if (unlikely(FAILED(hr)))
+        return hr;
 
-        HRESULT hrDS9 = device9->SetDepthStencilSurface(m_ds->GetCommonSurface()->GetD3D9Surface());
-        if (unlikely(FAILED(hrDS9))) {
-          Logger::err("D3D5Device::InitializeDS: Failed to set D3D9 depth stencil");
-        } else {
-          // This needs to act like an auto depth stencil of sorts, so manually enable z-buffering
-          device9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_TRUE);
-        }
+      const RECT* dsRect = m_ds->GetCommonSurface()->GetFullSurfaceRect();
+      Logger::info(str::format("D3D5Device: Depth stencil: ", dsRect->right, "x", dsRect->bottom));
+
+      d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
+      hr = device9->SetDepthStencilSurface(m_ds->GetCommonSurface()->GetD3D9Surface());
+      if (unlikely(FAILED(hr))) {
+        Logger::err("D3D5Device: Failed to set D3D9 depth stencil");
+        return hr;
       }
-    } else {
-      device9->SetDepthStencilSurface(nullptr);
-      // Should be superfluous, but play it safe
-      device9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_FALSE);
+
+      // The docs state D3DRS_ZENABLE isn't set based on depth stencil attachments in D3D5:
+      // "The default value is FALSE.", however some games apparently depend on it...
+      device9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_TRUE);
     }
+
+    return D3D_OK;
   }
 
   void D3D5Device::UpdateSurfaceDirtyTracking(bool dirtyRenderTarget, bool dirtyDepthStencil, bool dirtyPrimarySurface) {
     if (likely(dirtyRenderTarget))
       m_rt->GetCommonSurface()->DirtyD3D9Surface();
+
+    if (likely(dirtyDepthStencil && m_ds != nullptr))
+      m_ds->GetCommonSurface()->DirtyD3D9Surface();
 
     if (likely(dirtyPrimarySurface)) {
       DDrawCommonSurface* primarySurface = m_commonIntf->GetPrimarySurface();
@@ -1404,9 +1593,6 @@ namespace dxvk {
       if (likely(primarySurface != nullptr))
         primarySurface->DirtyD3D9Surface();
     }
-
-    if (likely(dirtyDepthStencil && m_ds != nullptr))
-      m_ds->GetCommonSurface()->DirtyD3D9Surface();
   }
 
   inline void D3D5Device::DDrawDirtySurfaceUpload() {
@@ -1421,30 +1607,6 @@ namespace dxvk {
       DDrawSurface* tex = DDrawCommonInterface::GetSurfaceFromTextureHandle(texHandle);
       if (likely(tex != nullptr))
         tex->InitializeOrUploadD3D9();
-    }
-  }
-
-  inline void D3D5Device::AddViewportInternal(IDirect3DViewport2* viewport) {
-    D3D5Viewport* d3d5Viewport = static_cast<D3D5Viewport*>(viewport);
-
-    auto it = std::find(m_viewports.begin(), m_viewports.end(), d3d5Viewport);
-    if (unlikely(it != m_viewports.end())) {
-      Logger::warn("D3D5Device::AddViewportInternal: Pre-existing viewport found");
-    } else {
-      m_viewports.push_back(d3d5Viewport);
-      d3d5Viewport->GetCommonViewport()->SetD3D5Device(this);
-    }
-  }
-
-  inline void D3D5Device::DeleteViewportInternal(IDirect3DViewport2* viewport) {
-    D3D5Viewport* d3d5Viewport = static_cast<D3D5Viewport*>(viewport);
-
-    auto it = std::find(m_viewports.begin(), m_viewports.end(), d3d5Viewport);
-    if (likely(it != m_viewports.end())) {
-      m_viewports.erase(it);
-      d3d5Viewport->GetCommonViewport()->SetD3D5Device(nullptr);
-    } else {
-      Logger::warn("D3D5Device::DeleteViewportInternal: Viewport not found");
     }
   }
 
@@ -1467,10 +1629,12 @@ namespace dxvk {
       return D3D_OK;
     }
 
+    DDrawCommonSurface* commonSurface = surface->GetCommonSurface();
+
     // If textures have been used on a different device, they
     // will get their D3D9 object reinitialized at this point
-    if (unlikely(surface->GetCommonSurface()->GetCommonD3DDevice() != m_commonD3DDevice.ptr()))
-      surface->GetCommonSurface()->DirtyDDrawSurface();
+    if (unlikely(commonSurface->GetCommonD3DDevice() != m_commonD3DDevice.ptr()))
+      commonSurface->DirtyDDrawSurface();
 
     hr = surface->InitializeOrUploadD3D9();
     if (unlikely(FAILED(hr))) {
@@ -1482,7 +1646,7 @@ namespace dxvk {
     //if (unlikely(m_commonD3DDevice->GetCurrentTextureHandle() == textureHandle))
       //return D3D_OK;
 
-    d3d9::IDirect3DTexture9* tex9 = surface->GetCommonSurface()->GetD3D9Texture();
+    d3d9::IDirect3DTexture9* tex9 = commonSurface->GetD3D9Texture();
 
     if (likely(tex9 != nullptr)) {
       hr = device9->SetTexture(0, tex9);
@@ -1495,15 +1659,15 @@ namespace dxvk {
       //  have been used with no texturing; if the texture does not contain an alpha component,
       //  alpha values at the vertices in the source are interpolated between vertices."
       if (m_commonD3DDevice->GetTextureMapBlend() == D3DTBLEND_MODULATE) {
-        const DWORD textureOp = surface->GetCommonSurface()->IsAlphaFormat() ? D3DTOP_SELECTARG1 : D3DTOP_SELECTARG2;
+        const DWORD textureOp = commonSurface->IsAlphaFormat() ? D3DTOP_SELECTARG1 : D3DTOP_SELECTARG2;
         device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP, textureOp);
       }
 
       const bool colorKeyEnable = m_commonD3DDevice->GetColorKeyEnable();
-      const bool validColorKey = surface->GetCommonSurface()->HasValidColorKey();
+      const bool validColorKey = commonSurface->HasValidColorKey();
       m_bridge->SetColorKeyState(colorKeyEnable && validColorKey);
       if (colorKeyEnable && validColorKey) {
-        DDCOLORKEY normalizedColorKey = surface->GetCommonSurface()->GetColorKeyNormalized();
+        DDCOLORKEY normalizedColorKey = commonSurface->GetColorKeyNormalized();
         m_bridge->SetColorKey(normalizedColorKey.dwColorSpaceLowValue,
                               normalizedColorKey.dwColorSpaceHighValue);
       }

--- a/src/ddraw/d3d5/d3d5_device.h
+++ b/src/ddraw/d3d5/d3d5_device.h
@@ -107,7 +107,7 @@ namespace dxvk {
 
     HRESULT STDMETHODCALLTYPE GetClipStatus(D3DCLIPSTATUS *clip_status);
 
-    void InitializeDS();
+    HRESULT InitializeRTAndDS();
 
     void UpdateSurfaceDirtyTracking(bool dirtyRenderTarget, bool dirtyDepthStencil, bool dirtyPrimarySurface);
 
@@ -135,10 +135,6 @@ namespace dxvk {
 
     inline void DDrawDirtySurfaceUpload();
 
-    inline void AddViewportInternal(IDirect3DViewport2* viewport);
-
-    inline void DeleteViewportInternal(IDirect3DViewport2* viewport);
-
     inline HRESULT SetTextureInternal(DDrawSurface* surface, DWORD textureHandle);
 
     inline void RefreshLastUsedDevice() {
@@ -163,34 +159,31 @@ namespace dxvk {
       }
     }
 
-    Com<D3DCommonDevice>           m_commonD3DDevice;
+    Com<D3DCommonDevice>            m_commonD3DDevice;
 
-    DDrawCommonInterface*          m_commonIntf       = nullptr;
+    DDrawCommonInterface*           m_commonIntf       = nullptr;
 
-    Com<DxvkD3D8Bridge>            m_bridge;
+    Com<IDxvkLegacyD3DDeviceBridge> m_bridge;
 
-    Com<D3D3Device, false>         m_device3;
+    Com<D3D3Device, false>          m_device3;
 
-    D3DMultithread                 m_multithread;
+    D3DMultithread                  m_multithread;
 
-    D3DDEVICEDESC2                 m_desc;
+    D3DDEVICEDESC2                  m_desc;
 
-    Com<DDrawSurface>              m_rt;
-    Com<DDrawSurface, false>       m_ds;
+    Com<DDrawSurface>               m_rt;
+    Com<DDrawSurface, false>        m_ds;
 
-    Com<D3D5Viewport>              m_currentViewport;
-    std::vector<Com<D3D5Viewport>> m_viewports;
+    Com<D3D5Viewport>               m_currentViewport;
+    std::vector<Com<D3D5Viewport>>  m_viewports;
 
-    VertexStreamInfo               m_vertexStreamInfo;
-    std::vector<D3DVERTEX>         m_vertexStream;
-    std::vector<D3DLVERTEX>        m_lvertexStream;
-    std::vector<D3DTLVERTEX>       m_tlvertexStream;
+    D3DMATRIX                       m_projectionMatrix = { };
+    const D3DMATRIX*                m_legacyProjection = nullptr;
 
-    D3DMATRIX                      m_projectionMatrix = { };
-    const D3DMATRIX*               m_legacyProjection = nullptr;
-
-    uint32_t                       m_deviceCount      = 0;
-    static std::atomic<uint32_t>   s_deviceCount;
+    VertexStreamInfo                m_vertexStreamInfo;
+    std::vector<D3DVERTEX>          m_vertexStream;
+    std::vector<D3DLVERTEX>         m_lvertexStream;
+    std::vector<D3DTLVERTEX>        m_tlvertexStream;
 
   };
 

--- a/src/ddraw/d3d5/d3d5_interface.cpp
+++ b/src/ddraw/d3d5/d3d5_interface.cpp
@@ -16,8 +16,6 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> D3D5Interface::s_intfCount = 0;
-
   D3D5Interface::D3D5Interface(
         D3DCommonInterface* commonD3DIntf,
         DDrawCommonInterface* m_commonIntf,
@@ -25,34 +23,28 @@ namespace dxvk {
     : DDrawChildObject<IUnknown, IDirect3D2>(pParent)
     , m_commonD3DIntf ( commonD3DIntf )
     , m_commonIntf ( m_commonIntf ) {
-    if (m_commonD3DIntf == nullptr) {
+    if (m_commonD3DIntf == nullptr)
       m_commonD3DIntf = new D3DCommonInterface();
 
-      Com<d3d9::IDirect3D9> d3d9Intf = d3d9::Direct3DCreate9(D3D_SDK_VERSION);
-      m_commonD3DIntf->SetD3D9Interface(std::move(d3d9Intf));
-    }
+    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
+    // Retrieve and cache the base capabilities
+    m_desc = GetD3D5BaseCaps(d3dOptions);
 
     d3d9::IDirect3D9* d3d9Intf = m_commonD3DIntf->GetD3D9Interface();
 
     // Get the bridge interface to D3D9
-    if (unlikely(FAILED(d3d9Intf->QueryInterface(__uuidof(IDxvkD3D8InterfaceBridge), reinterpret_cast<void**>(&m_bridge))))) {
+    if (unlikely(FAILED(d3d9Intf->QueryInterface(__uuidof(IDxvkLegacyD3DInterfaceBridge), reinterpret_cast<void**>(&m_bridge))))) {
       throw DxvkError("D3D5Interface: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
     }
 
     m_commonD3DIntf->SetD3D5Interface(this);
 
-    m_bridge->EnableD3D5CompatibilityMode();
-
-    m_intfCount = ++s_intfCount;
-
-    Logger::debug(str::format("D3D5Interface: Created a new interface nr. ((2-", m_intfCount, "))"));
+    m_bridge->SetD3DCompatibility(D3DCompatibility::D3D5);
   }
 
   D3D5Interface::~D3D5Interface() {
     if (m_commonD3DIntf->GetD3D5Interface() == this)
       m_commonD3DIntf->SetD3D5Interface(nullptr);
-
-    Logger::debug(str::format("D3D5Interface: Interface nr. ((2-", m_intfCount, ")) bites the dust"));
   }
 
   // Interlocked refcount with the parent IDirectDraw
@@ -149,8 +141,10 @@ namespace dxvk {
     // RAMP device (monochrome), this is expected to be exposed
     GUID guidRAMP = IID_IDirect3DRampDevice;
     // The caps of a RAMP device are mostly identical to an RGB device
-    D3DDEVICEDESC2 desc2RAMP_HAL = GetD3D5Caps(IID_IDirect3DRGBDevice, d3dOptions);
-    D3DDEVICEDESC2 desc2RAMP_HEL = desc2RAMP_HAL;
+    D3DDEVICEDESC2 desc2RAMP_HAL = m_desc;
+    ApplyD3D5DeviceCaps(&desc2RAMP_HAL, guidRAMP);
+    D3DDEVICEDESC2 desc2RAMP_HEL = m_desc;
+    ApplyD3D5DeviceCaps(&desc2RAMP_HEL, guidRAMP);
     D3DDEVICEDESC descRAMP_HAL = { };
     D3DDEVICEDESC descRAMP_HEL = { };
     desc2RAMP_HAL.dwFlags = 0;
@@ -182,8 +176,10 @@ namespace dxvk {
 
     // Software emulation, this is expected to be exposed
     GUID guidRGB = IID_IDirect3DRGBDevice;
-    D3DDEVICEDESC2 desc2RGB_HAL = GetD3D5Caps(IID_IDirect3DRGBDevice, d3dOptions);
-    D3DDEVICEDESC2 desc2RGB_HEL = desc2RGB_HAL;
+    D3DDEVICEDESC2 desc2RGB_HAL = m_desc;
+    ApplyD3D5DeviceCaps(&desc2RGB_HAL, guidRGB);
+    D3DDEVICEDESC2 desc2RGB_HEL = m_desc;
+    ApplyD3D5DeviceCaps(&desc2RGB_HEL, guidRGB);
     D3DDEVICEDESC descRGB_HAL = { };
     D3DDEVICEDESC descRGB_HEL = { };
     desc2RGB_HAL.dwFlags = 0;
@@ -214,8 +210,10 @@ namespace dxvk {
 
     // Hardware acceleration
     GUID guidHAL = IID_IDirect3DHALDevice;
-    D3DDEVICEDESC2 desc2HAL_HAL = GetD3D5Caps(IID_IDirect3DHALDevice, d3dOptions);
-    D3DDEVICEDESC2 desc2HAL_HEL = desc2HAL_HAL;
+    D3DDEVICEDESC2 desc2HAL_HAL = m_desc;
+    ApplyD3D5DeviceCaps(&desc2HAL_HAL, guidHAL);
+    D3DDEVICEDESC2 desc2HAL_HEL = m_desc;
+    ApplyD3D5DeviceCaps(&desc2HAL_HEL, guidHAL);
     D3DDEVICEDESC descHAL_HAL = { };
     D3DDEVICEDESC descHAL_HEL = { };
     desc2HAL_HEL.dcmColorModel = 0;
@@ -290,11 +288,11 @@ namespace dxvk {
     if (unlikely(!IsValidFindDeviceResultSize(lpD3DFDR->dwSize)))
       return DDERR_INVALIDPARAMS;
 
-    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
-
     // Software emulation, this is expected to be exposed
-    D3DDEVICEDESC2 descRGB_HAL = GetD3D5Caps(IID_IDirect3DRGBDevice, d3dOptions);
-    D3DDEVICEDESC2 descRGB_HEL = descRGB_HAL;
+    D3DDEVICEDESC2 descRGB_HAL = m_desc;
+    ApplyD3D5DeviceCaps(&descRGB_HAL, IID_IDirect3DRGBDevice);
+    D3DDEVICEDESC2 descRGB_HEL = m_desc;
+    ApplyD3D5DeviceCaps(&descRGB_HEL, IID_IDirect3DRGBDevice);
     descRGB_HAL.dwFlags = 0;
     descRGB_HAL.dcmColorModel = 0;
     // Some applications apparently care about HAL texture caps
@@ -306,8 +304,10 @@ namespace dxvk {
                                            & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
 
     // Hardware acceleration
-    D3DDEVICEDESC2 descHAL_HAL = GetD3D5Caps(IID_IDirect3DHALDevice, d3dOptions);
-    D3DDEVICEDESC2 descHAL_HEL = descHAL_HAL;
+    D3DDEVICEDESC2 descHAL_HAL = m_desc;
+    ApplyD3D5DeviceCaps(&descHAL_HAL, IID_IDirect3DHALDevice);
+    D3DDEVICEDESC2 descHAL_HEL = m_desc;
+    ApplyD3D5DeviceCaps(&descHAL_HEL, IID_IDirect3DHALDevice);
     descHAL_HEL.dcmColorModel = 0;
     // Some applications apparently care about HEL texture caps
     descHAL_HEL.dpcLineCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE
@@ -496,14 +496,12 @@ namespace dxvk {
 
     Logger::info(str::format("D3D5Interface::CreateDevice: Back buffer size: ", desc.dwWidth, "x", desc.dwHeight));
 
-    const DWORD backBufferCount = DetermineBackBufferCount(rt->GetProxied());
+    const DWORD backBufferCount = DetermineBackBufferCount<IDirectDrawSurface>(rt->GetProxied());
     Logger::info(str::format("D3D5Interface::CreateDevice: Back buffer count: ", backBufferCount));
-
-    Com<d3d9::IDirect3D9> d3d9Intf = m_commonD3DIntf->GetD3D9Interface();
 
     // Determine the supported AA sample count by querying the D3D9 interface
     const d3d9::D3DMULTISAMPLE_TYPE multiSampleType = d3dOptions->emulateFSAA != FSAAEmulation::Disabled ?
-                                                      GetSupportedMultiSampleType(d3d9Intf.ptr(), backBufferFormat) :
+                                                      m_commonD3DIntf->GetMultiSampleType(backBufferFormat) :
                                                       d3d9::D3DMULTISAMPLE_NONE;
 
     d3d9::D3DPRESENT_PARAMETERS params;
@@ -523,7 +521,7 @@ namespace dxvk {
     params.PresentationInterval       = D3DPRESENT_INTERVAL_DEFAULT; // A D3D5 device always uses VSync
 
     Com<d3d9::IDirect3DDevice9> device9;
-    HRESULT hr = d3d9Intf->CreateDevice(
+    HRESULT hr = m_commonD3DIntf->GetD3D9Interface()->CreateDevice(
       D3DADAPTER_DEFAULT,
       d3d9::D3DDEVTYPE_HAL,
       hWnd,
@@ -543,8 +541,11 @@ namespace dxvk {
 
       // Set the common device on the common interface
       m_commonIntf->SetCommonD3DDevice(device5->GetCommonD3DDevice());
-      // Now that we have a valid D3D9 device pointer, we can initialize the depth stencil (if any)
-      device5->InitializeDS();
+      // Now that we have a valid common D3D device on the DDraw interface,
+      // we can initialize the render target and depth stencil (if any)
+      hr = device5->InitializeRTAndDS();
+      if (unlikely(FAILED(hr)))
+        return hr;
 
       *lplpD3DDevice = device5.ref();
     } catch (const DxvkError& e) {
@@ -553,33 +554,6 @@ namespace dxvk {
     }
 
     return D3D_OK;
-  }
-
-  inline DWORD D3D5Interface::DetermineBackBufferCount(IDirectDrawSurface* renderTarget) {
-    DWORD backBufferCount = 0;
-
-    IDirectDrawSurface* backBuffer = renderTarget;
-    HRESULT hr;
-
-    while (backBuffer != nullptr) {
-      IDirectDrawSurface* parentSurface = backBuffer;
-      backBuffer = nullptr;
-
-      hr = parentSurface->EnumAttachedSurfaces(&backBuffer, ListBackBufferSurfacesCallback);
-      if (unlikely(FAILED(hr))) {
-        Logger::warn("D3D5Interface::DetermineBackBufferCount: Unable to enumerate attached surfaces");
-        break;
-      }
-
-      // The swapchain will eventually return to its origin
-      if (backBuffer == renderTarget)
-        break;
-
-      if (likely(backBuffer != nullptr))
-        backBufferCount++;
-    }
-
-    return std::max<DWORD>(1u, backBufferCount);
   }
 
 }

--- a/src/ddraw/d3d5/d3d5_interface.h
+++ b/src/ddraw/d3d5/d3d5_interface.h
@@ -54,19 +54,16 @@ namespace dxvk {
 
   private:
 
-    inline DWORD DetermineBackBufferCount(IDirectDrawSurface* renderTarget);
+    Com<IDxvkLegacyD3DInterfaceBridge> m_bridge;
 
-    Com<IDxvkD3D8InterfaceBridge> m_bridge;
+    Com<D3DCommonInterface>            m_commonD3DIntf;
 
-    Com<D3DCommonInterface>       m_commonD3DIntf;
+    DDrawCommonInterface*              m_commonIntf = nullptr;
 
-    DDrawCommonInterface*         m_commonIntf = nullptr;
+    D3DDEVICEDESC2                     m_desc;
 
-    Com<D3D6Interface, false>     m_d3d6Intf;
-    Com<D3D3Interface, false>     m_d3d3Intf;
-
-    uint32_t                      m_intfCount  = 0;
-    static std::atomic<uint32_t>  s_intfCount;
+    Com<D3D6Interface, false>          m_d3d6Intf;
+    Com<D3D3Interface, false>          m_d3d3Intf;
 
   };
 

--- a/src/ddraw/d3d5/d3d5_material.cpp
+++ b/src/ddraw/d3d5/d3d5_material.cpp
@@ -11,24 +11,16 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> D3D5Material::s_materialCount = 0;
-
   D3D5Material::D3D5Material(
         D3D5Interface* pParent)
     : DDrawChildObject<D3D5Interface, IDirect3DMaterial2>(pParent) {
     m_commonMaterial = new D3DCommonMaterial();
 
     m_commonMaterial->SetD3D5Material(this);
-
-    m_materialCount = ++s_materialCount;
-
-    Logger::debug(str::format("D3D5Material: Created a new material nr. [[2-", m_materialCount, "]]"));
   }
 
   D3D5Material::~D3D5Material() {
     m_commonMaterial->SetD3D5Material(nullptr);
-
-    Logger::debug(str::format("D3D5Material: Material nr. [[2-", m_materialCount, "]] bites the dust"));
   }
 
   HRESULT STDMETHODCALLTYPE D3D5Material::QueryInterface(REFIID riid, void** ppvObject) {

--- a/src/ddraw/d3d5/d3d5_material.h
+++ b/src/ddraw/d3d5/d3d5_material.h
@@ -33,9 +33,6 @@ namespace dxvk {
 
     Com<D3DCommonMaterial> m_commonMaterial;
 
-    uint32_t               m_materialCount = 0;
-    static std::atomic<uint32_t> s_materialCount;
-
   };
 
 }

--- a/src/ddraw/d3d5/d3d5_texture.cpp
+++ b/src/ddraw/d3d5/d3d5_texture.cpp
@@ -9,8 +9,6 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> D3D5Texture::s_texCount = 0;
-
   D3D5Texture::D3D5Texture(
         D3DCommonTexture* commonTex,
         DDrawCommonSurface* commonSurf,
@@ -30,16 +28,10 @@ namespace dxvk {
     // but is true in the vast majority of cases, so use the distinction for logging purposes.
     if (isD3D6Texture)
       m_objectType = "D3D6Texture";
-
-    m_texCount = ++s_texCount;
-
-    Logger::debug(str::format(m_objectType, ": Created a new texture nr. [[2-", m_texCount, "]]"));
   }
 
   D3D5Texture::~D3D5Texture() {
     m_commonTex->SetD3D5Texture(nullptr);
-
-    Logger::debug(str::format(m_objectType, ": Texture nr. [[2-", m_texCount, "]] bites the dust"));
   }
 
   // Interlocked refcount with the parent IDirectDrawSurface/IDirectDrawSurface4
@@ -147,7 +139,7 @@ namespace dxvk {
 
     DDrawCommonSurface* commonSurf = m_commonTex->GetCommonSurface();
 
-    hr = commonSurf->RefreshSurfaceDescripton();
+    hr = commonSurf->RefreshSurfaceDescripton(true);
     if (unlikely(FAILED(hr))) {
       Logger::err(str::format(m_objectType, "::Load: Failed to refresh surface description"));
       return hr;

--- a/src/ddraw/d3d5/d3d5_texture.h
+++ b/src/ddraw/d3d5/d3d5_texture.h
@@ -50,9 +50,6 @@ namespace dxvk {
 
     const char*           m_objectType = "D3D5Texture";
 
-    uint32_t              m_texCount   = 0;
-    static std::atomic<uint32_t> s_texCount;
-
   };
 
 }

--- a/src/ddraw/d3d5/d3d5_viewport.cpp
+++ b/src/ddraw/d3d5/d3d5_viewport.cpp
@@ -20,8 +20,6 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> D3D5Viewport::s_viewportCount = 0;
-
   D3D5Viewport::D3D5Viewport(
         D3DCommonViewport* commonViewport,
         D3D5Interface* pParent)
@@ -35,10 +33,6 @@ namespace dxvk {
       m_commonViewport->SetOrigin(this);
 
     m_commonViewport->SetD3D5Viewport(this);
-
-    m_viewportCount = ++s_viewportCount;
-
-    Logger::debug(str::format("D3D5Viewport: Created a new viewport nr. [[2-", m_viewportCount, "]]"));
   }
 
   D3D5Viewport::~D3D5Viewport() {
@@ -53,8 +47,6 @@ namespace dxvk {
       m_commonViewport->SetOrigin(nullptr);
 
     m_commonViewport->SetD3D5Viewport(nullptr);
-
-    Logger::debug(str::format("D3D5Viewport: Viewport nr. [[2-", m_viewportCount, "]] bites the dust"));
   }
 
   // Interlocked refcount with the origin viewport
@@ -159,8 +151,10 @@ namespace dxvk {
     if (unlikely(!m_commonViewport->HasDevice()))
       return D3DERR_VIEWPORTHASNODEVICE;
 
+    D3DCommonDevice* commonD3DDevice = m_commonViewport->GetCommonD3DDevice();
+
     // Use the full surface rect, since it is surface version agnostic
-    const RECT* surfRect = m_commonViewport->GetCommonRenderTarget()->GetFullSurfaceRect();
+    const RECT* surfRect = commonD3DDevice->GetCommonRenderTarget()->GetFullSurfaceRect();
     // D3D5 will fail when setting a viewport that's outside of the
     // current render target, though that works in D3D9
     HRESULT hr = ValidateViewportRT(data->dwX, data->dwY, data->dwWidth, data->dwHeight,
@@ -189,9 +183,8 @@ namespace dxvk {
     legacyClip->z = 0.0f;
 
     m_commonViewport->MarkViewportAsSet();
-
     if (m_commonViewport->IsCurrentViewport())
-      ApplyViewport();
+      m_commonViewport->ApplyViewport();
 
     return D3D_OK;
   }
@@ -204,20 +197,17 @@ namespace dxvk {
 
     // Temporarily activate this viewport, if not already active
     d3d9::D3DVIEWPORT9 currentViewport9;
-    if (!m_commonViewport->IsCurrentViewport()) {
-      D3D5Viewport* currentViewport = m_commonViewport->GetCurrentD3D5Viewport();
-      if (currentViewport != nullptr) {
-        currentViewport9 = *currentViewport->GetCommonViewport()->GetD3D9Viewport();
-      } else {
-        d3d9Device->GetViewport(&currentViewport9);
-      }
+    const bool isCurrentViewport = m_commonViewport->IsCurrentViewport();
+
+    if (!isCurrentViewport) {
+      d3d9Device->GetViewport(&currentViewport9);
       d3d9Device->SetViewport(m_commonViewport->GetD3D9Viewport());
     }
 
     HRESULT hr = m_commonViewport->TransformVertices(vertex_count, data, flags, offscreen);
 
     // Restore the previously active viewport
-    if (!m_commonViewport->IsCurrentViewport()) {
+    if (!isCurrentViewport) {
       d3d9Device->SetViewport(&currentViewport9);
     }
 
@@ -298,8 +288,10 @@ namespace dxvk {
     DDrawCommonSurface* rt = nullptr;
     DDrawCommonSurface* ds = nullptr;
 
+    D3DCommonDevice* commonD3DDevice = m_commonViewport->GetCommonD3DDevice();
+
     if (clearRenderTarget) {
-      rt = m_commonViewport->GetCommonRenderTarget();
+      rt = commonD3DDevice->GetCommonRenderTarget();
       if (likely(rt != nullptr)) {
         // If this isn't a full surface clear, we need to first upload the DDraw surface
         if (unlikely(count > 1 || !rt->IsFullSurfaceLock(reinterpret_cast<RECT*>(rects), nullptr))) {
@@ -311,7 +303,7 @@ namespace dxvk {
       }
     }
     if (clearDepthStencil) {
-      ds = m_commonViewport->GetCommonDepthStencil();
+      ds = commonD3DDevice->GetCommonDepthStencil();
       if (likely(ds != nullptr)) {
         // If this isn't a full surface clear, we need to first upload the DDraw surface
         if (unlikely(count > 1 || !ds->IsFullSurfaceLock(reinterpret_cast<RECT*>(rects), nullptr))) {
@@ -323,18 +315,14 @@ namespace dxvk {
       }
     }
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = commonD3DDevice->GetD3D9Device();
 
     // Temporarily activate this viewport in order to clear it
     d3d9::D3DVIEWPORT9 currentViewport9;
     const bool isCurrentViewport = m_commonViewport->IsCurrentViewport();
+
     if (!isCurrentViewport) {
-      D3D5Viewport* currentViewport = m_commonViewport->GetCurrentD3D5Viewport();
-      if (currentViewport != nullptr) {
-        currentViewport9 = *currentViewport->GetCommonViewport()->GetD3D9Viewport();
-      } else {
-        d3d9Device->GetViewport(&currentViewport9);
-      }
+      d3d9Device->GetViewport(&currentViewport9);
       d3d9Device->SetViewport(m_commonViewport->GetD3D9Viewport());
     }
 
@@ -363,7 +351,7 @@ namespace dxvk {
     if (clearDepthStencil && ds != nullptr)
       ds->UnDirtyDDrawSurface();
 
-    m_commonViewport->UpdateSurfaceDirtyTracking(clearRenderTarget, clearDepthStencil, false);
+    commonD3DDevice->UpdateSurfaceDirtyTracking(clearRenderTarget, clearDepthStencil, false);
 
     return D3D_OK;
   }
@@ -384,7 +372,7 @@ namespace dxvk {
     d3dLight->SetViewport5(this);
 
     if (m_commonViewport->HasDevice() && m_commonViewport->IsCurrentViewport())
-      ApplyAndActivateLight(d3dLight->GetIndex(), d3dLight);
+      m_commonViewport->ApplyAndActivateLight(d3dLight);
 
     return D3D_OK;
   }
@@ -402,14 +390,11 @@ namespace dxvk {
 
     auto it = std::find(lights.begin(), lights.end(), d3dLight);
     if (likely(it != lights.end())) {
-      const DWORD lightIndex = d3dLight->GetIndex();
-      if (m_commonViewport->HasDevice() && m_commonViewport->IsCurrentViewport() && d3dLight->IsActive()) {
-        //Logger::debug(str::format("D3D5Viewport: Disabling light nr. ", lightIndex));
-        d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
-        d3d9Device->LightEnable(lightIndex, FALSE);
-      }
-      lights.erase(it);
+      // Ensure the light is deactivated before deleting it
+      if (m_commonViewport->HasDevice() && m_commonViewport->IsCurrentViewport() && d3dLight->IsActive())
+        m_commonViewport->DeactivateLight(d3dLight);
       d3dLight->SetViewport5(nullptr);
+      lights.erase(it);
     } else {
       Logger::warn("D3D5Viewport::DeleteLight: Light not found");
       return DDERR_INVALIDPARAMS;
@@ -482,8 +467,10 @@ namespace dxvk {
     if (unlikely(!m_commonViewport->HasDevice()))
       return D3DERR_VIEWPORTHASNODEVICE;
 
+    D3DCommonDevice* commonD3DDevice = m_commonViewport->GetCommonD3DDevice();
+
     // Use the full surface rect, since it is surface version agnostic
-    const RECT* surfRect = m_commonViewport->GetCommonRenderTarget()->GetFullSurfaceRect();
+    const RECT* surfRect = commonD3DDevice->GetCommonRenderTarget()->GetFullSurfaceRect();
     // D3D5 will fail when setting a viewport that's outside of the
     // current render target, though that works in D3D9
     HRESULT hr = ValidateViewportRT(data->dwX, data->dwY, data->dwWidth, data->dwHeight,
@@ -510,79 +497,8 @@ namespace dxvk {
     legacyClip->z = -data->dvMinZ / (data->dvMaxZ - data->dvMinZ);
 
     m_commonViewport->MarkViewportAsSet();
-
     if (m_commonViewport->IsCurrentViewport())
-      ApplyViewport();
-
-    return D3D_OK;
-  }
-
-  HRESULT D3D5Viewport::ApplyViewport() {
-    if (!m_commonViewport->IsViewportSet())
-      return D3D_OK;
-
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
-
-    HRESULT hr = d3d9Device->SetViewport(m_commonViewport->GetD3D9Viewport());
-    if (unlikely(FAILED(hr))) {
-      Logger::err("D3D5Viewport: Failed to set the D3D9 viewport");
-      return hr;
-    }
-
-    return D3D_OK;
-  }
-
-  HRESULT D3D5Viewport::ApplyAndActivateLights() {
-    std::vector<Com<D3DLight>>& lights = m_commonViewport->GetLights();
-
-    if (!lights.size())
-      return D3D_OK;
-
-    for (auto light: lights)
-      ApplyAndActivateLight(light->GetIndex(), light.ptr());
-
-    return D3D_OK;
-  }
-
-  HRESULT D3D5Viewport::DeactivateLights() {
-    std::vector<Com<D3DLight>>& lights = m_commonViewport->GetLights();
-
-    if (!lights.size())
-      return D3D_OK;
-
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
-
-    for (auto light: lights) {
-      const DWORD lightIndex = light->GetIndex();
-      if (m_commonViewport->HasDevice() && m_commonViewport->IsCurrentViewport() && light->IsActive()) {
-        //Logger::debug(str::format("D3D5Viewport: Disabling light nr. ", lightIndex));
-        d3d9Device->LightEnable(lightIndex, FALSE);
-      }
-    }
-
-    return D3D_OK;
-  }
-
-  HRESULT D3D5Viewport::ApplyAndActivateLight(DWORD index, D3DLight* light) {
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
-
-    HRESULT hr = d3d9Device->SetLight(index, light->GetD3D9Light());
-    if (unlikely(FAILED(hr))) {
-      Logger::err("D3D5Viewport: Failed D3D9 SetLight call");
-      return hr;
-    }
-
-    if (light->IsActive()) {
-      //Logger::debug(str::format("D3D5Viewport: Enabling D3D9 light nr. ", index));
-      hr = d3d9Device->LightEnable(index, TRUE);
-      if (unlikely(FAILED(hr)))
-        Logger::err("D3D5Viewport: Failed D3D9 LightEnable call (TRUE)");
-    } else {
-      //Logger::debug(str::format("D3D5Viewport: Disabling D3D9 light nr. ", index));
-      hr = d3d9Device->LightEnable(index, FALSE);
-      if (unlikely(FAILED(hr)))
-        Logger::err("D3D5Viewport: Failed D3D9 LightEnable call (FALSE)");
-    }
+      m_commonViewport->ApplyViewport();
 
     return D3D_OK;
   }

--- a/src/ddraw/d3d5/d3d5_viewport.h
+++ b/src/ddraw/d3d5/d3d5_viewport.h
@@ -63,14 +63,6 @@ namespace dxvk {
 
     HRESULT STDMETHODCALLTYPE SetViewport2(D3DVIEWPORT2 *data);
 
-    HRESULT ApplyViewport();
-
-    HRESULT ApplyAndActivateLights();
-
-    HRESULT DeactivateLights();
-
-    HRESULT ApplyAndActivateLight(DWORD index, D3DLight* light);
-
     D3DCommonViewport* GetCommonViewport() const {
       return m_commonViewport.ptr();
     }
@@ -85,9 +77,6 @@ namespace dxvk {
 
     Com<D3D6Viewport, false> m_viewport6;
     Com<D3D3Viewport, false> m_viewport3;
-
-    uint32_t                 m_viewportCount        = 0;
-    static std::atomic<uint32_t> s_viewportCount;
 
   };
 

--- a/src/ddraw/d3d6/d3d6_buffer.cpp
+++ b/src/ddraw/d3d6/d3d6_buffer.cpp
@@ -13,8 +13,6 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> D3D6VertexBuffer::s_buffCount = 0;
-
   D3D6VertexBuffer::D3D6VertexBuffer(
         D3D6Interface* pParent,
         DWORD creationFlags,
@@ -25,13 +23,16 @@ namespace dxvk {
     , m_desc ( *pDesc )
     , m_stride ( GetFVFSize(pDesc->dwFVF) )
     , m_size ( m_stride * pDesc->dwNumVertices ) {
-    m_buffCount = ++s_buffCount;
-
-    ListBufferDetails();
+    // In the fortunate scenario where a D3D6 device is already present
+    // when a vertex buffer is created, initialize the buffer on the spot
+    // rather than deferring the initialization to the first Lock()
+    // or ProcessVertices() call, since that can cause hitching
+    RefreshD3DDevice();
+    if (m_d3d6Device != nullptr)
+      InitializeD3D9();
   }
 
   D3D6VertexBuffer::~D3D6VertexBuffer() {
-    Logger::debug(str::format("D3D6VertexBuffer: Buffer nr. {{1-", m_buffCount, "}} bites the dust"));
   }
 
   HRESULT STDMETHODCALLTYPE D3D6VertexBuffer::QueryInterface(REFIID riid, void** ppvObject) {
@@ -89,12 +90,10 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6VertexBuffer::Unlock() {
-    RefreshD3DDevice();
-    if (unlikely(!IsInitialized())) {
-      HRESULT hrInit = InitializeD3D9();
-      if (unlikely(FAILED(hrInit)))
-        return hrInit;
-    }
+    // Ignore the unlock call if the D3D9 buffer
+    // was lost since the previous Lock() call
+    if (unlikely(!IsInitialized()))
+      return D3D_OK;
 
     HRESULT hr = m_vb9->Unlock();
     if (unlikely(FAILED(hr)))
@@ -116,32 +115,32 @@ namespace dxvk {
       return DDERR_INVALIDPARAMS;
 
     D3D6Device* device6 = static_cast<D3D6Device*>(lpD3DDevice);
-    D3D6VertexBuffer* vb = static_cast<D3D6VertexBuffer*>(lpSrcBuffer);
-
-    vb->RefreshD3DDevice();
-    if (unlikely(vb->GetDevice() == nullptr || device6 != vb->GetDevice())) {
-      Logger::err("D3D6VertexBuffer::ProcessVertices: Incompatible or null device");
-      return DDERR_GENERIC;
-    }
-
-    HRESULT hrInit;
+    D3D6VertexBuffer* srcBuffer6 = static_cast<D3D6VertexBuffer*>(lpSrcBuffer);
 
     // Check and initialize the source buffer
-    if (unlikely(!vb->IsInitialized())) {
-      hrInit = vb->InitializeD3D9();
+    srcBuffer6->RefreshD3DDevice();
+    if (unlikely(!srcBuffer6->IsInitialized())) {
+      HRESULT hrInit = srcBuffer6->InitializeD3D9();
       if (unlikely(FAILED(hrInit)))
         return hrInit;
     }
 
     // Check and initialize the destination buffer (this buffer)
-    d3d9::IDirect3DDevice9* device9 = RefreshD3DDevice();
+    RefreshD3DDevice();
     if (unlikely(!IsInitialized())) {
-      hrInit = InitializeD3D9();
+      HRESULT hrInit = InitializeD3D9();
       if (unlikely(FAILED(hrInit)))
         return hrInit;
     }
 
+    if (unlikely(m_d3d6Device != device6)) {
+      Logger::err("D3D6VertexBuffer::ProcessVertices: Invalid device");
+      return DDERR_GENERIC;
+    }
+
     D3DDeviceLock lock = device6->LockDevice();
+
+    d3d9::IDirect3DDevice9* device9 = device6->GetCommonD3DDevice()->GetD3D9Device();
 
     const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
 
@@ -149,8 +148,10 @@ namespace dxvk {
       uint8_t *inData = nullptr;
       uint8_t *outData = nullptr;
 
-      HRESULT hr = vb->GetD3D9VertexBuffer()->Lock(dwSrcIndex * vb->GetStride(), dwCount * vb->GetStride(),
-                                                   reinterpret_cast<void**>(&inData), D3DLOCK_READONLY);
+      d3d9::IDirect3DVertexBuffer9* srcBuffer9 = srcBuffer6->GetD3D9VertexBuffer();
+
+      HRESULT hr = srcBuffer9->Lock(dwSrcIndex * srcBuffer6->GetStride(), dwCount * srcBuffer6->GetStride(),
+                                    reinterpret_cast<void**>(&inData), D3DLOCK_READONLY);
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D6VertexBuffer::ProcessVertices: Failed to lock source buffer");
         return D3DERR_VERTEXBUFFERLOCKED;
@@ -159,7 +160,7 @@ namespace dxvk {
       hr = m_vb9->Lock(dwDestIndex * m_stride, dwCount * m_stride, reinterpret_cast<void**>(&outData), 0);
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D6VertexBuffer::ProcessVertices: Failed to lock destination buffer");
-        vb->Unlock();
+        srcBuffer9->Unlock();
         return D3DERR_VERTEXBUFFERLOCKED;
       }
       // "Direct3D normally performs lighting calculations on any vertices that contain a vertex normal."
@@ -167,15 +168,15 @@ namespace dxvk {
       //  IDirect3DVertexBuffer::ProcessVertices method to enable or disable lighting for that vertex buffer."
       // "If the rendering device does not have a material assigned to it, the Direct3D lighting engine is disabled."
       const bool doLighting = (dwVertexOp & D3DVOP_LIGHT) &&
-                              (vb->GetFVF() & D3DFVF_NORMAL) &&
+                              (srcBuffer6->GetFVF() & D3DFVF_NORMAL) &&
                               device6->GetCommonD3DDevice()->GetCurrentMaterialHandle() != 0;
 
       D3DCommonViewport* commonViewport = device6->GetCurrentViewportInternal()->GetCommonViewport();
 
       ProcessVerticesData pvData;
       pvData.inData = inData;
-      pvData.inFVF = vb->GetFVF();
-      pvData.inStride = vb->GetStride();
+      pvData.inFVF = srcBuffer6->GetFVF();
+      pvData.inStride = srcBuffer6->GetStride();
       pvData.outData = outData;
       pvData.outFVF = m_desc.dwFVF;
       pvData.outStride = m_stride;
@@ -190,7 +191,7 @@ namespace dxvk {
 
       std::vector<d3d9::D3DLIGHT9> lights9;
       if (doLighting) {
-        commonViewport->GetD3D9Lights(&lights9);
+        commonViewport->GetD3D9ActiveLights(&lights9);
         pvData.lights = &lights9;
       } else {
         pvData.lights = nullptr;
@@ -199,7 +200,7 @@ namespace dxvk {
       ProcessVerticesSW(device9, m_commonIntf->GetOptions(), &pvData);
 
       m_vb9->Unlock();
-      vb->Unlock();
+      srcBuffer9->Unlock();
 
     } else {
       // D3D9 ProcessVertices doesn't handle lighting, only transforms
@@ -220,8 +221,8 @@ namespace dxvk {
         }
       }
 
-      device9->SetFVF(vb->GetFVF());
-      device9->SetStreamSource(0, vb->GetD3D9VertexBuffer(), 0, vb->GetStride());
+      device9->SetFVF(srcBuffer6->GetFVF());
+      device9->SetStreamSource(0, srcBuffer6->GetD3D9VertexBuffer(), 0, srcBuffer6->GetStride());
       HRESULT hr = device9->ProcessVertices(dwSrcIndex, dwDestIndex, dwCount, m_vb9.ptr(), nullptr, dwFlags);
 
       if (legacyProjection != nullptr) {
@@ -266,10 +267,6 @@ namespace dxvk {
                                d3dOptions->managedVertexBuffers ? d3d9::D3DPOOL_MANAGED : d3d9::D3DPOOL_DEFAULT;
     const DWORD usage = ConvertD3D6UsageFlags(m_desc.dwCaps, m_creationFlags, pool);
 
-    const char* poolPlacement = pool == d3d9::D3DPOOL_DEFAULT ? "D3DPOOL_DEFAULT" :
-                                pool == d3d9::D3DPOOL_SYSTEMMEM ? "D3DPOOL_SYSTEMMEM" : "D3DPOOL_MANAGED";
-    Logger::debug(str::format("D3D6VertexBuffer::InitializeD3D9: Placing in: ", poolPlacement));
-
     d3d9::IDirect3DDevice9* device9 = m_d3d6Device->GetCommonD3DDevice()->GetD3D9Device();
     HRESULT hr = device9->CreateVertexBuffer(m_size, usage, m_desc.dwFVF, pool, &m_vb9, nullptr);
 
@@ -281,7 +278,7 @@ namespace dxvk {
     return D3D_OK;
   }
 
-  d3d9::IDirect3DDevice9* D3D6VertexBuffer::RefreshD3DDevice() {
+  void D3D6VertexBuffer::RefreshD3DDevice() {
     D3DCommonDevice* commonD3DDevice = m_commonIntf->GetCommonD3DDevice();
 
     D3D6Device* d3d6Device = commonD3DDevice != nullptr ? commonD3DDevice->GetD3D6Device() : nullptr;
@@ -293,8 +290,6 @@ namespace dxvk {
       }
       m_d3d6Device = d3d6Device;
     }
-
-    return commonD3DDevice != nullptr ? commonD3DDevice->GetD3D9Device() : nullptr;
   }
 
 }

--- a/src/ddraw/d3d6/d3d6_buffer.h
+++ b/src/ddraw/d3d6/d3d6_buffer.h
@@ -35,7 +35,7 @@ namespace dxvk {
 
     HRESULT InitializeD3D9();
 
-    d3d9::IDirect3DDevice9* RefreshD3DDevice();
+    void RefreshD3DDevice();
 
     bool IsInitialized() const {
       return m_vb9 != nullptr;
@@ -71,13 +71,6 @@ namespace dxvk {
       return m_desc.dwCaps & D3DVBCAPS_OPTIMIZED;
     }
 
-    inline void ListBufferDetails() const {
-      Logger::debug(str::format("D3D6VertexBuffer: Created a new buffer nr. {{1-", m_buffCount, "}}:"));
-      Logger::debug(str::format("   Size:     ", m_size));
-      Logger::debug(str::format("   FVF:      ", m_desc.dwFVF));
-      Logger::debug(str::format("   Vertices: ", m_size / m_stride));
-    }
-
     bool                              m_locked        = false;
 
     DDrawCommonInterface*             m_commonIntf    = nullptr;
@@ -91,9 +84,6 @@ namespace dxvk {
     D3D6Device*                       m_d3d6Device    = nullptr;
 
     Com<d3d9::IDirect3DVertexBuffer9> m_vb9;
-
-    uint32_t                          m_buffCount     = 0;
-    static std::atomic<uint32_t>      s_buffCount;
 
   };
 

--- a/src/ddraw/d3d6/d3d6_device.cpp
+++ b/src/ddraw/d3d6/d3d6_device.cpp
@@ -15,8 +15,6 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> D3D6Device::s_deviceCount = 0;
-
   D3D6Device::D3D6Device(
         D3DCommonDevice* commonD3DDevice,
         D3D6Interface* pParent,
@@ -39,7 +37,8 @@ namespace dxvk {
 
     const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
     // Retrieve and cache the device capabilities
-    m_desc = GetD3D6Caps(deviceGUID, d3dOptions);
+    m_desc = GetD3D6BaseCaps(d3dOptions);
+    ApplyD3D6DeviceCaps(&m_desc, deviceGUID);
 
     d3d9::IDirect3DDevice9* device9;
 
@@ -60,12 +59,19 @@ namespace dxvk {
     }
 
     // Common D3D9 index buffers
-    if (unlikely(FAILED(InitializeIndexBuffers()))) {
-      throw DxvkError("D3D6Device: ERROR! Failed to initialize D3D9 index buffers.");
+    static constexpr DWORD Usage = D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY;
+
+    for (uint8_t ibIndex = 0; ibIndex < ddrawCaps::IndexBufferCount ; ibIndex++) {
+      const UINT ibSize = ddrawCaps::IndexCount[ibIndex] * sizeof(WORD);
+
+      HRESULT hr = device9->CreateIndexBuffer(ibSize, Usage, d3d9::D3DFMT_INDEX16,
+                                              d3d9::D3DPOOL_DEFAULT, &m_ib9[ibIndex], nullptr);
+      if (unlikely(FAILED(hr)))
+        throw DxvkError("D3D6Device: ERROR! Failed to initialize D3D9 index buffers.");
     }
 
     // Get the bridge interface to D3D9
-    if (unlikely(FAILED(device9->QueryInterface(__uuidof(IDxvkD3D8Bridge), reinterpret_cast<void**>(&m_bridge))))) {
+    if (unlikely(FAILED(device9->QueryInterface(__uuidof(IDxvkLegacyD3DDeviceBridge), reinterpret_cast<void**>(&m_bridge))))) {
       throw DxvkError("D3D6Device: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
     }
 
@@ -75,33 +81,18 @@ namespace dxvk {
     // Update D3D9 legacy light state
     m_bridge->SetLegacyLightsState(true);
 
+    // Update D3D9 alternate pixel center
+    m_bridge->SetAlternatePixelCenter(d3dOptions->alternatePixelCenter == AlternatePixelCenter::Enabled);
+
     if (m_commonD3DDevice->GetOrigin() == nullptr)
       m_commonD3DDevice->SetOrigin(this);
 
     m_commonD3DDevice->SetD3D6Device(this);
 
     m_textures.fill(nullptr);
-
-    m_deviceCount = ++s_deviceCount;
-
-    Logger::debug(str::format("D3D6Device: Created a new device nr. ((3-", m_deviceCount, "))"));
   }
 
   D3D6Device::~D3D6Device() {
-    if (LogIndexBufferUsageStats()) {
-      Logger::info("D3D6Device: Index buffer upload statistics:");
-      Logger::info(str::format("  0.25 kb : ", m_ib9_uploads[0]));
-      Logger::info(str::format("  0.5  kb : ", m_ib9_uploads[1]));
-      Logger::info(str::format("  1    kb : ", m_ib9_uploads[2]));
-      Logger::info(str::format("  2    kb : ", m_ib9_uploads[3]));
-      Logger::info(str::format("  4    kb : ", m_ib9_uploads[4]));
-      Logger::info(str::format("  8    kb : ", m_ib9_uploads[5]));
-      Logger::info(str::format("  16   kb : ", m_ib9_uploads[6]));
-      Logger::info(str::format("  32   kb : ", m_ib9_uploads[7]));
-      Logger::info(str::format("  64   kb : ", m_ib9_uploads[8]));
-      Logger::info(str::format("  128  kb : ", m_ib9_uploads[9]));
-    }
-
     // Dissasociate every bound viewport from this device
     for (auto viewport : m_viewports) {
       viewport->GetCommonViewport()->SetD3D6Device(nullptr);
@@ -112,8 +103,6 @@ namespace dxvk {
 
     if (m_commonD3DDevice->GetOrigin() == this)
       m_commonD3DDevice->SetOrigin(nullptr);
-
-    Logger::debug(str::format("D3D6Device: Device nr. ((3-", m_deviceCount, ")) bites the dust"));
   }
 
   // Interlocked refcount with the origin device
@@ -248,7 +237,15 @@ namespace dxvk {
     if (unlikely(viewport == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    AddViewportInternal(viewport);
+    D3D6Viewport* d3d6Viewport = static_cast<D3D6Viewport*>(viewport);
+
+    auto it = std::find(m_viewports.begin(), m_viewports.end(), d3d6Viewport);
+    if (unlikely(it != m_viewports.end())) {
+      Logger::warn("D3D6Device::AddViewport: Pre-existing viewport found");
+    } else {
+      m_viewports.push_back(d3d6Viewport);
+      d3d6Viewport->GetCommonViewport()->SetD3D6Device(this);
+    }
 
     return D3D_OK;
   }
@@ -259,12 +256,18 @@ namespace dxvk {
     if (unlikely(viewport == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    DeleteViewportInternal(viewport);
-
-    // Clear the current viewport if it is deleted from the device
     D3D6Viewport* d3d6Viewport = static_cast<D3D6Viewport*>(viewport);
-    if (m_currentViewport.ptr() == d3d6Viewport)
-      m_currentViewport = nullptr;
+
+    auto it = std::find(m_viewports.begin(), m_viewports.end(), d3d6Viewport);
+    if (likely(it != m_viewports.end())) {
+      d3d6Viewport->GetCommonViewport()->SetD3D6Device(nullptr);
+      // Clear the current viewport if it is deleted from the device
+      if (m_currentViewport.ptr() == d3d6Viewport)
+        m_currentViewport = nullptr;
+      m_viewports.erase(it);
+    } else {
+      Logger::warn("D3D6Device::DeleteViewport: Viewport not found");
+    }
 
     return D3D_OK;
   }
@@ -333,9 +336,7 @@ namespace dxvk {
     if (unlikely(hr != D3DENUMRET_OK))
       return D3D_OK;
 
-    // Not supported in D3D9, but some games need
-    // it to be advertised (for offscreen plain surfaces?)
-    if (unlikely(d3dOptions->supportR3G3B2)) {
+    if (d3dOptions->supportR3G3B2) {
       textureFormat = GetTextureFormat(d3d9::D3DFMT_R3G3B2);
       hr = cb(&textureFormat, ctx);
       if (unlikely(hr != D3DENUMRET_OK))
@@ -452,20 +453,26 @@ namespace dxvk {
     if (unlikely(m_currentViewport == d3d6Viewport))
       return D3D_OK;
 
+    D3DCommonViewport* commonViewport = d3d6Viewport->GetCommonViewport();
+
     // Validate that the viewport is attached to this (common) device
-    if (unlikely(m_commonD3DDevice != d3d6Viewport->GetCommonViewport()->GetCommonD3DDevice()))
+    if (unlikely(m_commonD3DDevice != commonViewport->GetCommonD3DDevice()))
       return DDERR_INVALIDPARAMS;
 
     if (likely(m_currentViewport != nullptr)) {
-      m_currentViewport->DeactivateLights();
-      m_currentViewport->GetCommonViewport()->SetIsCurrentViewport(false);
+      D3DCommonViewport* currentCommonViewport = m_currentViewport->GetCommonViewport();
+      if (currentCommonViewport->HasLights())
+        currentCommonViewport->DeactivateLights();
+      currentCommonViewport->SetIsCurrentViewport(false);
     }
 
     m_currentViewport = d3d6Viewport.ptr();
 
-    m_currentViewport->GetCommonViewport()->SetIsCurrentViewport(true);
-    m_currentViewport->ApplyViewport();
-    m_currentViewport->ApplyAndActivateLights();
+    commonViewport->SetIsCurrentViewport(true);
+    if (likely(commonViewport->IsViewportSet()))
+      commonViewport->ApplyViewport();
+    if (commonViewport->HasLights())
+      commonViewport->ApplyAndActivateLights();
 
     return D3D_OK;
   }
@@ -586,15 +593,19 @@ namespace dxvk {
     if (unlikely(vertex == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    if (m_vertexStreamInfo.d3dvt == D3DVT_VERTEX) {
-      m_vertexStream.push_back(*reinterpret_cast<D3DVERTEX*>(vertex));
-    } else if (m_vertexStreamInfo.d3dvt == D3DVT_LVERTEX) {
-      m_lvertexStream.push_back(*reinterpret_cast<D3DLVERTEX*>(vertex));
-    } else if (m_vertexStreamInfo.d3dvt == D3DVT_TLVERTEX) {
-      m_tlvertexStream.push_back(*reinterpret_cast<D3DTLVERTEX*>(vertex));
-    } else {
-      Logger::warn(">>> D3D6Device::Vertex: Invalid vertex type");
-      return DDERR_INVALIDPARAMS;
+    switch (m_vertexStreamInfo.d3dvt) {
+      case D3DVT_VERTEX:
+        m_vertexStream.push_back(*reinterpret_cast<D3DVERTEX*>(vertex));
+        break;
+      case D3DVT_LVERTEX:
+        m_lvertexStream.push_back(*reinterpret_cast<D3DLVERTEX*>(vertex));
+        break;
+      case D3DVT_TLVERTEX:
+        m_tlvertexStream.push_back(*reinterpret_cast<D3DTLVERTEX*>(vertex));
+        break;
+      default:
+        Logger::warn(">>> D3D6Device::Vertex: Invalid vertex type");
+        return DDERR_INVALIDPARAMS;
     }
 
     return D3D_OK;
@@ -609,25 +620,30 @@ namespace dxvk {
     D3DDeviceLock lock = LockDevice();
 
     HRESULT hr;
-    if (m_vertexStreamInfo.d3dvt == D3DVT_VERTEX) {
-      hr = DrawPrimitive(m_vertexStreamInfo.d3dpt, ConvertVertexType(m_vertexStreamInfo.d3dvt), m_vertexStream.data(),
-                         m_vertexStream.size(), m_vertexStreamInfo.dwFlags);
-      m_vertexStream.clear();
-    } else if (m_vertexStreamInfo.d3dvt == D3DVT_LVERTEX) {
-      hr = DrawPrimitive(m_vertexStreamInfo.d3dpt, ConvertVertexType(m_vertexStreamInfo.d3dvt), m_lvertexStream.data(),
-                         m_lvertexStream.size(), m_vertexStreamInfo.dwFlags);
-      m_lvertexStream.clear();
-    } else if (m_vertexStreamInfo.d3dvt == D3DVT_TLVERTEX) {
-      hr = DrawPrimitive(m_vertexStreamInfo.d3dpt, ConvertVertexType(m_vertexStreamInfo.d3dvt), m_tlvertexStream.data(),
-                         m_tlvertexStream.size(), m_vertexStreamInfo.dwFlags);
-      m_tlvertexStream.clear();
-    } else {
-      Logger::warn(">>> D3D6Device::End: Invalid vertex type");
-      return DDERR_INVALIDPARAMS;
+
+    switch (m_vertexStreamInfo.d3dvt) {
+      case D3DVT_VERTEX:
+        hr = DrawPrimitive(m_vertexStreamInfo.d3dpt, m_vertexStreamInfo.d3dvt, m_vertexStream.data(),
+                           m_vertexStream.size(), m_vertexStreamInfo.dwFlags);
+        m_vertexStream.clear();
+        break;
+      case D3DVT_LVERTEX:
+        hr = DrawPrimitive(m_vertexStreamInfo.d3dpt, m_vertexStreamInfo.d3dvt, m_lvertexStream.data(),
+                           m_lvertexStream.size(), m_vertexStreamInfo.dwFlags);
+        m_lvertexStream.clear();
+        break;
+      case D3DVT_TLVERTEX:
+        hr = DrawPrimitive(m_vertexStreamInfo.d3dpt, m_vertexStreamInfo.d3dvt, m_tlvertexStream.data(),
+                           m_tlvertexStream.size(), m_vertexStreamInfo.dwFlags);
+        m_tlvertexStream.clear();
+        break;
+      default:
+        Logger::warn(">>> D3D6Device::End: Invalid vertex type");
+        return DDERR_INVALIDPARAMS;
     }
 
     if (unlikely(FAILED(hr)))
-      Logger::warn(">>> D3D6Device::End: Failed call to DrawPrimitive");
+      Logger::err(">>> D3D6Device::End: Failed call to DrawPrimitive");
 
     m_vertexStreamInfo = { };
 
@@ -640,20 +656,110 @@ namespace dxvk {
     if (unlikely(lpdwRenderState == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    // As opposed to D3D7, D3D6 does not error out on
-    // unknown or invalid render states.
-    if (unlikely(!IsValidD3D6RenderStateType(dwRenderStateType)
-              && !m_commonIntf->GetOptions()->apitraceMode)) {
-      *lpdwRenderState = 0;
-      return D3D_OK;
-    }
-
     d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
     d3d9::D3DRENDERSTATETYPE State9 = d3d9::D3DRENDERSTATETYPE(dwRenderStateType);
 
     switch (dwRenderStateType) {
       // Most render states translate 1:1 to D3D9
-      default:
+      //case D3DRENDERSTATE_TEXTUREHANDLE:
+      //case D3DRENDERSTATE_ANTIALIAS:
+      //case D3DRENDERSTATE_TEXTUREADDRESS:
+      //case D3DRENDERSTATE_TEXTUREPERSPECTIVE:
+      //case D3DRENDERSTATE_WRAPU:
+      //case D3DRENDERSTATE_WRAPV:
+      case D3DRENDERSTATE_ZENABLE:
+      case D3DRENDERSTATE_FILLMODE:
+      case D3DRENDERSTATE_SHADEMODE:
+      //case D3DRENDERSTATE_LINEPATTERN:
+      //case D3DRENDERSTATE_MONOENABLE:
+      //case D3DRENDERSTATE_ROP2:
+      //case D3DRENDERSTATE_PLANEMASK:
+      case D3DRENDERSTATE_ZWRITEENABLE:
+      case D3DRENDERSTATE_ALPHATESTENABLE:
+      case D3DRENDERSTATE_LASTPIXEL:
+      //case D3DRENDERSTATE_TEXTUREMAG:
+      //case D3DRENDERSTATE_TEXTUREMIN:
+      case D3DRENDERSTATE_SRCBLEND:
+      case D3DRENDERSTATE_DESTBLEND:
+      //case D3DRENDERSTATE_TEXTUREMAPBLEND:
+      case D3DRENDERSTATE_CULLMODE:
+      case D3DRENDERSTATE_ZFUNC:
+      case D3DRENDERSTATE_ALPHAREF:
+      case D3DRENDERSTATE_ALPHAFUNC:
+      case D3DRENDERSTATE_DITHERENABLE:
+      case D3DRENDERSTATE_ALPHABLENDENABLE:
+      case D3DRENDERSTATE_FOGENABLE:
+      case D3DRENDERSTATE_SPECULARENABLE:
+      //case D3DRENDERSTATE_ZVISIBLE:
+      //case D3DRENDERSTATE_SUBPIXEL:
+      //case D3DRENDERSTATE_SUBPIXELX:
+      //case D3DRENDERSTATE_STIPPLEDALPHA:
+      case D3DRENDERSTATE_FOGCOLOR:
+      case D3DRENDERSTATE_FOGTABLEMODE:
+      case D3DRENDERSTATE_FOGTABLESTART:
+      case D3DRENDERSTATE_FOGTABLEEND:
+      case D3DRENDERSTATE_FOGTABLEDENSITY:
+      //case D3DRENDERSTATE_STIPPLEENABLE:
+      //case D3DRENDERSTATE_EDGEANTIALIAS:
+      //case D3DRENDERSTATE_COLORKEYENABLE:
+      //case D3DRENDERSTATE_BORDERCOLOR:
+      //case D3DRENDERSTATE_TEXTUREADDRESSU:
+      //case D3DRENDERSTATE_TEXTUREADDRESSV:
+      //case D3DRENDERSTATE_MIPMAPLODBIAS:
+      //case D3DRENDERSTATE_ZBIAS:
+      case D3DRENDERSTATE_RANGEFOGENABLE:
+      //case D3DRENDERSTATE_ANISOTROPY:
+      //case D3DRENDERSTATE_FLUSHBATCH:
+      //case D3DRENDERSTATE_TRANSLUCENTSORTINDEPENDENT:
+      case D3DRENDERSTATE_STENCILENABLE:
+      case D3DRENDERSTATE_STENCILFAIL:
+      case D3DRENDERSTATE_STENCILZFAIL:
+      case D3DRENDERSTATE_STENCILPASS:
+      case D3DRENDERSTATE_STENCILFUNC:
+      case D3DRENDERSTATE_STENCILREF:
+      case D3DRENDERSTATE_STENCILMASK:
+      case D3DRENDERSTATE_STENCILWRITEMASK:
+      case D3DRENDERSTATE_TEXTUREFACTOR:
+      //case D3DRENDERSTATE_STIPPLEPATTERN00:
+      //case D3DRENDERSTATE_STIPPLEPATTERN01:
+      //case D3DRENDERSTATE_STIPPLEPATTERN02:
+      //case D3DRENDERSTATE_STIPPLEPATTERN03:
+      //case D3DRENDERSTATE_STIPPLEPATTERN04:
+      //case D3DRENDERSTATE_STIPPLEPATTERN05:
+      //case D3DRENDERSTATE_STIPPLEPATTERN06:
+      //case D3DRENDERSTATE_STIPPLEPATTERN07:
+      //case D3DRENDERSTATE_STIPPLEPATTERN08:
+      //case D3DRENDERSTATE_STIPPLEPATTERN09:
+      //case D3DRENDERSTATE_STIPPLEPATTERN10:
+      //case D3DRENDERSTATE_STIPPLEPATTERN11:
+      //case D3DRENDERSTATE_STIPPLEPATTERN12:
+      //case D3DRENDERSTATE_STIPPLEPATTERN13:
+      //case D3DRENDERSTATE_STIPPLEPATTERN14:
+      //case D3DRENDERSTATE_STIPPLEPATTERN15:
+      //case D3DRENDERSTATE_STIPPLEPATTERN16:
+      //case D3DRENDERSTATE_STIPPLEPATTERN17:
+      //case D3DRENDERSTATE_STIPPLEPATTERN18:
+      //case D3DRENDERSTATE_STIPPLEPATTERN19:
+      //case D3DRENDERSTATE_STIPPLEPATTERN20:
+      //case D3DRENDERSTATE_STIPPLEPATTERN21:
+      //case D3DRENDERSTATE_STIPPLEPATTERN22:
+      //case D3DRENDERSTATE_STIPPLEPATTERN23:
+      //case D3DRENDERSTATE_STIPPLEPATTERN24:
+      //case D3DRENDERSTATE_STIPPLEPATTERN25:
+      //case D3DRENDERSTATE_STIPPLEPATTERN26:
+      //case D3DRENDERSTATE_STIPPLEPATTERN27:
+      //case D3DRENDERSTATE_STIPPLEPATTERN28:
+      //case D3DRENDERSTATE_STIPPLEPATTERN29:
+      //case D3DRENDERSTATE_STIPPLEPATTERN30:
+      //case D3DRENDERSTATE_STIPPLEPATTERN31:
+      case D3DRENDERSTATE_WRAP0:
+      case D3DRENDERSTATE_WRAP1:
+      case D3DRENDERSTATE_WRAP2:
+      case D3DRENDERSTATE_WRAP3:
+      case D3DRENDERSTATE_WRAP4:
+      case D3DRENDERSTATE_WRAP5:
+      case D3DRENDERSTATE_WRAP6:
+      case D3DRENDERSTATE_WRAP7:
         break;
 
       // "Texture handle for use when rendering with the IDirect3DDevice2 or earlier interfaces."
@@ -821,6 +927,15 @@ namespace dxvk {
       case D3DRENDERSTATE_STIPPLEPATTERN31:
         *lpdwRenderState = 0;
         return D3D_OK;
+
+      // As opposed to D3D7, D3D6 does not error out on
+      // unknown or invalid render states.
+      default:
+        if (likely(!m_commonIntf->GetOptions()->apitraceMode)) {
+          *lpdwRenderState = 0;
+          return D3D_OK;
+        }
+        break;
     }
 
     // This call will never fail
@@ -830,17 +945,111 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D6Device::SetRenderState(D3DRENDERSTATETYPE dwRenderStateType, DWORD dwRenderState) {
     D3DDeviceLock lock = LockDevice();
 
-    // As opposed to D3D7, D3D6 does not error out on
-    // unknown or invalid render states.
-    if (unlikely(!IsValidD3D6RenderStateType(dwRenderStateType)))
-      return D3D_OK;
-
     d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
     d3d9::D3DRENDERSTATETYPE State9 = d3d9::D3DRENDERSTATETYPE(dwRenderStateType);
 
     switch (dwRenderStateType) {
       // Most render states translate 1:1 to D3D9
-      default:
+      // Most render states translate 1:1 to D3D9
+      //case D3DRENDERSTATE_TEXTUREHANDLE:
+      //case D3DRENDERSTATE_ANTIALIAS:
+      //case D3DRENDERSTATE_TEXTUREADDRESS:
+      //case D3DRENDERSTATE_TEXTUREPERSPECTIVE:
+      //case D3DRENDERSTATE_WRAPU:
+      //case D3DRENDERSTATE_WRAPV:
+      case D3DRENDERSTATE_ZENABLE:
+      case D3DRENDERSTATE_FILLMODE:
+      case D3DRENDERSTATE_SHADEMODE:
+      //case D3DRENDERSTATE_LINEPATTERN:
+      //case D3DRENDERSTATE_MONOENABLE:
+      //case D3DRENDERSTATE_ROP2:
+      //case D3DRENDERSTATE_PLANEMASK:
+      //case D3DRENDERSTATE_ZWRITEENABLE:
+      case D3DRENDERSTATE_ALPHATESTENABLE:
+      case D3DRENDERSTATE_LASTPIXEL:
+      //case D3DRENDERSTATE_TEXTUREMAG:
+      //case D3DRENDERSTATE_TEXTUREMIN:
+      case D3DRENDERSTATE_SRCBLEND:
+      case D3DRENDERSTATE_DESTBLEND:
+      //case D3DRENDERSTATE_TEXTUREMAPBLEND:
+      case D3DRENDERSTATE_CULLMODE:
+      case D3DRENDERSTATE_ZFUNC:
+      case D3DRENDERSTATE_ALPHAREF:
+      case D3DRENDERSTATE_ALPHAFUNC:
+      case D3DRENDERSTATE_DITHERENABLE:
+      case D3DRENDERSTATE_ALPHABLENDENABLE:
+      case D3DRENDERSTATE_FOGENABLE:
+      case D3DRENDERSTATE_SPECULARENABLE:
+      //case D3DRENDERSTATE_ZVISIBLE:
+      //case D3DRENDERSTATE_SUBPIXEL:
+      //case D3DRENDERSTATE_SUBPIXELX:
+      //case D3DRENDERSTATE_STIPPLEDALPHA:
+      case D3DRENDERSTATE_FOGCOLOR:
+      case D3DRENDERSTATE_FOGTABLEMODE:
+      case D3DRENDERSTATE_FOGTABLESTART:
+      case D3DRENDERSTATE_FOGTABLEEND:
+      case D3DRENDERSTATE_FOGTABLEDENSITY:
+      //case D3DRENDERSTATE_STIPPLEENABLE:
+      //case D3DRENDERSTATE_EDGEANTIALIAS:
+      //case D3DRENDERSTATE_COLORKEYENABLE:
+      //case D3DRENDERSTATE_BORDERCOLOR:
+      //case D3DRENDERSTATE_TEXTUREADDRESSU:
+      //case D3DRENDERSTATE_TEXTUREADDRESSV:
+      //case D3DRENDERSTATE_MIPMAPLODBIAS:
+      //case D3DRENDERSTATE_ZBIAS:
+      case D3DRENDERSTATE_RANGEFOGENABLE:
+      //case D3DRENDERSTATE_ANISOTROPY:
+      //case D3DRENDERSTATE_FLUSHBATCH:
+      //case D3DRENDERSTATE_TRANSLUCENTSORTINDEPENDENT:
+      case D3DRENDERSTATE_STENCILENABLE:
+      case D3DRENDERSTATE_STENCILFAIL:
+      case D3DRENDERSTATE_STENCILZFAIL:
+      case D3DRENDERSTATE_STENCILPASS:
+      case D3DRENDERSTATE_STENCILFUNC:
+      case D3DRENDERSTATE_STENCILREF:
+      case D3DRENDERSTATE_STENCILMASK:
+      case D3DRENDERSTATE_STENCILWRITEMASK:
+      case D3DRENDERSTATE_TEXTUREFACTOR:
+      //case D3DRENDERSTATE_STIPPLEPATTERN00:
+      //case D3DRENDERSTATE_STIPPLEPATTERN01:
+      //case D3DRENDERSTATE_STIPPLEPATTERN02:
+      //case D3DRENDERSTATE_STIPPLEPATTERN03:
+      //case D3DRENDERSTATE_STIPPLEPATTERN04:
+      //case D3DRENDERSTATE_STIPPLEPATTERN05:
+      //case D3DRENDERSTATE_STIPPLEPATTERN06:
+      //case D3DRENDERSTATE_STIPPLEPATTERN07:
+      //case D3DRENDERSTATE_STIPPLEPATTERN08:
+      //case D3DRENDERSTATE_STIPPLEPATTERN09:
+      //case D3DRENDERSTATE_STIPPLEPATTERN10:
+      //case D3DRENDERSTATE_STIPPLEPATTERN11:
+      //case D3DRENDERSTATE_STIPPLEPATTERN12:
+      //case D3DRENDERSTATE_STIPPLEPATTERN13:
+      //case D3DRENDERSTATE_STIPPLEPATTERN14:
+      //case D3DRENDERSTATE_STIPPLEPATTERN15:
+      //case D3DRENDERSTATE_STIPPLEPATTERN16:
+      //case D3DRENDERSTATE_STIPPLEPATTERN17:
+      //case D3DRENDERSTATE_STIPPLEPATTERN18:
+      //case D3DRENDERSTATE_STIPPLEPATTERN19:
+      //case D3DRENDERSTATE_STIPPLEPATTERN20:
+      //case D3DRENDERSTATE_STIPPLEPATTERN21:
+      //case D3DRENDERSTATE_STIPPLEPATTERN22:
+      //case D3DRENDERSTATE_STIPPLEPATTERN23:
+      //case D3DRENDERSTATE_STIPPLEPATTERN24:
+      //case D3DRENDERSTATE_STIPPLEPATTERN25:
+      //case D3DRENDERSTATE_STIPPLEPATTERN26:
+      //case D3DRENDERSTATE_STIPPLEPATTERN27:
+      //case D3DRENDERSTATE_STIPPLEPATTERN28:
+      //case D3DRENDERSTATE_STIPPLEPATTERN29:
+      //case D3DRENDERSTATE_STIPPLEPATTERN30:
+      //case D3DRENDERSTATE_STIPPLEPATTERN31:
+      case D3DRENDERSTATE_WRAP0:
+      case D3DRENDERSTATE_WRAP1:
+      case D3DRENDERSTATE_WRAP2:
+      case D3DRENDERSTATE_WRAP3:
+      case D3DRENDERSTATE_WRAP4:
+      case D3DRENDERSTATE_WRAP5:
+      case D3DRENDERSTATE_WRAP6:
+      case D3DRENDERSTATE_WRAP7:
         break;
 
       // "Texture handle for use when rendering with the IDirect3DDevice2 or earlier interfaces."
@@ -854,7 +1063,7 @@ namespace dxvk {
             return DDERR_INVALIDPARAMS;
         }
 
-        HRESULT hr = SetTextureWithHandle(surface4, dwRenderState);
+        HRESULT hr = SetTextureInternal(surface4, dwRenderState);
         if (unlikely(FAILED(hr)))
           return hr;
 
@@ -936,6 +1145,11 @@ namespace dxvk {
       // rasterizers, and is often ignored by hardware drivers."
       case D3DRENDERSTATE_PLANEMASK:
         return D3D_OK;
+
+      // Track the depth write state for D3D9 depth stencil surface dirtying
+      case D3DRENDERSTATE_ZWRITEENABLE:
+        m_commonD3DDevice->SetDepthWriteEnabled(static_cast<bool>(dwRenderState));
+        break;
 
       // Docs: "[...]  only the first two (D3DFILTER_NEAREST and
       // D3DFILTER_LINEAR) are valid with D3DRENDERSTATE_TEXTUREMAG."
@@ -1168,6 +1382,11 @@ namespace dxvk {
       case D3DRENDERSTATE_STIPPLEPATTERN30:
       case D3DRENDERSTATE_STIPPLEPATTERN31:
         return D3D_OK;
+
+      // As opposed to D3D7, D3D6 does not error out on
+      // unknown or invalid render states.
+      default:
+        return D3D_OK;
     }
 
     // This call will never fail
@@ -1290,9 +1509,9 @@ namespace dxvk {
     if (unlikely(vertices == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
-
     DDrawDirtySurfaceUpload();
+
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     const bool useLighting = !(flags & D3DDP_DONOTLIGHT) &&
                               (vertex_type & D3DFVF_NORMAL) &&
@@ -1304,10 +1523,10 @@ namespace dxvk {
 
     device9->SetFVF(vertex_type);
     HRESULT hr = device9->DrawPrimitiveUP(
-                     d3d9::D3DPRIMITIVETYPE(primitive_type),
-                     GetPrimitiveCount(primitive_type, vertex_count),
-                     vertices,
-                     GetFVFSize(vertex_type));
+                      d3d9::D3DPRIMITIVETYPE(primitive_type),
+                      GetPrimitiveCount(primitive_type, vertex_count),
+                      vertices,
+                      GetFVFSize(vertex_type));
 
     if (!useLighting)
       device9->SetRenderState(d3d9::D3DRS_LIGHTING, TRUE);
@@ -1318,7 +1537,7 @@ namespace dxvk {
       return hr;
     }
 
-    UpdateSurfaceDirtyTracking(true, true, true);
+    UpdateSurfaceDirtyTracking(true, m_commonD3DDevice->IsDepthWriteEnabled(), true);
 
     return D3D_OK;
   }
@@ -1334,9 +1553,9 @@ namespace dxvk {
     if (unlikely(vertices == nullptr || indices == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
-
     DDrawDirtySurfaceUpload();
+
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     const bool useLighting = !(flags & D3DDP_DONOTLIGHT) &&
                               (fvf & D3DFVF_NORMAL) &&
@@ -1366,7 +1585,7 @@ namespace dxvk {
       return hr;
     }
 
-    UpdateSurfaceDirtyTracking(true, true, true);
+    UpdateSurfaceDirtyTracking(true, m_commonD3DDevice->IsDepthWriteEnabled(), true);
 
     return D3D_OK;
   }
@@ -1408,9 +1627,9 @@ namespace dxvk {
     if (unlikely(strided_data == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
-
     DDrawDirtySurfaceUpload();
+
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     // Transform strided vertex data to a standard vertex buffer stream
     PackedVertexBuffer pvb = TransformStridedtoUP(fvf, strided_data, vertex_count);
@@ -1425,10 +1644,10 @@ namespace dxvk {
 
     device9->SetFVF(fvf);
     HRESULT hr = device9->DrawPrimitiveUP(
-                     d3d9::D3DPRIMITIVETYPE(primitive_type),
-                     GetPrimitiveCount(primitive_type, vertex_count),
-                     pvb.vertexData.data(),
-                     pvb.stride);
+                      d3d9::D3DPRIMITIVETYPE(primitive_type),
+                      GetPrimitiveCount(primitive_type, vertex_count),
+                      pvb.vertexData.data(),
+                      pvb.stride);
 
     if (!useLighting)
       device9->SetRenderState(d3d9::D3DRS_LIGHTING, TRUE);
@@ -1439,7 +1658,7 @@ namespace dxvk {
       return hr;
     }
 
-    UpdateSurfaceDirtyTracking(true, true, true);
+    UpdateSurfaceDirtyTracking(true, m_commonD3DDevice->IsDepthWriteEnabled(), true);
 
     return D3D_OK;
   }
@@ -1455,9 +1674,9 @@ namespace dxvk {
     if (unlikely(strided_data == nullptr || indices == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
-
     DDrawDirtySurfaceUpload();
+
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     // Transform strided vertex data to a standard vertex buffer stream
     PackedVertexBuffer pvb = TransformStridedtoUP(fvf, strided_data, vertex_count);
@@ -1490,7 +1709,7 @@ namespace dxvk {
       return hr;
     }
 
-    UpdateSurfaceDirtyTracking(true, true, true);
+    UpdateSurfaceDirtyTracking(true, m_commonD3DDevice->IsDepthWriteEnabled(), true);
 
     return D3D_OK;
   }
@@ -1508,14 +1727,19 @@ namespace dxvk {
 
     Com<D3D6VertexBuffer> vb6 = static_cast<D3D6VertexBuffer*>(vb);
 
+    if (unlikely(vb6->GetDevice() != this)) {
+      Logger::err("D3D6Device::DrawIndexedPrimitiveVB: Invalid vertex buffer parent device");
+      return DDERR_GENERIC;
+    }
+
     if (unlikely(vb6->IsLocked())) {
       Logger::err("D3D6Device::DrawPrimitiveVB: Buffer is locked");
       return D3DERR_VERTEXBUFFERLOCKED;
     }
 
-    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
-
     DDrawDirtySurfaceUpload();
+
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     const bool useLighting = !(flags & D3DDP_DONOTLIGHT) &&
                               (vb6->GetFVF() & D3DFVF_NORMAL) &&
@@ -1528,9 +1752,9 @@ namespace dxvk {
     device9->SetFVF(vb6->GetFVF());
     device9->SetStreamSource(0, vb6->GetD3D9VertexBuffer(), 0, vb6->GetStride());
     HRESULT hr = device9->DrawPrimitive(
-                           d3d9::D3DPRIMITIVETYPE(primitive_type),
-                           start_vertex,
-                           GetPrimitiveCount(primitive_type, vertex_count));
+                      d3d9::D3DPRIMITIVETYPE(primitive_type),
+                      start_vertex,
+                      GetPrimitiveCount(primitive_type, vertex_count));
 
     if (!useLighting)
       device9->SetRenderState(d3d9::D3DRS_LIGHTING, TRUE);
@@ -1541,7 +1765,7 @@ namespace dxvk {
       return hr;
     }
 
-    UpdateSurfaceDirtyTracking(true, true, true);
+    UpdateSurfaceDirtyTracking(true, m_commonD3DDevice->IsDepthWriteEnabled(), true);
 
     return D3D_OK;
   }
@@ -1559,25 +1783,24 @@ namespace dxvk {
 
     Com<D3D6VertexBuffer> vb6 = static_cast<D3D6VertexBuffer*>(vb);
 
+    if (unlikely(vb6->GetDevice() != this)) {
+      Logger::err("D3D6Device::DrawIndexedPrimitiveVB: Invalid vertex buffer parent device");
+      return DDERR_GENERIC;
+    }
+
     if (unlikely(vb6->IsLocked())) {
       Logger::err("D3D6Device::DrawIndexedPrimitiveVB: Buffer is locked");
       return D3DERR_VERTEXBUFFERLOCKED;
     }
 
-    uint8_t ibIndex = 0;
-    // Try to fit index buffer uploads into the smallest buffer size possible,
-    // out of the five available: XS, S, M, L and XL (XL being the theoretical max)
-    while (index_count > ddrawCaps::IndexCount[ibIndex]) {
-      ibIndex++;
-      if (unlikely(ibIndex > ddrawCaps::IndexBufferCount - 1)) {
-        Logger::err("D3D6Device::DrawIndexedPrimitiveVB: Exceeded size of largest index buffer");
-        return DDERR_UNSUPPORTED;
-      }
+    if (unlikely(index_count > ddrawCaps::MaxIndexCount)) {
+      Logger::err("D3D7Device::DrawIndexedPrimitiveVB: Exceeded size of largest index buffer");
+      return DDERR_UNSUPPORTED;
     }
 
-    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
-
     DDrawDirtySurfaceUpload();
+
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     const bool useLighting = !(flags & D3DDP_DONOTLIGHT) &&
                               (vb6->GetFVF() & D3DFVF_NORMAL) &&
@@ -1587,20 +1810,31 @@ namespace dxvk {
       device9->SetRenderState(d3d9::D3DRS_LIGHTING, FALSE);
     HandlePreDrawLegacyProjection(device9, flags);
 
+    uint8_t ibIndex = 0;
+    // Fit index buffer uploads into the smallest buffer size possible
+    while (index_count > ddrawCaps::IndexCount[ibIndex])
+      ibIndex++;
+
     d3d9::IDirect3DIndexBuffer9* ib9 = m_ib9[ibIndex].ptr();
 
-    UploadIndices(ib9, indices, index_count);
-    m_ib9_uploads[ibIndex]++;
+    const size_t ibSize = index_count * sizeof(WORD);
+    void* pData = nullptr;
+
+    // Locking and unlocking are generally expected to work here
+    ib9->Lock(0, ibSize, &pData, D3DLOCK_DISCARD);
+    memcpy(pData, static_cast<void*>(indices), ibSize);
+    ib9->Unlock();
+
     device9->SetIndices(ib9);
     device9->SetFVF(vb6->GetFVF());
     device9->SetStreamSource(0, vb6->GetD3D9VertexBuffer(), 0, vb6->GetStride());
     HRESULT hr = device9->DrawIndexedPrimitive(
-                    d3d9::D3DPRIMITIVETYPE(primitive_type),
-                    0,
-                    0,
-                    vb6->GetNumVertices(),
-                    0,
-                    GetPrimitiveCount(primitive_type, index_count));
+                      d3d9::D3DPRIMITIVETYPE(primitive_type),
+                      0,
+                      0,
+                      vb6->GetNumVertices(),
+                      0,
+                      GetPrimitiveCount(primitive_type, index_count));
 
     if (!useLighting)
       device9->SetRenderState(d3d9::D3DRS_LIGHTING, TRUE);
@@ -1611,7 +1845,7 @@ namespace dxvk {
       return hr;
     }
 
-    UpdateSurfaceDirtyTracking(true, true, true);
+    UpdateSurfaceDirtyTracking(true, m_commonD3DDevice->IsDepthWriteEnabled(), true);
 
     return D3D_OK;
   }
@@ -1678,20 +1912,22 @@ namespace dxvk {
 
     // D3D5Texture (aka IDirect3DTexture2) is shared between D3D5 and D3D6
     D3D5Texture* texture6 = static_cast<D3D5Texture*>(texture);
-    DDraw4Surface* surface6 = texture6->GetCommonTexture()->GetDD4Surface();
+    DDraw4Surface* surface4 = texture6->GetCommonTexture()->GetDD4Surface();
 
     // Shouldn't ever happen, but play it safe
-    if (unlikely(surface6 == nullptr)) {
+    if (unlikely(surface4 == nullptr)) {
       Logger::err("D3D6Device::SetTexture: Failed to retrieve parent surface");
       return DDERR_UNSUPPORTED;
     }
 
+    DDrawCommonSurface* commonSurface = surface4->GetCommonSurface();
+
     // If textures have been used on a different device, they
     // will get their D3D9 object reinitialized at this point
-    if (unlikely(surface6->GetCommonSurface()->GetCommonD3DDevice() != m_commonD3DDevice.ptr()))
-      surface6->GetCommonSurface()->DirtyDDrawSurface();
+    if (unlikely(commonSurface->GetCommonD3DDevice() != m_commonD3DDevice.ptr()))
+      commonSurface->DirtyDDrawSurface();
 
-    hr = surface6->InitializeOrUploadD3D9();
+    hr = surface4->InitializeOrUploadD3D9();
     if (unlikely(FAILED(hr))) {
       Logger::err("D3D6Device::SetTexture: Failed to initialize/upload D3D9 texture");
       return hr;
@@ -1701,7 +1937,7 @@ namespace dxvk {
     //if (unlikely(m_textures[stage] == texture6))
       //return D3D_OK;
 
-    d3d9::IDirect3DTexture9* tex9 = surface6->GetCommonSurface()->GetD3D9Texture();
+    d3d9::IDirect3DTexture9* tex9 = commonSurface->GetD3D9Texture();
 
     if (likely(tex9 != nullptr)) {
       hr = device9->SetTexture(stage, tex9);
@@ -1715,15 +1951,15 @@ namespace dxvk {
         //  have been used with no texturing; if the texture does not contain an alpha component,
         //  alpha values at the vertices in the source are interpolated between vertices."
         if (m_commonD3DDevice->GetTextureMapBlend() == D3DTBLEND_MODULATE && !m_alphaOpSet) {
-          const DWORD textureOp = surface6->GetCommonSurface()->IsAlphaFormat() ? D3DTOP_SELECTARG1 : D3DTOP_SELECTARG2;
+          const DWORD textureOp = commonSurface->IsAlphaFormat() ? D3DTOP_SELECTARG1 : D3DTOP_SELECTARG2;
           device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP, textureOp);
         }
 
         const bool colorKeyEnable = m_commonD3DDevice->GetColorKeyEnable();
-        const bool validColorKey = surface6->GetCommonSurface()->HasValidColorKey();
+        const bool validColorKey = commonSurface->HasValidColorKey();
         m_bridge->SetColorKeyState(colorKeyEnable && validColorKey);
         if (colorKeyEnable && validColorKey) {
-          DDCOLORKEY normalizedColorKey = surface6->GetCommonSurface()->GetColorKeyNormalized();
+          DDCOLORKEY normalizedColorKey = commonSurface->GetColorKeyNormalized();
           m_bridge->SetColorKey(normalizedColorKey.dwColorSpaceLowValue,
                                 normalizedColorKey.dwColorSpaceHighValue);
         }
@@ -1754,9 +1990,8 @@ namespace dxvk {
     // If the type has been remapped to a sampler state type
     if (stateType != -1u) {
       // MAG/MIN/MIP filter enums are each different than the unified D3D9 D3DTEXTUREFILTERTYPE
-      if (stateType == d3d9::D3DSAMP_MAGFILTER ||
-          stateType == d3d9::D3DSAMP_MINFILTER || stateType == d3d9::D3DSAMP_MIPFILTER) {
-        DWORD dwStateProxy9 = 0;
+      if (stateType == d3d9::D3DSAMP_MAGFILTER || stateType == d3d9::D3DSAMP_MINFILTER || stateType == d3d9::D3DSAMP_MIPFILTER) {
+        DWORD dwStateProxy9;
 
         HRESULT hr = device9->GetSamplerState(dwStage, stateType, &dwStateProxy9);
         if (unlikely(FAILED(hr)))
@@ -1792,8 +2027,7 @@ namespace dxvk {
     // If the type has been remapped to a sampler state type
     if (stateType != -1u) {
       // MAG/MIN/MIP filter enums are each different than the unified D3D9 D3DTEXTUREFILTERTYPE
-      if (stateType == d3d9::D3DSAMP_MAGFILTER ||
-          stateType == d3d9::D3DSAMP_MINFILTER || stateType == d3d9::D3DSAMP_MIPFILTER) {
+      if (stateType == d3d9::D3DSAMP_MAGFILTER || stateType == d3d9::D3DSAMP_MINFILTER || stateType == d3d9::D3DSAMP_MIPFILTER) {
         const DWORD dwState9 = DecodeD3D7TexFilterValues(d3dTexStageStateType, dwState);
         return device9->SetSamplerState(dwStage, stateType, dwState9);
       } else {
@@ -1812,39 +2046,43 @@ namespace dxvk {
     return D3D_OK;
   }
 
-  void D3D6Device::InitializeDS() {
-    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
-
-    m_rt->InitializeD3D9RenderTarget();
+  HRESULT D3D6Device::InitializeRTAndDS() {
+    HRESULT hr = m_rt->InitializeD3D9RenderTarget();
+    if (unlikely(FAILED(hr)))
+      return hr;
 
     m_ds = m_rt->GetAttachedDepthStencil();
 
-    if (m_ds != nullptr) {
-      HRESULT hrDS = m_ds->InitializeD3D9DepthStencil();
-      if (unlikely(FAILED(hrDS))) {
-        Logger::err("D3D6Device::InitializeDS: Failed to initialize D3D9 DS");
-      } else {
-        const RECT* dsRect = m_ds->GetCommonSurface()->GetFullSurfaceRect();
-        Logger::info(str::format("D3D6Device::InitializeDS: Depth stencil: ", dsRect->right, "x", dsRect->bottom));
+    if (likely(m_ds != nullptr)) {
+      hr = m_ds->InitializeD3D9DepthStencil();
+      if (unlikely(FAILED(hr)))
+        return hr;
 
-        HRESULT hrDS9 = device9->SetDepthStencilSurface(m_ds->GetCommonSurface()->GetD3D9Surface());
-        if (unlikely(FAILED(hrDS9))) {
-          Logger::err("D3D6Device::InitializeDS: Failed to set D3D9 depth stencil");
-        } else {
-          // This needs to act like an auto depth stencil of sorts, so manually enable z-buffering
-          device9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_TRUE);
-        }
+      const RECT* dsRect = m_ds->GetCommonSurface()->GetFullSurfaceRect();
+      Logger::info(str::format("D3D6Device: Depth stencil: ", dsRect->right, "x", dsRect->bottom));
+
+      d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
+      hr = device9->SetDepthStencilSurface(m_ds->GetCommonSurface()->GetD3D9Surface());
+      if (unlikely(FAILED(hr))) {
+        Logger::err("D3D6Device: Failed to set D3D9 depth stencil");
+        return hr;
       }
-    } else {
-      device9->SetDepthStencilSurface(nullptr);
-      // Should be superfluous, but play it safe
-      device9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_FALSE);
+
+      // "The default value for this render state is D3DZB_TRUE if a depth buffer
+      //  is attached to the render-target surface, and D3DZB_FALSE otherwise."
+      device9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_TRUE);
     }
+
+    return D3D_OK;
   }
 
   void D3D6Device::UpdateSurfaceDirtyTracking(bool dirtyRenderTarget, bool dirtyDepthStencil, bool dirtyPrimarySurface) {
     if (likely(dirtyRenderTarget))
       m_rt->GetCommonSurface()->DirtyD3D9Surface();
+
+    if (likely(dirtyDepthStencil && m_ds != nullptr))
+      m_ds->GetCommonSurface()->DirtyD3D9Surface();
 
     if (likely(dirtyPrimarySurface)) {
       DDrawCommonSurface* primarySurface = m_commonIntf->GetPrimarySurface();
@@ -1853,9 +2091,6 @@ namespace dxvk {
       if (likely(primarySurface != nullptr))
         primarySurface->DirtyD3D9Surface();
     }
-
-    if (likely(dirtyDepthStencil && m_ds != nullptr))
-      m_ds->GetCommonSurface()->DirtyD3D9Surface();
   }
 
   HRESULT D3D6Device::ResetD3D9Swapchain(d3d9::D3DPRESENT_PARAMETERS* params) {
@@ -1867,15 +2102,19 @@ namespace dxvk {
       return hr;
     }
 
-    m_rt->GetCommonSurface()->SetD3D9Surface(nullptr);
-    m_rt->GetCommonSurface()->UnDirtyD3D9Surface();
+    DDrawCommonSurface* commonSurface = m_rt->GetCommonSurface();
+    commonSurface->ResetD3D9Objects();
+    // Ensure the DDraw surface content gets re-uploaded if needed
+    commonSurface->DirtyDDrawSurface();
 
     // Reset the D3D9 objects for all the following surfaces in the swapchain
     DDraw4Surface* nextFlippable = m_rt->GetNextFlippable();
 
     while (nextFlippable != nullptr) {
-      nextFlippable->GetCommonSurface()->SetD3D9Surface(nullptr);
-      nextFlippable->GetCommonSurface()->UnDirtyD3D9Surface();
+      commonSurface = nextFlippable->GetCommonSurface();
+      commonSurface->ResetD3D9Objects();
+      // Ensure the DDraw surface content gets re-uploaded if needed
+      commonSurface->DirtyDDrawSurface();
 
       nextFlippable = nextFlippable->GetNextFlippable();
     }
@@ -1884,8 +2123,10 @@ namespace dxvk {
     DDraw4Surface* parentSurf = m_rt->GetParentSurface();
 
     while (parentSurf != nullptr) {
-      parentSurf->GetCommonSurface()->SetD3D9Surface(nullptr);
-      parentSurf->GetCommonSurface()->UnDirtyD3D9Surface();
+      commonSurface = parentSurf->GetCommonSurface();
+      commonSurface->ResetD3D9Objects();
+      // Ensure the DDraw surface content gets re-uploaded if needed
+      commonSurface->DirtyDDrawSurface();
 
       parentSurf = parentSurf->GetParentSurface();
     }
@@ -1894,35 +2135,6 @@ namespace dxvk {
     // so there's no need to worry about it in this case
 
     return D3D_OK;
-  }
-
-  inline HRESULT D3D6Device::InitializeIndexBuffers() {
-    static constexpr DWORD Usage = D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY;
-
-    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
-
-    for (uint8_t ibIndex = 0; ibIndex < ddrawCaps::IndexBufferCount ; ibIndex++) {
-      const UINT ibSize = ddrawCaps::IndexCount[ibIndex] * sizeof(WORD);
-
-      Logger::debug(str::format("D3D6Device::InitializeIndexBuffer: Creating D3D9 index buffer, size: ", ibSize));
-
-      HRESULT hr = device9->CreateIndexBuffer(ibSize, Usage, d3d9::D3DFMT_INDEX16,
-                                              d3d9::D3DPOOL_DEFAULT, &m_ib9[ibIndex], nullptr);
-      if (unlikely(FAILED(hr)))
-        return hr;
-    }
-
-    return D3D_OK;
-  }
-
-  inline void D3D6Device::UploadIndices(d3d9::IDirect3DIndexBuffer9* ib9, WORD* indices, DWORD indexCount) {
-    const size_t size = indexCount * sizeof(WORD);
-    void* pData = nullptr;
-
-    // Locking and unlocking are generally expected to work here
-    ib9->Lock(0, size, &pData, D3DLOCK_DISCARD);
-    memcpy(pData, static_cast<void*>(indices), size);
-    ib9->Unlock();
   }
 
   inline void D3D6Device::DDrawDirtySurfaceUpload() {
@@ -1942,31 +2154,7 @@ namespace dxvk {
     }
   }
 
-  inline void D3D6Device::AddViewportInternal(IDirect3DViewport3* viewport) {
-    D3D6Viewport* d3d6Viewport = static_cast<D3D6Viewport*>(viewport);
-
-    auto it = std::find(m_viewports.begin(), m_viewports.end(), d3d6Viewport);
-    if (unlikely(it != m_viewports.end())) {
-      Logger::warn("D3D6Device::AddViewportInternal: Pre-existing viewport found");
-    } else {
-      m_viewports.push_back(d3d6Viewport);
-      d3d6Viewport->GetCommonViewport()->SetD3D6Device(this);
-    }
-  }
-
-  inline void D3D6Device::DeleteViewportInternal(IDirect3DViewport3* viewport) {
-    D3D6Viewport* d3d6Viewport = static_cast<D3D6Viewport*>(viewport);
-
-    auto it = std::find(m_viewports.begin(), m_viewports.end(), d3d6Viewport);
-    if (likely(it != m_viewports.end())) {
-      m_viewports.erase(it);
-       d3d6Viewport->GetCommonViewport()->SetD3D6Device(nullptr);
-    } else {
-      Logger::warn("D3D6Device::DeleteViewportInternal: Viewport not found");
-    }
-  }
-
-  inline HRESULT D3D6Device::SetTextureWithHandle(DDraw4Surface* surface, DWORD textureHandle) {
+  inline HRESULT D3D6Device::SetTextureInternal(DDraw4Surface* surface, DWORD textureHandle) {
     HRESULT hr;
 
     d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
@@ -1975,7 +2163,7 @@ namespace dxvk {
     if (surface == nullptr) {
       hr = device9->SetTexture(0, nullptr);
       if (unlikely(FAILED(hr))) {
-        Logger::err("D3D6Device::SetTextureWithHandle: Failed to unbind D3D9 texture");
+        Logger::err("D3D6Device::SetTextureInternal: Failed to unbind D3D9 texture");
         return hr;
       }
 
@@ -1985,14 +2173,16 @@ namespace dxvk {
       return D3D_OK;
     }
 
+    DDrawCommonSurface* commonSurface = surface->GetCommonSurface();
+
     // If textures have been used on a different device, they
     // will get their D3D9 object reinitialized at this point
-    if (unlikely(surface->GetCommonSurface()->GetCommonD3DDevice() != m_commonD3DDevice.ptr()))
-      surface->GetCommonSurface()->DirtyDDrawSurface();
+    if (unlikely(commonSurface->GetCommonD3DDevice() != m_commonD3DDevice.ptr()))
+      commonSurface->DirtyDDrawSurface();
 
     hr = surface->InitializeOrUploadD3D9();
     if (unlikely(FAILED(hr))) {
-      Logger::err("D3D6Device::SetTextureWithHandle: Failed to initialize/upload D3D9 texture");
+      Logger::err("D3D6Device::SetTextureInternal: Failed to initialize/upload D3D9 texture");
       return hr;
     }
 
@@ -2000,12 +2190,12 @@ namespace dxvk {
     //if (unlikely(m_commonD3DDevice->GetCurrentTextureHandle() == textureHandle))
       //return D3D_OK;
 
-    d3d9::IDirect3DTexture9* tex9 = surface->GetCommonSurface()->GetD3D9Texture();
+    d3d9::IDirect3DTexture9* tex9 = commonSurface->GetD3D9Texture();
 
     if (likely(tex9 != nullptr)) {
       hr = device9->SetTexture(0, tex9);
       if (unlikely(FAILED(hr))) {
-        Logger::warn("D3D6Device::SetTextureWithHandle: Failed to bind D3D9 texture");
+        Logger::warn("D3D6Device::SetTextureInternal: Failed to bind D3D9 texture");
         return hr;
       }
 
@@ -2013,20 +2203,20 @@ namespace dxvk {
       //  have been used with no texturing; if the texture does not contain an alpha component,
       //  alpha values at the vertices in the source are interpolated between vertices."
       if (m_commonD3DDevice->GetTextureMapBlend() == D3DTBLEND_MODULATE && !m_alphaOpSet) {
-        const DWORD textureOp = surface->GetCommonSurface()->IsAlphaFormat() ? D3DTOP_SELECTARG1 : D3DTOP_SELECTARG2;
+        const DWORD textureOp = commonSurface->IsAlphaFormat() ? D3DTOP_SELECTARG1 : D3DTOP_SELECTARG2;
         device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP, textureOp);
       }
 
       const bool colorKeyEnable = m_commonD3DDevice->GetColorKeyEnable();
-      const bool validColorKey = surface->GetCommonSurface()->HasValidColorKey();
+      const bool validColorKey = commonSurface->HasValidColorKey();
       m_bridge->SetColorKeyState(colorKeyEnable && validColorKey);
       if (colorKeyEnable && validColorKey) {
-        DDCOLORKEY normalizedColorKey = surface->GetCommonSurface()->GetColorKeyNormalized();
+        DDCOLORKEY normalizedColorKey = commonSurface->GetColorKeyNormalized();
         m_bridge->SetColorKey(normalizedColorKey.dwColorSpaceLowValue,
                               normalizedColorKey.dwColorSpaceHighValue);
       }
     } else {
-      Logger::err("D3D6Device::SetTextureWithHandle: Found no valid D3D9 texture");
+      Logger::err("D3D6Device::SetTextureInternal: Found no valid D3D9 texture");
     }
 
     m_commonD3DDevice->SetCurrentTextureHandle(textureHandle);

--- a/src/ddraw/d3d6/d3d6_device.h
+++ b/src/ddraw/d3d6/d3d6_device.h
@@ -130,7 +130,7 @@ namespace dxvk {
 
     HRESULT STDMETHODCALLTYPE ValidateDevice(LPDWORD lpdwPasses);
 
-    void InitializeDS();
+    HRESULT InitializeRTAndDS();
 
     void UpdateSurfaceDirtyTracking(bool dirtyRenderTarget, bool dirtyDepthStencil, bool dirtyPrimarySurface);
 
@@ -158,25 +158,9 @@ namespace dxvk {
 
   private:
 
-    inline HRESULT InitializeIndexBuffers();
-
-    inline void UploadIndices(d3d9::IDirect3DIndexBuffer9* ib9, WORD* indices, DWORD indexCount);
-
     inline void DDrawDirtySurfaceUpload();
 
-    inline void AddViewportInternal(IDirect3DViewport3* viewport);
-
-    inline void DeleteViewportInternal(IDirect3DViewport3* viewport);
-
-    inline HRESULT SetTextureWithHandle(DDraw4Surface* surface, DWORD textureHandle);
-
-    inline bool LogIndexBufferUsageStats() const {
-      for (uint32_t m_ib9_upload : m_ib9_uploads) {
-        if (m_ib9_upload > 0)
-          return true;
-      }
-      return false;
-    }
+    inline HRESULT SetTextureInternal(DDraw4Surface* surface, DWORD textureHandle);
 
     inline void RefreshLastUsedDevice() {
       if (unlikely(m_commonIntf->GetCommonD3DDevice() != m_commonD3DDevice.ptr()))
@@ -200,43 +184,39 @@ namespace dxvk {
       }
     }
 
-    bool                           m_alphaOpSet         = false;
+    bool                            m_alphaOpSet         = false;
 
-    Com<D3DCommonDevice>           m_commonD3DDevice;
+    Com<D3DCommonDevice>            m_commonD3DDevice;
 
-    DDrawCommonInterface*          m_commonIntf         = nullptr;
+    DDrawCommonInterface*           m_commonIntf         = nullptr;
 
-    Com<DxvkD3D8Bridge>            m_bridge;
+    Com<IDxvkLegacyD3DDeviceBridge> m_bridge;
 
-    Com<D3D5Device, false>         m_device5;
-    Com<D3D3Device, false>         m_device3;
+    Com<D3D5Device, false>          m_device5;
+    Com<D3D3Device, false>          m_device3;
 
-    D3DMultithread                 m_multithread;
+    D3DMultithread                  m_multithread;
 
-    D3DDEVICEDESC                  m_desc;
+    D3DDEVICEDESC                   m_desc;
 
-    Com<DDraw4Surface>             m_rt;
-    Com<DDraw4Surface, false>      m_ds;
+    Com<DDraw4Surface>              m_rt;
+    Com<DDraw4Surface, false>       m_ds;
 
-    Com<D3D6Viewport>              m_currentViewport;
-    std::vector<Com<D3D6Viewport>> m_viewports;
+    Com<D3D6Viewport>               m_currentViewport;
+    std::vector<Com<D3D6Viewport>>  m_viewports;
 
-    VertexStreamInfo               m_vertexStreamInfo;
-    std::vector<D3DVERTEX>         m_vertexStream;
-    std::vector<D3DLVERTEX>        m_lvertexStream;
-    std::vector<D3DTLVERTEX>       m_tlvertexStream;
+    D3DMATRIX                       m_projectionMatrix   = { };
+    const D3DMATRIX*                m_legacyProjection   = nullptr;
+
+    VertexStreamInfo                m_vertexStreamInfo;
+    std::vector<D3DVERTEX>          m_vertexStream;
+    std::vector<D3DLVERTEX>         m_lvertexStream;
+    std::vector<D3DTLVERTEX>        m_tlvertexStream;
 
     // D3D5Texture (aka IDirect3DTexture2) is shared between D3D5 and D3D6
     std::array<Com<D3D5Texture, false>, ddrawCaps::TextureStageCount> m_textures;
 
-    D3DMATRIX                      m_projectionMatrix   = { };
-    const D3DMATRIX*               m_legacyProjection   = nullptr;
-
     std::array<Com<d3d9::IDirect3DIndexBuffer9>, ddrawCaps::IndexBufferCount> m_ib9;
-    uint32_t m_ib9_uploads[ddrawCaps::IndexBufferCount] = { };
-
-    uint32_t                       m_deviceCount        = 0;
-    static std::atomic<uint32_t>   s_deviceCount;
 
   };
 

--- a/src/ddraw/d3d6/d3d6_interface.cpp
+++ b/src/ddraw/d3d6/d3d6_interface.cpp
@@ -16,8 +16,6 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> D3D6Interface::s_intfCount = 0;
-
   D3D6Interface::D3D6Interface(
         D3DCommonInterface* commonD3DIntf,
         DDrawCommonInterface* commonIntf,
@@ -26,34 +24,28 @@ namespace dxvk {
     : DDrawWrappedObject<IUnknown, IDirect3D3>(pParent, std::move(d3d6IntfProxy))
     , m_commonD3DIntf ( commonD3DIntf )
     , m_commonIntf ( commonIntf ) {
-    if (m_commonD3DIntf == nullptr) {
+    if (m_commonD3DIntf == nullptr)
       m_commonD3DIntf = new D3DCommonInterface();
 
-      Com<d3d9::IDirect3D9> d3d9Intf = d3d9::Direct3DCreate9(D3D_SDK_VERSION);
-      m_commonD3DIntf->SetD3D9Interface(std::move(d3d9Intf));
-    }
+    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
+    // Retrieve and cache the base capabilities
+    m_desc = GetD3D6BaseCaps(d3dOptions);
 
     d3d9::IDirect3D9* d3d9Intf = m_commonD3DIntf->GetD3D9Interface();
 
     // Get the bridge interface to D3D9
-    if (unlikely(FAILED(d3d9Intf->QueryInterface(__uuidof(IDxvkD3D8InterfaceBridge), reinterpret_cast<void**>(&m_bridge))))) {
+    if (unlikely(FAILED(d3d9Intf->QueryInterface(__uuidof(IDxvkLegacyD3DInterfaceBridge), reinterpret_cast<void**>(&m_bridge))))) {
       throw DxvkError("D3D6Interface: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
     }
 
     m_commonD3DIntf->SetD3D6Interface(this);
 
-    m_bridge->EnableD3D6CompatibilityMode();
-
-    m_intfCount = ++s_intfCount;
-
-    Logger::debug(str::format("D3D6Interface: Created a new interface nr. ((3-", m_intfCount, "))"));
+    m_bridge->SetD3DCompatibility(D3DCompatibility::D3D6);
   }
 
   D3D6Interface::~D3D6Interface() {
     if (m_commonD3DIntf->GetD3D6Interface() == this)
       m_commonD3DIntf->SetD3D6Interface(nullptr);
-
-    Logger::debug(str::format("D3D6Interface: Interface nr. ((3-", m_intfCount, ")) bites the dust"));
   }
 
   // Interlocked refcount with the parent IDirectDraw4
@@ -143,8 +135,10 @@ namespace dxvk {
 
     // Software emulation, this is expected to be exposed
     GUID guidRGB = IID_IDirect3DRGBDevice;
-    D3DDEVICEDESC descRGB_HAL = GetD3D6Caps(IID_IDirect3DRGBDevice, d3dOptions);
-    D3DDEVICEDESC descRGB_HEL = descRGB_HAL;
+    D3DDEVICEDESC descRGB_HAL = m_desc;
+    ApplyD3D6DeviceCaps(&descRGB_HAL, guidRGB);
+    D3DDEVICEDESC descRGB_HEL = m_desc;
+    ApplyD3D6DeviceCaps(&descRGB_HEL, guidRGB);
     descRGB_HAL.dwFlags = 0;
     descRGB_HAL.dcmColorModel = 0;
     // Some applications apparently care about HAL texture caps
@@ -171,8 +165,10 @@ namespace dxvk {
 
     // Hardware acceleration
     GUID guidHAL = IID_IDirect3DHALDevice;
-    D3DDEVICEDESC descHAL_HAL = GetD3D6Caps(IID_IDirect3DHALDevice, d3dOptions);
-    D3DDEVICEDESC descHAL_HEL = descHAL_HAL;
+    D3DDEVICEDESC descHAL_HAL = m_desc;
+    ApplyD3D6DeviceCaps(&descHAL_HAL, guidHAL);
+    D3DDEVICEDESC descHAL_HEL = m_desc;
+    ApplyD3D6DeviceCaps(&descHAL_HEL, guidHAL);
     descHAL_HEL.dcmColorModel = 0;
     // Some applications apparently care about RGB texture caps
     descHAL_HEL.dpcLineCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE
@@ -243,11 +239,11 @@ namespace dxvk {
     if (unlikely(!IsValidFindDeviceResultSize(lpD3DFDR->dwSize)))
       return DDERR_INVALIDPARAMS;
 
-    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
-
     // Software emulation, this is expected to be exposed
-    D3DDEVICEDESC descRGB_HAL = GetD3D6Caps(IID_IDirect3DRGBDevice, d3dOptions);
-    D3DDEVICEDESC descRGB_HEL = descRGB_HAL;
+    D3DDEVICEDESC descRGB_HAL = m_desc;
+    ApplyD3D6DeviceCaps(&descRGB_HAL, IID_IDirect3DRGBDevice);
+    D3DDEVICEDESC descRGB_HEL = m_desc;
+    ApplyD3D6DeviceCaps(&descRGB_HEL, IID_IDirect3DRGBDevice);
     descRGB_HAL.dwFlags = 0;
     descRGB_HAL.dcmColorModel = 0;
     // Some applications apparently care about HAL texture caps
@@ -259,8 +255,10 @@ namespace dxvk {
                                            & ~D3DPTEXTURECAPS_NONPOW2CONDITIONAL;
 
     // Hardware acceleration
-    D3DDEVICEDESC descHAL_HAL = GetD3D6Caps(IID_IDirect3DHALDevice, d3dOptions);
-    D3DDEVICEDESC descHAL_HEL = descHAL_HAL;
+    D3DDEVICEDESC descHAL_HAL = m_desc;
+    ApplyD3D6DeviceCaps(&descHAL_HAL, IID_IDirect3DHALDevice);
+    D3DDEVICEDESC descHAL_HEL = m_desc;
+    ApplyD3D6DeviceCaps(&descHAL_HEL, IID_IDirect3DHALDevice);
     descHAL_HEL.dcmColorModel = 0;
     // Some applications apparently care about HEL texture caps
     descHAL_HEL.dpcLineCaps.dwTextureCaps &= ~D3DPTEXTURECAPS_PERSPECTIVE
@@ -418,14 +416,12 @@ namespace dxvk {
 
     Logger::info(str::format("D3D6Interface::CreateDevice: Back buffer size: ", desc.dwWidth, "x", desc.dwHeight));
 
-    const DWORD backBufferCount = DetermineBackBufferCount(rt4->GetProxied());
+    const DWORD backBufferCount = DetermineBackBufferCount<IDirectDrawSurface4>(rt4->GetProxied());
     Logger::info(str::format("D3D6Interface::CreateDevice: Back buffer count: ", backBufferCount));
-
-    Com<d3d9::IDirect3D9> d3d9Intf = m_commonD3DIntf->GetD3D9Interface();
 
     // Determine the supported AA sample count by querying the D3D9 interface
     const d3d9::D3DMULTISAMPLE_TYPE multiSampleType = d3dOptions->emulateFSAA != FSAAEmulation::Disabled ?
-                                                      GetSupportedMultiSampleType(d3d9Intf.ptr(), backBufferFormat) :
+                                                      m_commonD3DIntf->GetMultiSampleType(backBufferFormat) :
                                                       d3d9::D3DMULTISAMPLE_NONE;
 
     // Always appears to be enabled when running in non-exclusive mode
@@ -448,7 +444,7 @@ namespace dxvk {
     params.PresentationInterval       = vBlankStatus ? D3DPRESENT_INTERVAL_DEFAULT : D3DPRESENT_INTERVAL_IMMEDIATE;
 
     Com<d3d9::IDirect3DDevice9> device9;
-    HRESULT hr = d3d9Intf->CreateDevice(
+    HRESULT hr = m_commonD3DIntf->GetD3D9Interface()->CreateDevice(
       D3DADAPTER_DEFAULT,
       d3d9::D3DDEVTYPE_HAL,
       hWnd,
@@ -468,8 +464,11 @@ namespace dxvk {
 
       // Set the common device on the common interface
       m_commonIntf->SetCommonD3DDevice(device6->GetCommonD3DDevice());
-      // Now that we have a valid D3D9 device pointer, we can initialize the depth stencil (if any)
-      device6->InitializeDS();
+      // Now that we have a valid common D3D device on the DDraw interface,
+      // we can initialize the render target and depth stencil (if any)
+      hr = device6->InitializeRTAndDS();
+      if (unlikely(FAILED(hr)))
+        return hr;
 
       *lplpD3DDevice = device6.ref();
     } catch (const DxvkError& e) {
@@ -555,33 +554,6 @@ namespace dxvk {
     }
 
     return D3D_OK;
-  }
-
-  inline DWORD D3D6Interface::DetermineBackBufferCount(IDirectDrawSurface4* renderTarget) {
-    DWORD backBufferCount = 0;
-
-    IDirectDrawSurface4* backBuffer = renderTarget;
-    HRESULT hr;
-
-    while (backBuffer != nullptr) {
-      IDirectDrawSurface4* parentSurface = backBuffer;
-      backBuffer = nullptr;
-
-      hr = parentSurface->EnumAttachedSurfaces(&backBuffer, ListBackBufferSurfaces4Callback);
-      if (unlikely(FAILED(hr))) {
-        Logger::warn("D3D6Interface::DetermineBackBufferCount: Unable to enumerate attached surfaces");
-        break;
-      }
-
-      // The swapchain will eventually return to its origin
-      if (backBuffer == renderTarget)
-        break;
-
-      if (likely(backBuffer != nullptr))
-        backBufferCount++;
-    }
-
-    return std::max<DWORD>(1u, backBufferCount);
   }
 
 }

--- a/src/ddraw/d3d6/d3d6_interface.h
+++ b/src/ddraw/d3d6/d3d6_interface.h
@@ -61,19 +61,16 @@ namespace dxvk {
 
   private:
 
-    inline DWORD DetermineBackBufferCount(IDirectDrawSurface4* renderTarget);
+    Com<IDxvkLegacyD3DInterfaceBridge> m_bridge;
 
-    Com<IDxvkD3D8InterfaceBridge> m_bridge;
+    Com<D3DCommonInterface>            m_commonD3DIntf;
 
-    Com<D3DCommonInterface>       m_commonD3DIntf;
+    DDrawCommonInterface*              m_commonIntf = nullptr;
 
-    DDrawCommonInterface*         m_commonIntf = nullptr;
+    D3DDEVICEDESC                      m_desc;
 
-    Com<D3D5Interface, false>     m_d3d5Intf;
-    Com<D3D3Interface, false>     m_d3d3Intf;
-
-    uint32_t                      m_intfCount  = 0;
-    static std::atomic<uint32_t>  s_intfCount;
+    Com<D3D5Interface, false>          m_d3d5Intf;
+    Com<D3D3Interface, false>          m_d3d3Intf;
 
   };
 

--- a/src/ddraw/d3d6/d3d6_material.cpp
+++ b/src/ddraw/d3d6/d3d6_material.cpp
@@ -11,24 +11,16 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> D3D6Material::s_materialCount = 0;
-
   D3D6Material::D3D6Material(
         D3D6Interface* pParent)
     : DDrawChildObject<D3D6Interface, IDirect3DMaterial3>(pParent) {
     m_commonMaterial = new D3DCommonMaterial();
 
     m_commonMaterial->SetD3D6Material(this);
-
-    m_materialCount = ++s_materialCount;
-
-    Logger::debug(str::format("D3D6Material: Created a new material nr. [[3-", m_materialCount, "]]"));
   }
 
   D3D6Material::~D3D6Material() {
     m_commonMaterial->SetD3D6Material(nullptr);
-
-    Logger::debug(str::format("D3D6Material: Material nr. [[3-", m_materialCount, "]] bites the dust"));
   }
 
   HRESULT STDMETHODCALLTYPE D3D6Material::QueryInterface(REFIID riid, void** ppvObject) {

--- a/src/ddraw/d3d6/d3d6_material.h
+++ b/src/ddraw/d3d6/d3d6_material.h
@@ -33,9 +33,6 @@ namespace dxvk {
 
     Com<D3DCommonMaterial> m_commonMaterial;
 
-    uint32_t               m_materialCount = 0;
-    static std::atomic<uint32_t> s_materialCount;
-
   };
 
 }

--- a/src/ddraw/d3d6/d3d6_viewport.cpp
+++ b/src/ddraw/d3d6/d3d6_viewport.cpp
@@ -21,8 +21,6 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> D3D6Viewport::s_viewportCount = 0;
-
   D3D6Viewport::D3D6Viewport(
         D3DCommonViewport* commonViewport,
         D3D6Interface* pParent)
@@ -36,10 +34,6 @@ namespace dxvk {
       m_commonViewport->SetOrigin(this);
 
     m_commonViewport->SetD3D6Viewport(this);
-
-    m_viewportCount = ++s_viewportCount;
-
-    Logger::debug(str::format("D3D6Viewport: Created a new viewport nr. [[3-", m_viewportCount, "]]"));
   }
 
   D3D6Viewport::~D3D6Viewport() {
@@ -54,8 +48,6 @@ namespace dxvk {
       m_commonViewport->SetOrigin(nullptr);
 
     m_commonViewport->SetD3D6Viewport(nullptr);
-
-    Logger::debug(str::format("D3D6Viewport: Viewport nr. [[3-", m_viewportCount, "]] bites the dust"));
   }
 
   // Interlocked refcount with the origin viewport
@@ -159,8 +151,10 @@ namespace dxvk {
     if (unlikely(!m_commonViewport->HasDevice()))
       return D3DERR_VIEWPORTHASNODEVICE;
 
+    D3DCommonDevice* commonD3DDevice = m_commonViewport->GetCommonD3DDevice();
+
     // Use the full surface rect, since it is surface version agnostic
-    const RECT* surfRect = m_commonViewport->GetCommonRenderTarget()->GetFullSurfaceRect();
+    const RECT* surfRect = commonD3DDevice->GetCommonRenderTarget()->GetFullSurfaceRect();
     // D3D6 will fail when setting a viewport that's outside of the
     // current render target, though that works in D3D9
     HRESULT hr = ValidateViewportRT(data->dwX, data->dwY, data->dwWidth, data->dwHeight,
@@ -189,9 +183,8 @@ namespace dxvk {
     legacyClip->z = 0.0f;
 
     m_commonViewport->MarkViewportAsSet();
-
     if (m_commonViewport->IsCurrentViewport())
-      ApplyViewport();
+      m_commonViewport->ApplyViewport();
 
     return D3D_OK;
   }
@@ -204,20 +197,17 @@ namespace dxvk {
 
     // Temporarily activate this viewport, if not already active
     d3d9::D3DVIEWPORT9 currentViewport9;
-    if (!m_commonViewport->IsCurrentViewport()) {
-      D3D6Viewport* currentViewport = m_commonViewport->GetCurrentD3D6Viewport();
-      if (currentViewport != nullptr) {
-        currentViewport9 = *currentViewport->GetCommonViewport()->GetD3D9Viewport();
-      } else {
-        d3d9Device->GetViewport(&currentViewport9);
-      }
+    const bool isCurrentViewport = m_commonViewport->IsCurrentViewport();
+
+    if (!isCurrentViewport) {
+      d3d9Device->GetViewport(&currentViewport9);
       d3d9Device->SetViewport(m_commonViewport->GetD3D9Viewport());
     }
 
     HRESULT hr = m_commonViewport->TransformVertices(vertex_count, data, flags, offscreen);
 
     // Restore the previously active viewport
-    if (!m_commonViewport->IsCurrentViewport()) {
+    if (!isCurrentViewport) {
       d3d9Device->SetViewport(&currentViewport9);
     }
 
@@ -298,8 +288,10 @@ namespace dxvk {
     DDrawCommonSurface* rt = nullptr;
     DDrawCommonSurface* ds = nullptr;
 
+    D3DCommonDevice* commonD3DDevice = m_commonViewport->GetCommonD3DDevice();
+
     if (clearRenderTarget) {
-      rt = m_commonViewport->GetCommonRenderTarget();
+      rt = commonD3DDevice->GetCommonRenderTarget();
       if (likely(rt != nullptr)) {
         // If this isn't a full surface clear, we need to first upload the DDraw surface
         if (unlikely(count > 1 || !rt->IsFullSurfaceLock(reinterpret_cast<RECT*>(rects), nullptr))) {
@@ -311,7 +303,7 @@ namespace dxvk {
       }
     }
     if (clearDepthStencil) {
-      ds = m_commonViewport->GetCommonDepthStencil();
+      ds = commonD3DDevice->GetCommonDepthStencil();
       if (likely(ds != nullptr)) {
         // If this isn't a full surface clear, we need to first upload the DDraw surface
         if (unlikely(count > 1 || !ds->IsFullSurfaceLock(reinterpret_cast<RECT*>(rects), nullptr))) {
@@ -323,18 +315,14 @@ namespace dxvk {
       }
     }
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = commonD3DDevice->GetD3D9Device();
 
     // Temporarily activate this viewport in order to clear it
     d3d9::D3DVIEWPORT9 currentViewport9;
     const bool isCurrentViewport = m_commonViewport->IsCurrentViewport();
+
     if (!isCurrentViewport) {
-      D3D6Viewport* currentViewport = m_commonViewport->GetCurrentD3D6Viewport();
-      if (currentViewport != nullptr) {
-        currentViewport9 = *currentViewport->GetCommonViewport()->GetD3D9Viewport();
-      } else {
-        d3d9Device->GetViewport(&currentViewport9);
-      }
+      d3d9Device->GetViewport(&currentViewport9);
       d3d9Device->SetViewport(m_commonViewport->GetD3D9Viewport());
     }
 
@@ -363,7 +351,7 @@ namespace dxvk {
     if (clearDepthStencil && ds != nullptr)
       ds->UnDirtyDDrawSurface();
 
-    m_commonViewport->UpdateSurfaceDirtyTracking(clearRenderTarget, clearDepthStencil, false);
+    commonD3DDevice->UpdateSurfaceDirtyTracking(clearRenderTarget, clearDepthStencil, false);
 
     return D3D_OK;
   }
@@ -384,7 +372,7 @@ namespace dxvk {
     d3dLight->SetViewport6(this);
 
     if (m_commonViewport->HasDevice() && m_commonViewport->IsCurrentViewport())
-      ApplyAndActivateLight(d3dLight->GetIndex(), d3dLight);
+      m_commonViewport->ApplyAndActivateLight(d3dLight);
 
     return D3D_OK;
   }
@@ -402,14 +390,11 @@ namespace dxvk {
 
     auto it = std::find(lights.begin(), lights.end(), d3dLight);
     if (likely(it != lights.end())) {
-      const DWORD lightIndex = d3dLight->GetIndex();
-      if (m_commonViewport->HasDevice() && m_commonViewport->IsCurrentViewport() && d3dLight->IsActive()) {
-        //Logger::debug(str::format("D3D6Viewport: Disabling light nr. ", lightIndex));
-        d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
-        d3d9Device->LightEnable(lightIndex, FALSE);
-      }
-      lights.erase(it);
+      // Ensure the light is deactivated before deleting it
+      if (m_commonViewport->HasDevice() && m_commonViewport->IsCurrentViewport() && d3dLight->IsActive())
+        m_commonViewport->DeactivateLight(d3dLight);
       d3dLight->SetViewport6(nullptr);
+      lights.erase(it);
     } else {
       Logger::warn("D3D6Viewport::DeleteLight: Light not found");
       return DDERR_INVALIDPARAMS;
@@ -482,8 +467,10 @@ namespace dxvk {
     if (unlikely(!m_commonViewport->HasDevice()))
       return D3DERR_VIEWPORTHASNODEVICE;
 
+    D3DCommonDevice* commonD3DDevice = m_commonViewport->GetCommonD3DDevice();
+
     // Use the full surface rect, since it is surface version agnostic
-    const RECT* surfRect = m_commonViewport->GetCommonRenderTarget()->GetFullSurfaceRect();
+    const RECT* surfRect = commonD3DDevice->GetCommonRenderTarget()->GetFullSurfaceRect();
     // D3D6 will fail when setting a viewport that's outside of the
     // current render target, though that works in D3D9
     HRESULT hr = ValidateViewportRT(data->dwX, data->dwY, data->dwWidth, data->dwHeight,
@@ -510,9 +497,8 @@ namespace dxvk {
     legacyClip->z = -data->dvMinZ / (data->dvMaxZ - data->dvMinZ);
 
     m_commonViewport->MarkViewportAsSet();
-
     if (m_commonViewport->IsCurrentViewport())
-      ApplyViewport();
+      m_commonViewport->ApplyViewport();
 
     return D3D_OK;
   }
@@ -560,8 +546,10 @@ namespace dxvk {
     DDrawCommonSurface* rt = nullptr;
     DDrawCommonSurface* ds = nullptr;
 
+    D3DCommonDevice* commonD3DDevice = m_commonViewport->GetCommonD3DDevice();
+
     if (clearRenderTarget) {
-      rt = m_commonViewport->GetCommonRenderTarget();
+      rt = commonD3DDevice->GetCommonRenderTarget();
       if (likely(rt != nullptr)) {
         // If this isn't a full surface clear, we need to first upload the DDraw surface
         if (unlikely(count > 1 || !rt->IsFullSurfaceLock(reinterpret_cast<RECT*>(rects), nullptr))) {
@@ -573,7 +561,7 @@ namespace dxvk {
       }
     }
     if (clearDepthStencil) {
-      ds = m_commonViewport->GetCommonDepthStencil();
+      ds = commonD3DDevice->GetCommonDepthStencil();
       if (likely(ds != nullptr)) {
         // If this isn't a full surface clear, we need to first upload the DDraw surface
         if (unlikely(count > 1 || !ds->IsFullSurfaceLock(reinterpret_cast<RECT*>(rects), nullptr))) {
@@ -585,18 +573,14 @@ namespace dxvk {
       }
     }
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = commonD3DDevice->GetD3D9Device();
 
     // Temporarily activate this viewport in order to clear it
     d3d9::D3DVIEWPORT9 currentViewport9;
     const bool isCurrentViewport = m_commonViewport->IsCurrentViewport();
+
     if (!isCurrentViewport) {
-      D3D6Viewport* currentViewport = m_commonViewport->GetCurrentD3D6Viewport();
-      if (currentViewport != nullptr) {
-        currentViewport9 = *currentViewport->GetCommonViewport()->GetD3D9Viewport();
-      }  else {
-        d3d9Device->GetViewport(&currentViewport9);
-      }
+      d3d9Device->GetViewport(&currentViewport9);
       d3d9Device->SetViewport(m_commonViewport->GetD3D9Viewport());
     }
 
@@ -622,77 +606,7 @@ namespace dxvk {
     if (clearDepthStencil && ds != nullptr)
       ds->UnDirtyDDrawSurface();
 
-    m_commonViewport->UpdateSurfaceDirtyTracking(clearRenderTarget, clearDepthStencil, false);
-
-    return D3D_OK;
-  }
-
-  HRESULT D3D6Viewport::ApplyViewport() {
-    if (!m_commonViewport->IsViewportSet())
-      return D3D_OK;
-
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
-
-    HRESULT hr = d3d9Device->SetViewport(m_commonViewport->GetD3D9Viewport());
-    if (unlikely(FAILED(hr))) {
-      Logger::err("D3D6Viewport: Failed to set the D3D9 viewport");
-      return hr;
-    }
-
-    return D3D_OK;
-  }
-
-  HRESULT D3D6Viewport::ApplyAndActivateLights() {
-    std::vector<Com<D3DLight>>& lights = m_commonViewport->GetLights();
-
-    if (!lights.size())
-      return D3D_OK;
-
-    for (auto light: lights)
-      ApplyAndActivateLight(light->GetIndex(), light.ptr());
-
-    return D3D_OK;
-  }
-
-  HRESULT D3D6Viewport::DeactivateLights() {
-    std::vector<Com<D3DLight>>& lights = m_commonViewport->GetLights();
-
-    if (!lights.size())
-      return D3D_OK;
-
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
-
-    for (auto light: lights) {
-      const DWORD lightIndex = light->GetIndex();
-      if (m_commonViewport->HasDevice() && m_commonViewport->IsCurrentViewport() && light->IsActive()) {
-        //Logger::debug(str::format("D3D6Viewport: Disabling light nr. ", lightIndex));
-        d3d9Device->LightEnable(lightIndex, FALSE);
-      }
-    }
-
-    return D3D_OK;
-  }
-
-  HRESULT D3D6Viewport::ApplyAndActivateLight(DWORD index, D3DLight* light) {
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonViewport->GetCommonD3DDevice()->GetD3D9Device();
-
-    HRESULT hr = d3d9Device->SetLight(index, light->GetD3D9Light());
-    if (unlikely(FAILED(hr))) {
-      Logger::err("D3D6Viewport: Failed D3D9 SetLight call");
-      return hr;
-    }
-
-    if (light->IsActive()) {
-      //Logger::debug(str::format("D3D6Viewport: Enabling D3D9 light nr. ", index));
-      hr = d3d9Device->LightEnable(index, TRUE);
-      if (unlikely(FAILED(hr)))
-        Logger::err("D3D6Viewport: Failed D3D9 LightEnable call (TRUE)");
-    } else {
-      //Logger::debug(str::format("D3D6Viewport: Disabling D3D9 light nr. ", index));
-      hr = d3d9Device->LightEnable(index, FALSE);
-      if (unlikely(FAILED(hr)))
-        Logger::err("D3D6Viewport: Failed D3D9 LightEnable call (FALSE)");
-    }
+    commonD3DDevice->UpdateSurfaceDirtyTracking(clearRenderTarget, clearDepthStencil, false);
 
     return D3D_OK;
   }

--- a/src/ddraw/d3d6/d3d6_viewport.h
+++ b/src/ddraw/d3d6/d3d6_viewport.h
@@ -70,14 +70,6 @@ namespace dxvk {
 
     HRESULT STDMETHODCALLTYPE Clear2(DWORD count, D3DRECT *rects, DWORD flags, DWORD color, D3DVALUE z, DWORD stencil);
 
-    HRESULT ApplyViewport();
-
-    HRESULT ApplyAndActivateLights();
-
-    HRESULT DeactivateLights();
-
-    HRESULT ApplyAndActivateLight(DWORD index, D3DLight* light);
-
     D3DCommonViewport* GetCommonViewport() const {
       return m_commonViewport.ptr();
     }
@@ -94,9 +86,6 @@ namespace dxvk {
 
     Com<D3D5Viewport, false> m_viewport5;
     Com<D3D3Viewport, false> m_viewport3;
-
-    uint32_t                 m_viewportCount         = 0;
-    static std::atomic<uint32_t> s_viewportCount;
 
   };
 

--- a/src/ddraw/d3d7/d3d7_buffer.cpp
+++ b/src/ddraw/d3d7/d3d7_buffer.cpp
@@ -13,8 +13,6 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> D3D7VertexBuffer::s_buffCount = 0;
-
   D3D7VertexBuffer::D3D7VertexBuffer(
         D3D7Interface* pParent,
         D3DVERTEXBUFFERDESC* pDesc)
@@ -25,15 +23,17 @@ namespace dxvk {
     , m_size ( m_stride * pDesc->dwNumVertices ) {
     m_parent->AddRef();
 
-    m_buffCount = ++s_buffCount;
-
-    ListBufferDetails();
+    // In the fortunate scenario where a D3D7 device is already present
+    // when a vertex buffer is created, initialize the buffer on the spot
+    // rather than deferring the initialization to the first Lock()
+    // or ProcessVertices() call, since that can cause hitching
+    RefreshD3DDevice();
+    if (m_d3d7Device != nullptr)
+      InitializeD3D9();
   }
 
   D3D7VertexBuffer::~D3D7VertexBuffer() {
     m_parent->Release();
-
-    Logger::debug(str::format("D3D7VertexBuffer: Buffer nr. {{7-", m_buffCount, "}} bites the dust"));
   }
 
   HRESULT STDMETHODCALLTYPE D3D7VertexBuffer::QueryInterface(REFIID riid, void** ppvObject) {
@@ -96,12 +96,10 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7VertexBuffer::Unlock() {
-    RefreshD3DDevice();
-    if (unlikely(!IsInitialized())) {
-      HRESULT hrInit = InitializeD3D9();
-      if (unlikely(FAILED(hrInit)))
-        return hrInit;
-    }
+    // Ignore the unlock call if the D3D9 buffer
+    // was lost since the previous Lock() call
+    if (unlikely(!IsInitialized()))
+      return D3D_OK;
 
     HRESULT hr = m_vb9->Unlock();
     if (unlikely(FAILED(hr)))
@@ -123,32 +121,32 @@ namespace dxvk {
       return DDERR_INVALIDPARAMS;
 
     D3D7Device* device7 = static_cast<D3D7Device*>(lpD3DDevice);
-    D3D7VertexBuffer* vb = static_cast<D3D7VertexBuffer*>(lpSrcBuffer);
-
-    vb->RefreshD3DDevice();
-    if (unlikely(vb->GetDevice() == nullptr || device7 != vb->GetDevice())) {
-      Logger::err("D3D7VertexBuffer::ProcessVertices: Incompatible or null device");
-      return DDERR_GENERIC;
-    }
-
-    HRESULT hrInit;
+    D3D7VertexBuffer* srcBuffer7 = static_cast<D3D7VertexBuffer*>(lpSrcBuffer);
 
     // Check and initialize the source buffer
-    if (unlikely(!vb->IsInitialized())) {
-      hrInit = vb->InitializeD3D9();
+    srcBuffer7->RefreshD3DDevice();
+    if (unlikely(!srcBuffer7->IsInitialized())) {
+      HRESULT hrInit = srcBuffer7->InitializeD3D9();
       if (unlikely(FAILED(hrInit)))
         return hrInit;
     }
 
     // Check and initialize the destination buffer (this buffer)
-    d3d9::IDirect3DDevice9* device9 = RefreshD3DDevice();
+    RefreshD3DDevice();
     if (unlikely(!IsInitialized())) {
-      hrInit = InitializeD3D9();
+      HRESULT hrInit = InitializeD3D9();
       if (unlikely(FAILED(hrInit)))
         return hrInit;
     }
 
+    if (unlikely(m_d3d7Device != device7)) {
+      Logger::err("D3D7VertexBuffer::ProcessVertices: Invalid device");
+      return DDERR_GENERIC;
+    }
+
     D3DDeviceLock lock = device7->LockDevice();
+
+    d3d9::IDirect3DDevice9* device9 = device7->GetCommonD3DDevice()->GetD3D9Device();
 
     const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
 
@@ -156,8 +154,10 @@ namespace dxvk {
       uint8_t *inData = nullptr;
       uint8_t *outData = nullptr;
 
-      HRESULT hr = vb->GetD3D9VertexBuffer()->Lock(dwSrcIndex * vb->GetStride(), dwCount * vb->GetStride(),
-                                                   reinterpret_cast<void**>(&inData), D3DLOCK_READONLY);
+      d3d9::IDirect3DVertexBuffer9* srcBuffer9 = srcBuffer7->GetD3D9VertexBuffer();
+
+      HRESULT hr = srcBuffer9->Lock(dwSrcIndex * srcBuffer7->GetStride(), dwCount * srcBuffer7->GetStride(),
+                                    reinterpret_cast<void**>(&inData), D3DLOCK_READONLY);
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D7VertexBuffer::ProcessVertices: Failed to lock source buffer");
         return D3DERR_VERTEXBUFFERLOCKED;
@@ -166,7 +166,7 @@ namespace dxvk {
       hr = m_vb9->Lock(dwDestIndex * m_stride, dwCount * m_stride, reinterpret_cast<void**>(&outData), 0);
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D7VertexBuffer::ProcessVertices: Failed to lock destination buffer");
-        vb->Unlock();
+        srcBuffer9->Unlock();
         return D3DERR_VERTEXBUFFERLOCKED;
       }
 
@@ -174,8 +174,8 @@ namespace dxvk {
 
       ProcessVerticesData pvData;
       pvData.inData = inData;
-      pvData.inFVF = vb->GetFVF();
-      pvData.inStride = vb->GetStride();
+      pvData.inFVF = srcBuffer7->GetFVF();
+      pvData.inStride = srcBuffer7->GetStride();
       pvData.outData = outData;
       pvData.outFVF = m_desc.dwFVF;
       pvData.outStride = m_stride;
@@ -190,7 +190,7 @@ namespace dxvk {
 
       std::vector<d3d9::D3DLIGHT9> lights9;
       if (doLighting) {
-        device7->GetD3D9Lights(&lights9);
+        device7->GetD3D9ActiveLights(&lights9);
         pvData.lights = &lights9;
       } else {
         pvData.lights = nullptr;
@@ -199,15 +199,15 @@ namespace dxvk {
       ProcessVerticesSW(device9, m_commonIntf->GetOptions(), &pvData);
 
       m_vb9->Unlock();
-      vb->Unlock();
+      srcBuffer9->Unlock();
 
     } else {
       // D3D9 ProcessVertices doesn't handle lighting, only transforms
       if (unlikely(dwVertexOp & D3DVOP_LIGHT))
         Logger::warn("D3D7VertexBuffer::ProcessVertices: Unsupported operation D3DVOP_LIGHT");
 
-      device9->SetFVF(vb->GetFVF());
-      device9->SetStreamSource(0, vb->GetD3D9VertexBuffer(), 0, vb->GetStride());
+      device9->SetFVF(srcBuffer7->GetFVF());
+      device9->SetStreamSource(0, srcBuffer7->GetD3D9VertexBuffer(), 0, srcBuffer7->GetStride());
       HRESULT hr = device9->ProcessVertices(dwSrcIndex, dwDestIndex, dwCount, m_vb9.ptr(), nullptr, dwFlags);
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D7VertexBuffer::ProcessVertices: Failed call to D3D9 ProcessVertices");
@@ -227,23 +227,24 @@ namespace dxvk {
     if (unlikely(lpD3DDevice == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    D3D7Device* device = static_cast<D3D7Device*>(lpD3DDevice);
+    D3D7Device* device7 = static_cast<D3D7Device*>(lpD3DDevice);
 
-    RefreshD3DDevice();
-    if (unlikely(m_d3d7Device == nullptr || device != m_d3d7Device)) {
-      Logger::err(">>> D3D7VertexBuffer::ProcessVerticesStrided: Incompatible or null device");
-      return DDERR_GENERIC;
-    }
-
-    //d3d9::IDirect3DDevice9* device9 = RefreshD3DDevice();
     // Check and initialize the destination buffer (this buffer)
+    RefreshD3DDevice();
     if (unlikely(!IsInitialized())) {
       HRESULT hrInit = InitializeD3D9();
       if (unlikely(FAILED(hrInit)))
         return hrInit;
     }
 
-    D3DDeviceLock lock = device->LockDevice();
+    if (unlikely(m_d3d7Device != device7)) {
+      Logger::err("D3D7VertexBuffer::ProcessVerticesStrided: Invalid device");
+      return DDERR_GENERIC;
+    }
+
+    D3DDeviceLock lock = device7->LockDevice();
+
+    //d3d9::IDirect3DDevice9* device9 = device7->GetCommonD3DDevice()->GetD3D9Device();
 
     // TODO: lpVertexArray needs to be transformed into a non-strided vertex buffer stream
 
@@ -280,10 +281,6 @@ namespace dxvk {
     m_legacyDiscard = m_commonIntf->GetOptions()->forceLegacyDiscard &&
                       (usage & D3DUSAGE_DYNAMIC) && (usage & D3DUSAGE_WRITEONLY);
 
-    const char* poolPlacement = pool == d3d9::D3DPOOL_DEFAULT ? "D3DPOOL_DEFAULT" :
-                                pool == d3d9::D3DPOOL_SYSTEMMEM ? "D3DPOOL_SYSTEMMEM" : "D3DPOOL_MANAGED";
-    Logger::debug(str::format("D3D7VertexBuffer::InitializeD3D9: Placing in: ", poolPlacement));
-
     d3d9::IDirect3DDevice9* device9 = m_d3d7Device->GetCommonD3DDevice()->GetD3D9Device();
     HRESULT hr = device9->CreateVertexBuffer(m_size, usage, m_desc.dwFVF, pool, &m_vb9, nullptr);
     if (unlikely(FAILED(hr))) {
@@ -294,7 +291,7 @@ namespace dxvk {
     return D3D_OK;
   }
 
-  d3d9::IDirect3DDevice9* D3D7VertexBuffer::RefreshD3DDevice() {
+  void D3D7VertexBuffer::RefreshD3DDevice() {
     D3DCommonDevice* commonD3DDevice = m_commonIntf->GetCommonD3DDevice();
 
     D3D7Device* d3d7Device = commonD3DDevice != nullptr ? commonD3DDevice->GetD3D7Device() : nullptr;
@@ -306,8 +303,6 @@ namespace dxvk {
       }
       m_d3d7Device = d3d7Device;
     }
-
-    return commonD3DDevice != nullptr ? commonD3DDevice->GetD3D9Device() : nullptr;
   }
 
 }

--- a/src/ddraw/d3d7/d3d7_buffer.h
+++ b/src/ddraw/d3d7/d3d7_buffer.h
@@ -36,7 +36,7 @@ namespace dxvk {
 
     HRESULT InitializeD3D9();
 
-    d3d9::IDirect3DDevice9* RefreshD3DDevice();
+    void RefreshD3DDevice();
 
     bool IsInitialized() const {
       return m_vb9 != nullptr;
@@ -68,13 +68,6 @@ namespace dxvk {
       return m_desc.dwCaps & D3DVBCAPS_OPTIMIZED;
     }
 
-    inline void ListBufferDetails() const {
-      Logger::debug(str::format("D3D7VertexBuffer: Created a new buffer nr. {{7-", m_buffCount, "}}:"));
-      Logger::debug(str::format("   Size:     ", m_size));
-      Logger::debug(str::format("   FVF:      ", m_desc.dwFVF));
-      Logger::debug(str::format("   Vertices: ", m_size / m_stride));
-    }
-
     bool                              m_locked        = false;
     bool                              m_legacyDiscard = false;
 
@@ -88,9 +81,6 @@ namespace dxvk {
     D3D7Device*                       m_d3d7Device    = nullptr;
 
     Com<d3d9::IDirect3DVertexBuffer9> m_vb9;
-
-    uint32_t                          m_buffCount     = 0;
-    static std::atomic<uint32_t>      s_buffCount;
 
   };
 

--- a/src/ddraw/d3d7/d3d7_device.cpp
+++ b/src/ddraw/d3d7/d3d7_device.cpp
@@ -9,8 +9,6 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> D3D7Device::s_deviceCount = 0;
-
   D3D7Device::D3D7Device(
         D3DCommonDevice* commonD3DDevice,
         Com<IDirect3DDevice7>&& d3d7DeviceProxy,
@@ -34,7 +32,8 @@ namespace dxvk {
 
     const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
     // Retrieve and cache the device capabilities
-    m_desc = GetD3D7Caps(deviceGUID, d3dOptions);
+    m_desc = GetD3D7BaseCaps(d3dOptions);
+    ApplyD3D7DeviceCaps(&m_desc, deviceGUID);
 
     d3d9::IDirect3DDevice9* device9;
 
@@ -55,12 +54,19 @@ namespace dxvk {
     }
 
     // Common D3D9 index buffers
-    if (unlikely(FAILED(InitializeIndexBuffers()))) {
-      throw DxvkError("D3D7Device: ERROR! Failed to initialize D3D9 index buffers.");
+    static constexpr DWORD Usage = D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY;
+
+    for (uint8_t ibIndex = 0; ibIndex < ddrawCaps::IndexBufferCount ; ibIndex++) {
+      const UINT ibSize = ddrawCaps::IndexCount[ibIndex] * sizeof(WORD);
+
+      HRESULT hr = device9->CreateIndexBuffer(ibSize, Usage, d3d9::D3DFMT_INDEX16,
+                                              d3d9::D3DPOOL_DEFAULT, &m_ib9[ibIndex], nullptr);
+      if (unlikely(FAILED(hr)))
+        throw DxvkError("D3D7Device: ERROR! Failed to initialize D3D9 index buffers.");
     }
 
     // Get the bridge interface to D3D9
-    if (unlikely(FAILED(device9->QueryInterface(__uuidof(IDxvkD3D8Bridge), reinterpret_cast<void**>(&m_bridge))))) {
+    if (unlikely(FAILED(device9->QueryInterface(__uuidof(IDxvkLegacyD3DDeviceBridge), reinterpret_cast<void**>(&m_bridge))))) {
       throw DxvkError("D3D7Device: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
     }
 
@@ -70,40 +76,23 @@ namespace dxvk {
     // Update D3D9 legacy light state
     m_bridge->SetLegacyLightsState(false);
 
+    // Update D3D9 alternate pixel center
+    m_bridge->SetAlternatePixelCenter(d3dOptions->alternatePixelCenter == AlternatePixelCenter::Enabled);
+
     if (m_commonD3DDevice->GetOrigin() == nullptr)
       m_commonD3DDevice->SetOrigin(this);
 
     m_commonD3DDevice->SetD3D7Device(this);
 
     m_textures.fill(nullptr);
-
-    m_deviceCount = ++s_deviceCount;
-
-    Logger::debug(str::format("D3D7Device: Created a new device nr. ((7-", m_deviceCount, "))"));
   }
 
   D3D7Device::~D3D7Device() {
-    if (LogIndexBufferUsageStats()) {
-      Logger::info("D3D7Device: Index buffer upload statistics:");
-      Logger::info(str::format("  0.25 kb : ", m_ib9_uploads[0]));
-      Logger::info(str::format("  0.5  kb : ", m_ib9_uploads[1]));
-      Logger::info(str::format("  1    kb : ", m_ib9_uploads[2]));
-      Logger::info(str::format("  2    kb : ", m_ib9_uploads[3]));
-      Logger::info(str::format("  4    kb : ", m_ib9_uploads[4]));
-      Logger::info(str::format("  8    kb : ", m_ib9_uploads[5]));
-      Logger::info(str::format("  16   kb : ", m_ib9_uploads[6]));
-      Logger::info(str::format("  32   kb : ", m_ib9_uploads[7]));
-      Logger::info(str::format("  64   kb : ", m_ib9_uploads[8]));
-      Logger::info(str::format("  128  kb : ", m_ib9_uploads[9]));
-    }
-
     if (m_commonD3DDevice->GetD3D7Device() == this)
       m_commonD3DDevice->SetD3D7Device(nullptr);
 
     if (m_commonD3DDevice->GetOrigin() == this)
       m_commonD3DDevice->SetOrigin(nullptr);
-
-    Logger::debug(str::format("D3D7Device: Device nr. ((7-", m_deviceCount, ")) bites the dust"));
   }
 
   HRESULT STDMETHODCALLTYPE D3D7Device::QueryInterface(REFIID riid, void** ppvObject) {
@@ -183,9 +172,7 @@ namespace dxvk {
     if (unlikely(hr != D3DENUMRET_OK))
       return D3D_OK;
 
-    // Not supported in D3D9, but some games need
-    // it to be advertised (for offscreen plain surfaces?)
-    if (unlikely(d3dOptions->supportR3G3B2)) {
+    if (d3dOptions->supportR3G3B2) {
       textureFormat = GetTextureFormat(d3d9::D3DFMT_R3G3B2);
       hr = cb(&textureFormat, ctx);
       if (unlikely(hr != D3DENUMRET_OK))
@@ -514,16 +501,72 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D7Device::SetRenderState(D3DRENDERSTATETYPE dwRenderStateType, DWORD dwRenderState) {
     D3DDeviceLock lock = LockDevice();
 
-    // As opposed to D3D8/9, D3D7 actually validates and
-    // errors out in case of unknown/invalid render states
-    if (unlikely(!IsValidD3D7RenderStateType(dwRenderStateType)))
-      return DDERR_INVALIDPARAMS;
-
     d3d9::D3DRENDERSTATETYPE State9 = d3d9::D3DRENDERSTATETYPE(dwRenderStateType);
 
     switch (dwRenderStateType) {
       // Most render states translate 1:1 to D3D9
-      default:
+      //case D3DRENDERSTATE_ANTIALIAS:
+      //case D3DRENDERSTATE_TEXTUREPERSPECTIVE:
+      case D3DRENDERSTATE_ZENABLE:
+      case D3DRENDERSTATE_FILLMODE:
+      case D3DRENDERSTATE_SHADEMODE:
+      //case D3DRENDERSTATE_LINEPATTERN:
+      //case D3DRENDERSTATE_ZWRITEENABLE:
+      case D3DRENDERSTATE_ALPHATESTENABLE:
+      case D3DRENDERSTATE_LASTPIXEL:
+      case D3DRENDERSTATE_SRCBLEND:
+      case D3DRENDERSTATE_DESTBLEND:
+      case D3DRENDERSTATE_CULLMODE:
+      case D3DRENDERSTATE_ZFUNC:
+      case D3DRENDERSTATE_ALPHAREF:
+      case D3DRENDERSTATE_ALPHAFUNC:
+      case D3DRENDERSTATE_DITHERENABLE:
+      case D3DRENDERSTATE_ALPHABLENDENABLE:
+      case D3DRENDERSTATE_FOGENABLE:
+      case D3DRENDERSTATE_SPECULARENABLE:
+      //case D3DRENDERSTATE_ZVISIBLE:
+      //case D3DRENDERSTATE_STIPPLEDALPHA:
+      case D3DRENDERSTATE_FOGCOLOR:
+      case D3DRENDERSTATE_FOGTABLEMODE:
+      case D3DRENDERSTATE_FOGSTART:   // same as D3DRENDERSTATE_FOGTABLESTART
+      case D3DRENDERSTATE_FOGEND:     // same as D3DRENDERSTATE_FOGTABLEEND
+      case D3DRENDERSTATE_FOGDENSITY: // same as D3DRENDERSTATE_FOGTABLEDENSITY
+      //case D3DRENDERSTATE_EDGEANTIALIAS:
+      //case D3DRENDERSTATE_COLORKEYENABLE:
+      //case D3DRENDERSTATE_ZBIAS:
+      case D3DRENDERSTATE_RANGEFOGENABLE:
+      case D3DRENDERSTATE_STENCILENABLE:
+      case D3DRENDERSTATE_STENCILFAIL:
+      case D3DRENDERSTATE_STENCILZFAIL:
+      case D3DRENDERSTATE_STENCILPASS:
+      case D3DRENDERSTATE_STENCILFUNC:
+      case D3DRENDERSTATE_STENCILREF:
+      case D3DRENDERSTATE_STENCILMASK:
+      case D3DRENDERSTATE_STENCILWRITEMASK:
+      case D3DRENDERSTATE_TEXTUREFACTOR:
+      case D3DRENDERSTATE_WRAP0:
+      case D3DRENDERSTATE_WRAP1:
+      case D3DRENDERSTATE_WRAP2:
+      case D3DRENDERSTATE_WRAP3:
+      case D3DRENDERSTATE_WRAP4:
+      case D3DRENDERSTATE_WRAP5:
+      case D3DRENDERSTATE_WRAP6:
+      case D3DRENDERSTATE_WRAP7:
+      case D3DRENDERSTATE_CLIPPING:
+      case D3DRENDERSTATE_LIGHTING:
+      //case D3DRENDERSTATE_EXTENTS:
+      case D3DRENDERSTATE_AMBIENT:
+      case D3DRENDERSTATE_FOGVERTEXMODE:
+      case D3DRENDERSTATE_COLORVERTEX:
+      case D3DRENDERSTATE_LOCALVIEWER:
+      case D3DRENDERSTATE_NORMALIZENORMALS:
+      //case D3DRENDERSTATE_COLORKEYBLENDENABLE:
+      case D3DRENDERSTATE_DIFFUSEMATERIALSOURCE:
+      case D3DRENDERSTATE_SPECULARMATERIALSOURCE:
+      case D3DRENDERSTATE_AMBIENTMATERIALSOURCE:
+      case D3DRENDERSTATE_EMISSIVEMATERIALSOURCE:
+      case D3DRENDERSTATE_VERTEXBLEND:
+      case D3DRENDERSTATE_CLIPPLANEENABLE:
         break;
 
       case D3DRENDERSTATE_ANTIALIAS: {
@@ -560,6 +603,11 @@ namespace dxvk {
 
         m_commonD3DDevice->SetLinePattern(bit::cast<D3DLINEPATTERN>(dwRenderState));
         return D3D_OK;
+
+      // Track the depth write state for D3D9 depth stencil surface dirtying
+      case D3DRENDERSTATE_ZWRITEENABLE:
+        m_commonD3DDevice->SetDepthWriteEnabled(static_cast<bool>(dwRenderState));
+        break;
 
       // Not supported by D3D7
       case D3DRENDERSTATE_ZVISIBLE:
@@ -606,6 +654,11 @@ namespace dxvk {
       case D3DRENDERSTATE_COLORKEYBLENDENABLE:
         m_commonD3DDevice->SetColorKeyBlendEnable(dwRenderState);
         return D3D_OK;
+
+      // As opposed to D3D8/9, D3D7 actually validates and
+      // errors out in case of unknown/invalid render states
+      default:
+        return DDERR_INVALIDPARAMS;
     }
 
     // This call will never fail
@@ -618,17 +671,72 @@ namespace dxvk {
     if (unlikely(lpdwRenderState == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    // As opposed to D3D8/9, D3D7 actually validates and
-    // errors out in case of unknown/invalid render states
-    if (unlikely(!IsValidD3D7RenderStateType(dwRenderStateType)
-              && !m_commonIntf->GetOptions()->apitraceMode))
-      return DDERR_INVALIDPARAMS;
-
     d3d9::D3DRENDERSTATETYPE State9 = d3d9::D3DRENDERSTATETYPE(dwRenderStateType);
 
     switch (dwRenderStateType) {
       // Most render states translate 1:1 to D3D9
-      default:
+      //case D3DRENDERSTATE_ANTIALIAS:
+      //case D3DRENDERSTATE_TEXTUREPERSPECTIVE:
+      case D3DRENDERSTATE_ZENABLE:
+      case D3DRENDERSTATE_FILLMODE:
+      case D3DRENDERSTATE_SHADEMODE:
+      //case D3DRENDERSTATE_LINEPATTERN:
+      case D3DRENDERSTATE_ZWRITEENABLE:
+      case D3DRENDERSTATE_ALPHATESTENABLE:
+      case D3DRENDERSTATE_LASTPIXEL:
+      case D3DRENDERSTATE_SRCBLEND:
+      case D3DRENDERSTATE_DESTBLEND:
+      case D3DRENDERSTATE_CULLMODE:
+      case D3DRENDERSTATE_ZFUNC:
+      case D3DRENDERSTATE_ALPHAREF:
+      case D3DRENDERSTATE_ALPHAFUNC:
+      case D3DRENDERSTATE_DITHERENABLE:
+      case D3DRENDERSTATE_ALPHABLENDENABLE:
+      case D3DRENDERSTATE_FOGENABLE:
+      case D3DRENDERSTATE_SPECULARENABLE:
+      //case D3DRENDERSTATE_ZVISIBLE:
+      //case D3DRENDERSTATE_STIPPLEDALPHA:
+      case D3DRENDERSTATE_FOGCOLOR:
+      case D3DRENDERSTATE_FOGTABLEMODE:
+      case D3DRENDERSTATE_FOGSTART:   // same as D3DRENDERSTATE_FOGTABLESTART
+      case D3DRENDERSTATE_FOGEND:     // same as D3DRENDERSTATE_FOGTABLEEND
+      case D3DRENDERSTATE_FOGDENSITY: // same as D3DRENDERSTATE_FOGTABLEDENSITY
+      //case D3DRENDERSTATE_EDGEANTIALIAS:
+      //case D3DRENDERSTATE_COLORKEYENABLE:
+      //case D3DRENDERSTATE_ZBIAS:
+      case D3DRENDERSTATE_RANGEFOGENABLE:
+      case D3DRENDERSTATE_STENCILENABLE:
+      case D3DRENDERSTATE_STENCILFAIL:
+      case D3DRENDERSTATE_STENCILZFAIL:
+      case D3DRENDERSTATE_STENCILPASS:
+      case D3DRENDERSTATE_STENCILFUNC:
+      case D3DRENDERSTATE_STENCILREF:
+      case D3DRENDERSTATE_STENCILMASK:
+      case D3DRENDERSTATE_STENCILWRITEMASK:
+      case D3DRENDERSTATE_TEXTUREFACTOR:
+      case D3DRENDERSTATE_WRAP0:
+      case D3DRENDERSTATE_WRAP1:
+      case D3DRENDERSTATE_WRAP2:
+      case D3DRENDERSTATE_WRAP3:
+      case D3DRENDERSTATE_WRAP4:
+      case D3DRENDERSTATE_WRAP5:
+      case D3DRENDERSTATE_WRAP6:
+      case D3DRENDERSTATE_WRAP7:
+      case D3DRENDERSTATE_CLIPPING:
+      case D3DRENDERSTATE_LIGHTING:
+      //case D3DRENDERSTATE_EXTENTS:
+      case D3DRENDERSTATE_AMBIENT:
+      case D3DRENDERSTATE_FOGVERTEXMODE:
+      case D3DRENDERSTATE_COLORVERTEX:
+      case D3DRENDERSTATE_LOCALVIEWER:
+      case D3DRENDERSTATE_NORMALIZENORMALS:
+      //case D3DRENDERSTATE_COLORKEYBLENDENABLE:
+      case D3DRENDERSTATE_DIFFUSEMATERIALSOURCE:
+      case D3DRENDERSTATE_SPECULARMATERIALSOURCE:
+      case D3DRENDERSTATE_AMBIENTMATERIALSOURCE:
+      case D3DRENDERSTATE_EMISSIVEMATERIALSOURCE:
+      case D3DRENDERSTATE_VERTEXBLEND:
+      case D3DRENDERSTATE_CLIPPLANEENABLE:
         break;
 
       case D3DRENDERSTATE_ANTIALIAS:
@@ -677,6 +785,13 @@ namespace dxvk {
       case D3DRENDERSTATE_COLORKEYBLENDENABLE:
         *lpdwRenderState = m_commonD3DDevice->GetColorKeyBlendEnable();
         return D3D_OK;
+
+      // As opposed to D3D8/9, D3D7 actually validates and
+      // errors out in case of unknown/invalid render states
+      default:
+        if (likely(!m_commonIntf->GetOptions()->apitraceMode))
+          return DDERR_INVALIDPARAMS;
+        break;
     }
 
     // This call will never fail
@@ -855,9 +970,9 @@ namespace dxvk {
     if (unlikely(lpvVertices == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
-
     DDrawDirtySurfaceUpload();
+
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     device9->SetFVF(dwVertexTypeDesc);
     HRESULT hr = device9->DrawPrimitiveUP(
@@ -871,7 +986,7 @@ namespace dxvk {
       return hr;
     }
 
-    UpdateSurfaceDirtyTracking(true, true, true);
+    UpdateSurfaceDirtyTracking(true, m_commonD3DDevice->IsDepthWriteEnabled(), true);
 
     return D3D_OK;
   }
@@ -887,9 +1002,9 @@ namespace dxvk {
     if (unlikely(lpvVertices == nullptr || lpwIndices == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
-
     DDrawDirtySurfaceUpload();
+
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     device9->SetFVF(dwVertexTypeDesc);
     HRESULT hr = device9->DrawIndexedPrimitiveUP(
@@ -907,7 +1022,7 @@ namespace dxvk {
       return hr;
     }
 
-    UpdateSurfaceDirtyTracking(true, true, true);
+    UpdateSurfaceDirtyTracking(true, m_commonD3DDevice->IsDepthWriteEnabled(), true);
 
     return D3D_OK;
   }
@@ -949,9 +1064,9 @@ namespace dxvk {
     if (unlikely(lpVertexArray == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
-
     DDrawDirtySurfaceUpload();
+
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     // Transform strided vertex data to a standard vertex buffer stream
     PackedVertexBuffer pvb = TransformStridedtoUP(dwVertexTypeDesc, lpVertexArray, dwVertexCount);
@@ -968,7 +1083,7 @@ namespace dxvk {
       return hr;
     }
 
-    UpdateSurfaceDirtyTracking(true, true, true);
+    UpdateSurfaceDirtyTracking(true, m_commonD3DDevice->IsDepthWriteEnabled(), true);
 
     return D3D_OK;
   }
@@ -984,9 +1099,9 @@ namespace dxvk {
     if (unlikely(lpVertexArray == nullptr || lpwIndices == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
-
     DDrawDirtySurfaceUpload();
+
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     // Transform strided vertex data to a standard vertex buffer stream
     PackedVertexBuffer pvb = TransformStridedtoUP(dwVertexTypeDesc, lpVertexArray, dwVertexCount);
@@ -1007,7 +1122,7 @@ namespace dxvk {
       return hr;
     }
 
-    UpdateSurfaceDirtyTracking(true, true, true);
+    UpdateSurfaceDirtyTracking(true, m_commonD3DDevice->IsDepthWriteEnabled(), true);
 
     return D3D_OK;
   }
@@ -1023,30 +1138,35 @@ namespace dxvk {
     if (unlikely(lpd3dVertexBuffer == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    Com<D3D7VertexBuffer> vb = static_cast<D3D7VertexBuffer*>(lpd3dVertexBuffer);
+    Com<D3D7VertexBuffer> vb7 = static_cast<D3D7VertexBuffer*>(lpd3dVertexBuffer);
 
-    if (unlikely(vb->IsLocked())) {
+    if (unlikely(vb7->GetDevice() != this)) {
+      Logger::err("D3D7Device::DrawPrimitiveVB: Invalid vertex buffer parent device");
+      return DDERR_GENERIC;
+    }
+
+    if (unlikely(vb7->IsLocked())) {
       Logger::err("D3D7Device::DrawPrimitiveVB: Buffer is locked");
       return D3DERR_VERTEXBUFFERLOCKED;
     }
 
-    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
-
     DDrawDirtySurfaceUpload();
 
-    device9->SetFVF(vb->GetFVF());
-    device9->SetStreamSource(0, vb->GetD3D9VertexBuffer(), 0, vb->GetStride());
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
+    device9->SetFVF(vb7->GetFVF());
+    device9->SetStreamSource(0, vb7->GetD3D9VertexBuffer(), 0, vb7->GetStride());
     HRESULT hr = device9->DrawPrimitive(
-                           d3d9::D3DPRIMITIVETYPE(d3dptPrimitiveType),
-                           dwStartVertex,
-                           GetPrimitiveCount(d3dptPrimitiveType, dwNumVertices));
+                      d3d9::D3DPRIMITIVETYPE(d3dptPrimitiveType),
+                      dwStartVertex,
+                      GetPrimitiveCount(d3dptPrimitiveType, dwNumVertices));
 
     if (unlikely(FAILED(hr))) {
       Logger::err("D3D7Device::DrawPrimitiveVB: Failed D3D9 call to DrawPrimitive");
       return hr;
     }
 
-    UpdateSurfaceDirtyTracking(true, true, true);
+    UpdateSurfaceDirtyTracking(true, m_commonD3DDevice->IsDepthWriteEnabled(), true);
 
     return D3D_OK;
   }
@@ -1062,48 +1182,59 @@ namespace dxvk {
     if (unlikely(lpd3dVertexBuffer == nullptr || lpwIndices == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    Com<D3D7VertexBuffer> vb = static_cast<D3D7VertexBuffer*>(lpd3dVertexBuffer);
+    Com<D3D7VertexBuffer> vb7 = static_cast<D3D7VertexBuffer*>(lpd3dVertexBuffer);
 
-    if (unlikely(vb->IsLocked())) {
+    if (unlikely(vb7->GetDevice() != this)) {
+      Logger::err("D3D7Device::DrawIndexedPrimitiveVB: Invalid vertex buffer parent device");
+      return DDERR_GENERIC;
+    }
+
+    if (unlikely(vb7->IsLocked())) {
       Logger::err("D3D7Device::DrawIndexedPrimitiveVB: Buffer is locked");
       return D3DERR_VERTEXBUFFERLOCKED;
     }
 
-    uint8_t ibIndex = 0;
-    // Fit index buffer uploads into the smallest buffer size possible
-    while (dwIndexCount > ddrawCaps::IndexCount[ibIndex]) {
-      ibIndex++;
-      if (unlikely(ibIndex > ddrawCaps::IndexBufferCount - 1)) {
-        Logger::err("D3D7Device::DrawIndexedPrimitiveVB: Exceeded size of largest index buffer");
-        return DDERR_UNSUPPORTED;
-      }
+    if (unlikely(dwIndexCount > ddrawCaps::MaxIndexCount)) {
+      Logger::err("D3D7Device::DrawIndexedPrimitiveVB: Exceeded size of largest index buffer");
+      return DDERR_UNSUPPORTED;
     }
-
-    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     DDrawDirtySurfaceUpload();
 
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
+    uint8_t ibIndex = 0;
+    // Fit index buffer uploads into the smallest buffer size possible
+    while (dwIndexCount > ddrawCaps::IndexCount[ibIndex])
+      ibIndex++;
+
     d3d9::IDirect3DIndexBuffer9* ib9 = m_ib9[ibIndex].ptr();
 
-    UploadIndices(ib9, lpwIndices, dwIndexCount);
-    m_ib9_uploads[ibIndex]++;
+    const size_t ibSize = dwIndexCount * sizeof(WORD);
+    void* pData = nullptr;
+
+    // Locking and unlocking are generally expected to work here
+    ib9->Lock(0, ibSize, &pData, D3DLOCK_DISCARD);
+    memcpy(pData, static_cast<void*>(lpwIndices), ibSize);
+    ib9->Unlock();
+
     device9->SetIndices(ib9);
-    device9->SetFVF(vb->GetFVF());
-    device9->SetStreamSource(0, vb->GetD3D9VertexBuffer(), 0, vb->GetStride());
+    device9->SetFVF(vb7->GetFVF());
+    device9->SetStreamSource(0, vb7->GetD3D9VertexBuffer(), 0, vb7->GetStride());
     HRESULT hr = device9->DrawIndexedPrimitive(
-                    d3d9::D3DPRIMITIVETYPE(d3dptPrimitiveType),
-                    dwStartVertex,
-                    0,
-                    dwNumVertices,
-                    0,
-                    GetPrimitiveCount(d3dptPrimitiveType, dwIndexCount));
+                      d3d9::D3DPRIMITIVETYPE(d3dptPrimitiveType),
+                      dwStartVertex,
+                      0,
+                      dwNumVertices,
+                      0,
+                      GetPrimitiveCount(d3dptPrimitiveType, dwIndexCount));
 
     if (unlikely(FAILED(hr))) {
       Logger::err("D3D7Device::DrawIndexedPrimitiveVB: Failed D3D9 call to DrawIndexedPrimitive");
       return hr;
     }
 
-    UpdateSurfaceDirtyTracking(true, true, true);
+    UpdateSurfaceDirtyTracking(true, m_commonD3DDevice->IsDepthWriteEnabled(), true);
 
     return D3D_OK;
   }
@@ -1179,10 +1310,12 @@ namespace dxvk {
 
     DDraw7Surface* surface7 = static_cast<DDraw7Surface*>(surface);
 
+    DDrawCommonSurface* commonSurface = surface7->GetCommonSurface();
+
     // If textures have been used on a different device, they
     // will get their D3D9 object reinitialized at this point
-    if (unlikely(surface7->GetCommonSurface()->GetCommonD3DDevice() != m_commonD3DDevice.ptr()))
-      surface7->GetCommonSurface()->DirtyDDrawSurface();
+    if (unlikely(commonSurface->GetCommonD3DDevice() != m_commonD3DDevice.ptr()))
+      commonSurface->DirtyDDrawSurface();
 
     hr = surface7->InitializeOrUploadD3D9();
     if (unlikely(FAILED(hr))) {
@@ -1194,8 +1327,8 @@ namespace dxvk {
     //if (unlikely(m_textures[stage] == surface7))
       //return D3D_OK;
 
-    d3d9::IDirect3DTexture9*     tex9  = surface7->GetCommonSurface()->GetD3D9Texture();
-    d3d9::IDirect3DCubeTexture9* cube9 = surface7->GetCommonSurface()->GetD3D9CubeTexture();
+    d3d9::IDirect3DTexture9*     tex9  = commonSurface->GetD3D9Texture();
+    d3d9::IDirect3DCubeTexture9* cube9 = commonSurface->GetD3D9CubeTexture();
 
     if (likely(tex9 != nullptr)) {
       hr = device9->SetTexture(stage, tex9);
@@ -1206,10 +1339,10 @@ namespace dxvk {
 
       if (likely(stage == 0)) {
         const bool colorKeyEnable = m_commonD3DDevice->GetColorKeyEnable();
-        const bool validColorKey = surface7->GetCommonSurface()->HasValidColorKey();
+        const bool validColorKey = commonSurface->HasValidColorKey();
         m_bridge->SetColorKeyState(colorKeyEnable && validColorKey);
         if (colorKeyEnable && validColorKey) {
-          DDCOLORKEY normalizedColorKey = surface7->GetCommonSurface()->GetColorKeyNormalized();
+          DDCOLORKEY normalizedColorKey = commonSurface->GetColorKeyNormalized();
           m_bridge->SetColorKey(normalizedColorKey.dwColorSpaceLowValue,
                                 normalizedColorKey.dwColorSpaceHighValue);
         }
@@ -1223,7 +1356,7 @@ namespace dxvk {
 
       if (likely(stage == 0)) {
         const bool colorKeyEnable = m_commonD3DDevice->GetColorKeyEnable();
-        const bool validColorKey = surface7->GetCommonSurface()->HasValidColorKey();
+        const bool validColorKey = commonSurface->HasValidColorKey();
         if (unlikely(colorKeyEnable && validColorKey))
           Logger::warn("D3D7Device::SetTexture: Unsupported use of cube texture color key");
       }
@@ -1253,9 +1386,8 @@ namespace dxvk {
     // If the type has been remapped to a sampler state type
     if (stateType != -1u) {
       // MAG/MIN/MIP filter enums are each different than the unified D3D9 D3DTEXTUREFILTERTYPE
-      if (stateType == d3d9::D3DSAMP_MAGFILTER ||
-          stateType == d3d9::D3DSAMP_MINFILTER || stateType == d3d9::D3DSAMP_MIPFILTER) {
-        DWORD dwStateProxy9 = 0;
+      if (stateType == d3d9::D3DSAMP_MAGFILTER || stateType == d3d9::D3DSAMP_MINFILTER || stateType == d3d9::D3DSAMP_MIPFILTER) {
+        DWORD dwStateProxy9;
 
         HRESULT hr = device9->GetSamplerState(dwStage, stateType, &dwStateProxy9);
         if (unlikely(FAILED(hr)))
@@ -1287,8 +1419,7 @@ namespace dxvk {
     // If the type has been remapped to a sampler state type
     if (stateType != -1u) {
       // MAG/MIN/MIP filter enums are each different than the unified D3D9 D3DTEXTUREFILTERTYPE
-      if (stateType == d3d9::D3DSAMP_MAGFILTER ||
-          stateType == d3d9::D3DSAMP_MINFILTER || stateType == d3d9::D3DSAMP_MIPFILTER) {
+      if (stateType == d3d9::D3DSAMP_MAGFILTER || stateType == d3d9::D3DSAMP_MINFILTER || stateType == d3d9::D3DSAMP_MIPFILTER) {
         const DWORD dwState9 = DecodeD3D7TexFilterValues(d3dTexStageStateType, dwState);
         return device9->SetSamplerState(dwStage, stateType, dwState9);
       } else {
@@ -1315,27 +1446,27 @@ namespace dxvk {
     DDraw7Surface* ddraw7SurfaceSrc = nullptr;
     DDraw7Surface* ddraw7SurfaceDst = nullptr;
 
-    RECT* sourceFullSurfaceRect = nullptr;
-    if (likely(DDrawCommonInterface::IsWrappedSurface(src_surface))) {
-      ddraw7SurfaceSrc = static_cast<DDraw7Surface*>(src_surface);
-      ddraw7SurfaceSrc->DownloadSurfaceData();
-      sourceFullSurfaceRect = ddraw7SurfaceSrc->GetCommonSurface()->GetFullSurfaceRect();
-    } else {
+    if (unlikely(!DDrawCommonInterface::IsWrappedSurface(src_surface))) {
       Logger::err("D3D7Device::Load: Unwrapped surface source");
       return DDERR_UNSUPPORTED;
     }
 
-    if (likely(DDrawCommonInterface::IsWrappedSurface(dst_surface))) {
-      ddraw7SurfaceDst = static_cast<DDraw7Surface*>(dst_surface);
-      if ((dst_point == nullptr || (dst_point->x == 0 && dst_point->y == 0)) &&
-          ddraw7SurfaceDst->GetCommonSurface()->IsFullSurfaceLock(src_rect, sourceFullSurfaceRect)) {
-        ddraw7SurfaceDst->GetCommonSurface()->UnDirtyD3D9Surface();
-      } else {
-        ddraw7SurfaceDst->DownloadSurfaceData();
-      }
-    } else {
+    const RECT* sourceFullSurfaceRect = nullptr;
+    ddraw7SurfaceSrc = static_cast<DDraw7Surface*>(src_surface);
+    ddraw7SurfaceSrc->DownloadSurfaceData();
+    sourceFullSurfaceRect = ddraw7SurfaceSrc->GetCommonSurface()->GetFullSurfaceRect();
+
+    if (unlikely(!DDrawCommonInterface::IsWrappedSurface(dst_surface))) {
       Logger::err("D3D7Device::Load: Unwrapped surface destination");
       return DDERR_UNSUPPORTED;
+    }
+
+    ddraw7SurfaceDst = static_cast<DDraw7Surface*>(dst_surface);
+    if ((dst_point == nullptr || (dst_point->x == 0 && dst_point->y == 0)) &&
+        ddraw7SurfaceDst->GetCommonSurface()->IsFullSurfaceLock(src_rect, sourceFullSurfaceRect)) {
+      ddraw7SurfaceDst->GetCommonSurface()->UnDirtyD3D9Surface();
+    } else {
+      ddraw7SurfaceDst->DownloadSurfaceData();
     }
 
     HRESULT hr = m_proxy->Load(ddraw7SurfaceDst->GetProxied(), dst_point,
@@ -1344,7 +1475,7 @@ namespace dxvk {
       return hr;
 
     DDrawCommonSurface* dstCommonSurf = ddraw7SurfaceDst->GetCommonSurface();
-    hr = dstCommonSurf->RefreshSurfaceDescripton();
+    hr = dstCommonSurf->RefreshSurfaceDescripton(true);
     if (unlikely(FAILED(hr))) {
       Logger::err("D3D7Device::Load: Failed to refresh surface description");
       return hr;
@@ -1376,8 +1507,7 @@ namespace dxvk {
 
     m_lightsStates[dwLightIndex] = bEnable;
     // Store a default light if the light cache doesn't contain one
-    if (unlikely(m_lights.find(dwLightIndex) == m_lights.end()))
-      m_lights[dwLightIndex] = DefaultLight;
+    m_lights.try_emplace(dwLightIndex, DefaultLight);
 
     return D3D_OK;
   }
@@ -1406,39 +1536,43 @@ namespace dxvk {
     return S_FALSE;
   }
 
-  void D3D7Device::InitializeDS() {
-    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
-
-    m_rt->InitializeD3D9RenderTarget();
+  HRESULT D3D7Device::InitializeRTAndDS() {
+    HRESULT hr = m_rt->InitializeD3D9RenderTarget();
+    if (unlikely(FAILED(hr)))
+      return hr;
 
     m_ds = m_rt->GetAttachedDepthStencil();
 
-    if (m_ds != nullptr) {
-      HRESULT hrDS = m_ds->InitializeD3D9DepthStencil();
-      if (unlikely(FAILED(hrDS))) {
-        Logger::err("D3D7Device::InitializeDS: Failed to initialize D3D9 DS");
-      } else {
-        const RECT* dsRect = m_ds->GetCommonSurface()->GetFullSurfaceRect();
-        Logger::info(str::format("D3D7Device::InitializeDS: Depth stencil: ", dsRect->right, "x", dsRect->bottom));
+    if (likely(m_ds != nullptr)) {
+      hr = m_ds->InitializeD3D9DepthStencil();
+      if (unlikely(FAILED(hr)))
+        return hr;
 
-        HRESULT hrDS9 = device9->SetDepthStencilSurface(m_ds->GetCommonSurface()->GetD3D9Surface());
-        if (unlikely(FAILED(hrDS9))) {
-          Logger::err("D3D7Device::InitializeDS: Failed to set D3D9 depth stencil");
-        } else {
-          // This needs to act like an auto depth stencil of sorts, so manually enable z-buffering
-          device9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_TRUE);
-        }
+      const RECT* dsRect = m_ds->GetCommonSurface()->GetFullSurfaceRect();
+      Logger::info(str::format("D3D7Device: Depth stencil: ", dsRect->right, "x", dsRect->bottom));
+
+      d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+
+      hr = device9->SetDepthStencilSurface(m_ds->GetCommonSurface()->GetD3D9Surface());
+      if (unlikely(FAILED(hr))) {
+        Logger::err("D3D7Device: Failed to set D3D9 depth stencil");
+        return hr;
       }
-    } else {
-      device9->SetDepthStencilSurface(nullptr);
-      // Should be superfluous, but play it safe
-      device9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_FALSE);
+
+      // "The default value for this render state is D3DZB_TRUE if a depth buffer
+      //  is attached to the render-target surface, and D3DZB_FALSE otherwise."
+      device9->SetRenderState(d3d9::D3DRS_ZENABLE, d3d9::D3DZB_TRUE);
     }
+
+    return D3D_OK;
   }
 
   void D3D7Device::UpdateSurfaceDirtyTracking(bool dirtyRenderTarget, bool dirtyDepthStencil, bool dirtyPrimarySurface) {
     if (likely(dirtyRenderTarget))
       m_rt->GetCommonSurface()->DirtyD3D9Surface();
+
+    if (likely(dirtyDepthStencil && m_ds != nullptr))
+      m_ds->GetCommonSurface()->DirtyD3D9Surface();
 
     if (likely(dirtyPrimarySurface)) {
       DDrawCommonSurface* primarySurface = m_commonIntf->GetPrimarySurface();
@@ -1447,9 +1581,6 @@ namespace dxvk {
       if (likely(primarySurface != nullptr))
         primarySurface->DirtyD3D9Surface();
     }
-
-    if (likely(dirtyDepthStencil && m_ds != nullptr))
-      m_ds->GetCommonSurface()->DirtyD3D9Surface();
   }
 
   HRESULT D3D7Device::ResetD3D9Swapchain(d3d9::D3DPRESENT_PARAMETERS* params) {
@@ -1461,15 +1592,19 @@ namespace dxvk {
       return hr;
     }
 
-    m_rt->GetCommonSurface()->SetD3D9Surface(nullptr);
-    m_rt->GetCommonSurface()->UnDirtyD3D9Surface();
+    DDrawCommonSurface* commonSurface = m_rt->GetCommonSurface();
+    commonSurface->ResetD3D9Objects();
+    // Ensure the DDraw surface content gets re-uploaded if needed
+    commonSurface->DirtyDDrawSurface();
 
     // Reset the D3D9 objects for all the following surfaces in the swapchain
     DDraw7Surface* nextFlippable = m_rt->GetNextFlippable();
 
     while (nextFlippable != nullptr) {
-      nextFlippable->GetCommonSurface()->SetD3D9Surface(nullptr);
-      nextFlippable->GetCommonSurface()->UnDirtyD3D9Surface();
+      commonSurface = nextFlippable->GetCommonSurface();
+      commonSurface->ResetD3D9Objects();
+      // Ensure the DDraw surface content gets re-uploaded if needed
+      commonSurface->DirtyDDrawSurface();
 
       nextFlippable = nextFlippable->GetNextFlippable();
     }
@@ -1478,8 +1613,10 @@ namespace dxvk {
     DDraw7Surface* parentSurf = m_rt->GetParentSurface();
 
     while (parentSurf != nullptr) {
-      parentSurf->GetCommonSurface()->SetD3D9Surface(nullptr);
-      parentSurf->GetCommonSurface()->UnDirtyD3D9Surface();
+      commonSurface = parentSurf->GetCommonSurface();
+      commonSurface->ResetD3D9Objects();
+      // Ensure the DDraw surface content gets re-uploaded if needed
+      commonSurface->DirtyDDrawSurface();
 
       parentSurf = parentSurf->GetParentSurface();
     }
@@ -1488,35 +1625,6 @@ namespace dxvk {
     // so there's no need to worry about it in this case
 
     return D3D_OK;
-  }
-
-  inline HRESULT D3D7Device::InitializeIndexBuffers() {
-    static constexpr DWORD Usage = D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY;
-
-    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
-
-    for (uint8_t ibIndex = 0; ibIndex < ddrawCaps::IndexBufferCount ; ibIndex++) {
-      const UINT ibSize = ddrawCaps::IndexCount[ibIndex] * sizeof(WORD);
-
-      Logger::debug(str::format("D3D7Device::InitializeIndexBuffer: Creating D3D9 index buffer, size: ", ibSize));
-
-      HRESULT hr = device9->CreateIndexBuffer(ibSize, Usage, d3d9::D3DFMT_INDEX16,
-                                              d3d9::D3DPOOL_DEFAULT, &m_ib9[ibIndex], nullptr);
-      if (unlikely(FAILED(hr)))
-        return hr;
-    }
-
-    return D3D_OK;
-  }
-
-  inline void D3D7Device::UploadIndices(d3d9::IDirect3DIndexBuffer9* ib9, WORD* indices, DWORD indexCount) {
-    const size_t size = indexCount * sizeof(WORD);
-    void* pData = nullptr;
-
-    // Locking and unlocking are generally expected to work here
-    ib9->Lock(0, size, &pData, D3DLOCK_DISCARD);
-    memcpy(pData, static_cast<void*>(indices), size);
-    ib9->Unlock();
   }
 
   inline void D3D7Device::DDrawDirtySurfaceUpload() {

--- a/src/ddraw/d3d7/d3d7_device.h
+++ b/src/ddraw/d3d7/d3d7_device.h
@@ -139,7 +139,7 @@ namespace dxvk {
 
     HRESULT STDMETHODCALLTYPE GetInfo(DWORD info_id, void *info, DWORD info_size);
 
-    void InitializeDS();
+    HRESULT InitializeRTAndDS();
 
     void UpdateSurfaceDirtyTracking(bool dirtyRenderTarget, bool dirtyDepthStencil, bool dirtyPrimarySurface);
 
@@ -161,7 +161,7 @@ namespace dxvk {
       return m_ds.ptr();
     }
 
-    void GetD3D9Lights(std::vector<d3d9::D3DLIGHT9>* lights9) {
+    void GetD3D9ActiveLights(std::vector<d3d9::D3DLIGHT9>* lights9) {
       for (const auto& [idx, light9] : m_lights) {
         if (m_lightsStates[idx])
           lights9->push_back(light9);
@@ -170,19 +170,7 @@ namespace dxvk {
 
   private:
 
-    inline HRESULT InitializeIndexBuffers();
-
-    inline void UploadIndices(d3d9::IDirect3DIndexBuffer9* ib9, WORD* indices, DWORD indexCount);
-
     inline void DDrawDirtySurfaceUpload();
-
-    inline bool LogIndexBufferUsageStats() const {
-      for (uint32_t m_ib9_upload : m_ib9_uploads) {
-        if (m_ib9_upload > 0)
-          return true;
-      }
-      return false;
-    }
 
     inline bool ShouldRecord() const { return m_recorder != nullptr; }
 
@@ -191,34 +179,30 @@ namespace dxvk {
         m_commonIntf->SetCommonD3DDevice(m_commonD3DDevice.ptr());
     }
 
-    Com<D3DCommonDevice>        m_commonD3DDevice;
+    Com<D3DCommonDevice>            m_commonD3DDevice;
 
-    DDrawCommonInterface*       m_commonIntf            = nullptr;
+    DDrawCommonInterface*           m_commonIntf            = nullptr;
 
-    Com<DxvkD3D8Bridge>         m_bridge;
+    Com<IDxvkLegacyD3DDeviceBridge> m_bridge;
 
-    D3DMultithread              m_multithread;
+    D3DMultithread                  m_multithread;
 
-    D3DDEVICEDESC7              m_desc;
+    D3DDEVICEDESC7                  m_desc;
 
-    Com<DDraw7Surface>          m_rt;
-    Com<DDraw7Surface, false>   m_ds;
+    Com<DDraw7Surface>              m_rt;
+    Com<DDraw7Surface, false>       m_ds;
 
     std::array<Com<DDraw7Surface, false>, ddrawCaps::TextureStageCount> m_textures;
 
     std::unordered_map<DWORD, d3d9::D3DLIGHT9> m_lights;
     std::unordered_map<DWORD, BOOL>            m_lightsStates;
 
-    D3D7StateBlock*             m_recorder              = nullptr;
-    DWORD                       m_recorderHandle        = 0;
-    DWORD                       m_handle                = 0;
+    D3D7StateBlock*                 m_recorder              = nullptr;
+    DWORD                           m_recorderHandle        = 0;
+    DWORD                           m_handle                = 0;
     std::unordered_map<DWORD, D3D7StateBlock> m_stateBlocks;
 
     std::array<Com<d3d9::IDirect3DIndexBuffer9>, ddrawCaps::IndexBufferCount> m_ib9;
-    uint32_t m_ib9_uploads[ddrawCaps::IndexBufferCount] = { };
-
-    uint32_t                    m_deviceCount           = 0;
-    static std::atomic<uint32_t> s_deviceCount;
 
   };
 

--- a/src/ddraw/d3d7/d3d7_interface.cpp
+++ b/src/ddraw/d3d7/d3d7_interface.cpp
@@ -10,8 +10,6 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> D3D7Interface::s_intfCount = 0;
-
   D3D7Interface::D3D7Interface(
         D3DCommonInterface* commonD3DIntf,
         DDrawCommonInterface* commonIntf,
@@ -20,34 +18,28 @@ namespace dxvk {
     : DDrawWrappedObject<IUnknown, IDirect3D7>(pParent, std::move(d3d7IntfProxy))
     , m_commonD3DIntf ( commonD3DIntf )
     , m_commonIntf ( commonIntf ) {
-    if (m_commonD3DIntf == nullptr) {
+    if (m_commonD3DIntf == nullptr)
       m_commonD3DIntf = new D3DCommonInterface();
 
-      Com<d3d9::IDirect3D9> d3d9Intf = d3d9::Direct3DCreate9(D3D_SDK_VERSION);
-      m_commonD3DIntf->SetD3D9Interface(std::move(d3d9Intf));
-    }
+    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
+    // Retrieve and cache the base capabilities
+    m_desc = GetD3D7BaseCaps(d3dOptions);
 
     d3d9::IDirect3D9* d3d9Intf = m_commonD3DIntf->GetD3D9Interface();
 
     // Get the bridge interface to D3D9
-    if (unlikely(FAILED(d3d9Intf->QueryInterface(__uuidof(IDxvkD3D8InterfaceBridge), reinterpret_cast<void**>(&m_bridge))))) {
+    if (unlikely(FAILED(d3d9Intf->QueryInterface(__uuidof(IDxvkLegacyD3DInterfaceBridge), reinterpret_cast<void**>(&m_bridge))))) {
       throw DxvkError("D3D7Interface: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
     }
 
     m_commonD3DIntf->SetD3D7Interface(this);
 
-    m_bridge->EnableD3D7CompatibilityMode();
-
-    m_intfCount = ++s_intfCount;
-
-    Logger::debug(str::format("D3D7Interface: Created a new interface nr. ((7-", m_intfCount, "))"));
+    m_bridge->SetD3DCompatibility(D3DCompatibility::D3D7);
   }
 
   D3D7Interface::~D3D7Interface() {
     if (m_commonD3DIntf->GetD3D7Interface() == this)
       m_commonD3DIntf->SetD3D7Interface(nullptr);
-
-    Logger::debug(str::format("D3D7Interface: Interface nr. ((7-", m_intfCount, ")) bites the dust"));
   }
 
   // Interlocked refcount with the parent IDirectDraw7
@@ -119,7 +111,8 @@ namespace dxvk {
     HRESULT hr;
 
     // Software emulation, this is expected to be exposed
-    D3DDEVICEDESC7 desc7RGB = GetD3D7Caps(IID_IDirect3DRGBDevice, d3dOptions);
+    D3DDEVICEDESC7 desc7RGB = m_desc;
+    ApplyD3D7DeviceCaps(&desc7RGB, IID_IDirect3DRGBDevice);
     if (likely(!d3dOptions->legacyDeviceNames)) {
       static char deviceDescRGB[100] = "D7VK RGB";
       static char deviceNameRGB[100] = "D7VK RGB";
@@ -133,7 +126,8 @@ namespace dxvk {
       return D3D_OK;
 
     // Hardware acceleration (no T&L)
-    D3DDEVICEDESC7 desc7HAL = GetD3D7Caps(IID_IDirect3DHALDevice, d3dOptions);
+    D3DDEVICEDESC7 desc7HAL = m_desc;
+    ApplyD3D7DeviceCaps(&desc7HAL, IID_IDirect3DHALDevice);
     if (likely(!d3dOptions->legacyDeviceNames)) {
       static char deviceDescHAL[100] = "D7VK HAL";
       static char deviceNameHAL[100] = "D7VK HAL";
@@ -147,7 +141,8 @@ namespace dxvk {
       return D3D_OK;
 
     // Hardware acceleration with T&L
-    D3DDEVICEDESC7 desc7TNL = GetD3D7Caps(IID_IDirect3DTnLHalDevice, d3dOptions);
+    D3DDEVICEDESC7 desc7TNL = m_desc;
+    ApplyD3D7DeviceCaps(&desc7TNL, IID_IDirect3DTnLHalDevice);
     if (likely(!d3dOptions->legacyDeviceNames)) {
       static char deviceDescTNL[100] = "D7VK T&L HAL";
       static char deviceNameTNL[100] = "D7VK T&L HAL";
@@ -277,14 +272,12 @@ namespace dxvk {
 
     Logger::info(str::format("D3D7Interface::CreateDevice: Back buffer size: ", desc.dwWidth, "x", desc.dwHeight));
 
-    const DWORD backBufferCount = DetermineBackBufferCount(rt7->GetProxied());
+    const DWORD backBufferCount = DetermineBackBufferCount<IDirectDrawSurface7>(rt7->GetProxied());
     Logger::info(str::format("D3D7Interface::CreateDevice: Back buffer count: ", backBufferCount));
-
-    Com<d3d9::IDirect3D9> d3d9Intf = m_commonD3DIntf->GetD3D9Interface();
 
     // Determine the supported AA sample count by querying the D3D9 interface
     const d3d9::D3DMULTISAMPLE_TYPE multiSampleType = d3dOptions->emulateFSAA != FSAAEmulation::Disabled ?
-                                                      GetSupportedMultiSampleType(d3d9Intf.ptr(), backBufferFormat) :
+                                                      m_commonD3DIntf->GetMultiSampleType(backBufferFormat) :
                                                       d3d9::D3DMULTISAMPLE_NONE;
 
     // Always appears to be enabled when running in non-exclusive mode
@@ -307,7 +300,7 @@ namespace dxvk {
     params.PresentationInterval       = vBlankStatus ? D3DPRESENT_INTERVAL_DEFAULT : D3DPRESENT_INTERVAL_IMMEDIATE;
 
     Com<d3d9::IDirect3DDevice9> device9;
-    hr = d3d9Intf->CreateDevice(
+    hr = m_commonD3DIntf->GetD3D9Interface()->CreateDevice(
       D3DADAPTER_DEFAULT,
       d3d9::D3DDEVTYPE_HAL,
       hWnd,
@@ -328,8 +321,11 @@ namespace dxvk {
 
       // Set the common device on the common interface
       m_commonIntf->SetCommonD3DDevice(device7->GetCommonD3DDevice());
-      // Now that we have a valid D3D9 device pointer, we can initialize the depth stencil (if any)
-      device7->InitializeDS();
+      // Now that we have a valid common D3D device on the DDraw interface,
+      // we can initialize the render target and depth stencil (if any)
+      hr = device7->InitializeRTAndDS();
+      if (unlikely(FAILED(hr)))
+        return hr;
 
       *ppd3dDevice = device7.ref();
     } catch (const DxvkError& e) {
@@ -413,33 +409,6 @@ namespace dxvk {
     }
 
     return D3D_OK;
-  }
-
-  inline DWORD D3D7Interface::DetermineBackBufferCount(IDirectDrawSurface7* renderTarget) {
-    DWORD backBufferCount = 0;
-
-    IDirectDrawSurface7* backBuffer = renderTarget;
-    HRESULT hr;
-
-    while (backBuffer != nullptr) {
-      IDirectDrawSurface7* parentSurface = backBuffer;
-      backBuffer = nullptr;
-
-      hr = parentSurface->EnumAttachedSurfaces(&backBuffer, ListBackBufferSurfaces7Callback);
-      if (unlikely(FAILED(hr))) {
-        Logger::warn("D3D7Interface::DetermineBackBufferCount: Unable to enumerate attached surfaces");
-        break;
-      }
-
-      // The swapchain will eventually return to its origin
-      if (backBuffer == renderTarget)
-        break;
-
-      if (likely(backBuffer != nullptr))
-        backBufferCount++;
-    }
-
-    return std::max<DWORD>(1u, backBufferCount);
   }
 
 }

--- a/src/ddraw/d3d7/d3d7_interface.h
+++ b/src/ddraw/d3d7/d3d7_interface.h
@@ -52,16 +52,13 @@ namespace dxvk {
 
   private:
 
-    inline DWORD DetermineBackBufferCount(IDirectDrawSurface7* renderTarget);
+    Com<IDxvkLegacyD3DInterfaceBridge> m_bridge;
 
-    Com<IDxvkD3D8InterfaceBridge> m_bridge;
+    Com<D3DCommonInterface>            m_commonD3DIntf;
 
-    Com<D3DCommonInterface>       m_commonD3DIntf;
+    DDrawCommonInterface*              m_commonIntf = nullptr;
 
-    DDrawCommonInterface*         m_commonIntf = nullptr;
-
-    uint32_t                      m_intfCount  = 0;
-    static std::atomic<uint32_t>  s_intfCount;
+    D3DDEVICEDESC7                     m_desc;
 
   };
 

--- a/src/ddraw/d3d_common_device.cpp
+++ b/src/ddraw/d3d_common_device.cpp
@@ -46,13 +46,13 @@ namespace dxvk {
     return nullptr;
   }
 
+  // D3D5/3 has no way of disabling/re-enabling VSync, so skip the D3D5/3 devices
   HRESULT D3DCommonDevice::ResetD3D9Swapchain(d3d9::D3DPRESENT_PARAMETERS* params) {
     if (m_device7 != nullptr) {
       return m_device7->ResetD3D9Swapchain(params);
     } else if (m_device6 != nullptr) {
       return m_device6->ResetD3D9Swapchain(params);
     }
-    // D3D5/3 has no way of disabling/re-enabling VSync
 
     return DDERR_UNSUPPORTED;
   }
@@ -70,11 +70,58 @@ namespace dxvk {
     return m_device7 != nullptr ? m_device7->GetRenderTarget() : nullptr;
   }
 
+  // Only needed by D3D6 and earlier viewports, so skip the D3D7 device
+  DDrawCommonSurface* D3DCommonDevice::GetCommonRenderTarget() const {
+    if (m_device6 != nullptr) {
+      DDraw4Surface* rt = m_device6->GetRenderTarget();
+      return rt != nullptr ? rt->GetCommonSurface() : nullptr;
+    }
+    if (m_device5 != nullptr) {
+      DDrawSurface* rt = m_device5->GetRenderTarget();
+      return rt != nullptr ? rt->GetCommonSurface() : nullptr;
+    }
+    if (m_device3 != nullptr) {
+      DDrawSurface* rt = m_device3->GetRenderTarget();
+      return rt != nullptr ? rt->GetCommonSurface() : nullptr;
+    }
+
+    return nullptr;
+  }
+
+  // Only needed by D3D6 and earlier viewports, so skip the D3D7 device
+  DDrawCommonSurface* D3DCommonDevice::GetCommonDepthStencil() const {
+    if (m_device6 != nullptr) {
+      DDraw4Surface* ds = m_device6->GetDepthStencil();
+      return ds != nullptr ? ds->GetCommonSurface() : nullptr;
+    }
+    if (m_device5 != nullptr) {
+      DDrawSurface* ds = m_device5->GetDepthStencil();
+      return ds != nullptr ? ds->GetCommonSurface() : nullptr;
+    }
+    if (m_device3 != nullptr) {
+      DDrawSurface* ds = m_device3->GetDepthStencil();
+      return ds != nullptr ? ds->GetCommonSurface() : nullptr;
+    }
+
+    return nullptr;
+  }
+
   bool D3DCommonDevice::IsCurrentRenderTarget(DDrawCommonSurface* commonSurface) const {
     return m_device7 != nullptr ? m_device7->GetRenderTarget()->GetCommonSurface() == commonSurface :
            m_device6 != nullptr ? m_device6->GetRenderTarget()->GetCommonSurface() == commonSurface :
            m_device5 != nullptr ? m_device5->GetRenderTarget()->GetCommonSurface() == commonSurface :
            m_device3 != nullptr ? m_device3->GetRenderTarget()->GetCommonSurface() == commonSurface : false;
+  }
+
+  // Only needed by D3D6 and earlier viewport clears, so skip the D3D7 device
+  void D3DCommonDevice::UpdateSurfaceDirtyTracking(bool dirtyRenderTarget, bool dirtyDepthStencil, bool dirtyPrimarySurface) {
+    if (m_device6 != nullptr) {
+      m_device6->UpdateSurfaceDirtyTracking(dirtyRenderTarget, dirtyDepthStencil, dirtyPrimarySurface);
+    } else if (m_device5 != nullptr) {
+      m_device5->UpdateSurfaceDirtyTracking(dirtyRenderTarget, dirtyDepthStencil, dirtyPrimarySurface);
+    } else if (m_device3 != nullptr) {
+      m_device3->UpdateSurfaceDirtyTracking(dirtyRenderTarget, dirtyDepthStencil, dirtyPrimarySurface);
+    }
   }
 
 }

--- a/src/ddraw/d3d_common_device.h
+++ b/src/ddraw/d3d_common_device.h
@@ -44,7 +44,21 @@ namespace dxvk {
 
     DDraw7Surface* GetCurrentRenderTarget7() const;
 
+    DDrawCommonSurface* GetCommonRenderTarget() const;
+
+    DDrawCommonSurface* GetCommonDepthStencil() const;
+
     bool IsCurrentRenderTarget(DDrawCommonSurface* commonSurface) const;
+
+    void UpdateSurfaceDirtyTracking(bool dirtyRenderTarget, bool dirtyDepthStencil, bool dirtyPrimarySurface);
+
+    void SetDepthWriteEnabled(bool isDepthWriteEnabled) {
+      m_isDepthWriteEnabled = isDepthWriteEnabled;
+    }
+
+    bool IsDepthWriteEnabled() const {
+      return m_isDepthWriteEnabled;
+    }
 
     void SetInScene(bool inScene) {
       m_inScene = inScene;
@@ -196,6 +210,9 @@ namespace dxvk {
   private:
 
     bool                        m_inScene             = false;
+    // D3DRENDERSTATE_ZWRITEENABLE, defaults to TRUE.
+    // Used only for D3D9 depth stencil surface dirtying.
+    bool                        m_isDepthWriteEnabled = true;
 
     DDrawCommonInterface*       m_commonIntf          = nullptr;
 

--- a/src/ddraw/d3d_common_interface.cpp
+++ b/src/ddraw/d3d_common_interface.cpp
@@ -6,7 +6,8 @@ namespace dxvk {
 
   std::atomic<D3DMATERIALHANDLE> D3DCommonInterface::s_materialHandle = 0;
 
-  D3DCommonInterface::D3DCommonInterface() {
+  D3DCommonInterface::D3DCommonInterface()
+    : m_d3d9Intf ( d3d9::Direct3DCreate9(D3D_SDK_VERSION) ) {
   }
 
   D3DCommonInterface::~D3DCommonInterface() {
@@ -36,6 +37,24 @@ namespace dxvk {
 
     if (likely(materialsIter != s_materials.end()))
       s_materials.erase(materialsIter);
+  }
+
+  d3d9::D3DMULTISAMPLE_TYPE D3DCommonInterface::GetMultiSampleType(d3d9::D3DFORMAT backBufferFormat) const {
+    HRESULT hr = m_d3d9Intf->CheckDeviceMultiSampleType(0, d3d9::D3DDEVTYPE_HAL, backBufferFormat,
+                                                        TRUE, d3d9::D3DMULTISAMPLE_4_SAMPLES, NULL);
+    if (likely(SUCCEEDED(hr))) {
+      Logger::info("D3DCommonInterface::GetMultiSampleType: Using 4x MSAA for FSAA emulation");
+      return d3d9::D3DMULTISAMPLE_4_SAMPLES;
+    }
+
+    hr = m_d3d9Intf->CheckDeviceMultiSampleType(0, d3d9::D3DDEVTYPE_HAL, backBufferFormat,
+                                                TRUE, d3d9::D3DMULTISAMPLE_2_SAMPLES, NULL);
+    if (SUCCEEDED(hr)) {
+      Logger::info("D3DCommonInterface::GetMultiSampleType: Using 2x MSAA for FSAA emulation");
+      return d3d9::D3DMULTISAMPLE_2_SAMPLES;
+    }
+
+    return d3d9::D3DMULTISAMPLE_NONE;
   }
 
 }

--- a/src/ddraw/d3d_common_interface.h
+++ b/src/ddraw/d3d_common_interface.h
@@ -32,12 +32,10 @@ namespace dxvk {
 
     static void ReleaseMaterialHandle(D3DMATERIALHANDLE handle);
 
+    d3d9::D3DMULTISAMPLE_TYPE GetMultiSampleType(d3d9::D3DFORMAT backBufferFormat) const;
+
     static D3DMATERIALHANDLE GetNextMaterialHandle() {
       return ++s_materialHandle;
-    }
-
-    void SetD3D9Interface(Com<d3d9::IDirect3D9>&& d3d9Intf) {
-      m_d3d9Intf = d3d9Intf;
     }
 
     d3d9::IDirect3D9* GetD3D9Interface() const {

--- a/src/ddraw/d3d_common_viewport.cpp
+++ b/src/ddraw/d3d_common_viewport.cpp
@@ -19,86 +19,54 @@ namespace dxvk {
   D3DCommonViewport::~D3DCommonViewport() {
   }
 
-  D3D6Viewport* D3DCommonViewport::GetCurrentD3D6Viewport() {
-    if (likely(m_device6 != nullptr))
-      return m_device6->GetCurrentViewportInternal();
+  void D3DCommonViewport::ApplyViewport() {
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonD3DDevice->GetD3D9Device();
 
-    return nullptr;
+    HRESULT hr = d3d9Device->SetViewport(&m_viewport9);
+    if (unlikely(FAILED(hr)))
+      Logger::err("D3DCommonViewport: Failed to set the D3D9 viewport");
   }
 
-  D3D5Viewport* D3DCommonViewport::GetCurrentD3D5Viewport() {
-    if (likely(m_device5 != nullptr))
-      return m_device5->GetCurrentViewportInternal();
-
-    return nullptr;
+  void D3DCommonViewport::DeactivateLights() {
+    for (auto light : m_lights) {
+      if (light->IsActive())
+        DeactivateLight(light.ptr());
+    }
   }
 
-  D3D3Viewport* D3DCommonViewport::GetCurrentD3D3Viewport() {
-    if (likely(m_device3 != nullptr))
-      return m_device3->GetCurrentViewportInternal();
+  void D3DCommonViewport::DeactivateLight(D3DLight* light) {
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonD3DDevice->GetD3D9Device();
 
-    return nullptr;
+    const DWORD light9Index = light->GetIndex();
+    //Logger::debug(str::format("D3DCommonViewport::DeactivateLight: Disabling light nr. ", light9Index));
+    HRESULT hr = d3d9Device->LightEnable(light9Index, FALSE);
+    if (unlikely(FAILED(hr)))
+      Logger::err("D3DCommonViewport::DeactivateLight: Failed D3D9 LightEnable call");
   }
 
-  DDrawCommonSurface* D3DCommonViewport::GetCommonRenderTarget() {
-    if (m_device6 != nullptr) {
-      DDraw4Surface* rt = m_device6->GetRenderTarget();
-      if (likely(rt != nullptr))
-        return rt->GetCommonSurface();
-    }
-    if (m_device5 != nullptr) {
-      DDrawSurface* rt = m_device5->GetRenderTarget();
-      if (likely(rt != nullptr))
-        return rt->GetCommonSurface();
-    }
-    if (m_device3 != nullptr) {
-      DDrawSurface* rt = m_device3->GetRenderTarget();
-      if (likely(rt != nullptr))
-        return rt->GetCommonSurface();
-    }
-
-    return nullptr;
+  void D3DCommonViewport::ApplyAndActivateLights() {
+    for (auto light : m_lights)
+      ApplyAndActivateLight(light.ptr());
   }
 
-  DDrawCommonSurface* D3DCommonViewport::GetCommonDepthStencil() {
-    if (m_device6 != nullptr) {
-      DDraw4Surface* ds = m_device6->GetDepthStencil();
-      if (likely(ds != nullptr))
-        return ds->GetCommonSurface();
-    }
-    if (m_device5 != nullptr) {
-      DDrawSurface* ds = m_device5->GetDepthStencil();
-      if (likely(ds != nullptr))
-        return ds->GetCommonSurface();
-    }
-    if (m_device3 != nullptr) {
-      DDrawSurface* ds = m_device3->GetDepthStencil();
-      if (likely(ds != nullptr))
-        return ds->GetCommonSurface();
-    }
+  void D3DCommonViewport::ApplyAndActivateLight(D3DLight* light) {
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonD3DDevice->GetD3D9Device();
 
-    return nullptr;
-  }
+    const DWORD light9Index = light->GetIndex();
+    HRESULT hr = d3d9Device->SetLight(light9Index, light->GetD3D9Light());
+    if (unlikely(FAILED(hr)))
+      Logger::err("D3DCommonViewport::ApplyAndActivateLight: Failed D3D9 SetLight call");
 
-  D3DCommonDevice* D3DCommonViewport::GetCommonD3DDevice() {
-    if (m_device6 != nullptr) {
-      return m_device6->GetCommonD3DDevice();
-    } else if (m_device5 != nullptr) {
-      return m_device5->GetCommonD3DDevice();
-    } else if (m_device3 != nullptr) {
-      return m_device3->GetCommonD3DDevice();
-    }
-
-    return nullptr;
-  }
-
-  void D3DCommonViewport::UpdateSurfaceDirtyTracking(bool dirtyRenderTarget, bool dirtyDepthStencil, bool dirtyPrimarySurface) {
-    if (m_device6 != nullptr) {
-      m_device6->UpdateSurfaceDirtyTracking(dirtyRenderTarget, dirtyDepthStencil, dirtyPrimarySurface);
-    } else if (m_device5 != nullptr) {
-      m_device5->UpdateSurfaceDirtyTracking(dirtyRenderTarget, dirtyDepthStencil, dirtyPrimarySurface);
-    } else if (m_device3 != nullptr) {
-      m_device3->UpdateSurfaceDirtyTracking(dirtyRenderTarget, dirtyDepthStencil, dirtyPrimarySurface);
+    if (light->IsActive()) {
+      //Logger::debug(str::format("D3DCommonViewport::ApplyAndActivateLight: Enabling D3D9 light nr. ", light9Index));
+      hr = d3d9Device->LightEnable(light9Index, TRUE);
+      if (unlikely(FAILED(hr)))
+        Logger::err("D3DCommonViewport::ApplyAndActivateLight: Failed D3D9 LightEnable call (TRUE)");
+    } else {
+      //Logger::debug(str::format("D3DCommonViewport::ApplyAndActivateLight: Disabling D3D9 light nr. ", light9Index));
+      hr = d3d9Device->LightEnable(light9Index, FALSE);
+      if (unlikely(FAILED(hr)))
+        Logger::err("D3DCommonViewport::ApplyAndActivateLight: Failed D3D9 LightEnable call (FALSE)");
     }
   }
 
@@ -131,14 +99,17 @@ namespace dxvk {
 
     // Ensure transform states aren't modified in flight
     D3DDeviceLock lock6, lock5, lock3;
-    if (m_device6 != nullptr)
-      lock6 = m_device6->LockDevice();
-    if (m_device5 != nullptr)
-      lock5 = m_device5->LockDevice();
-    if (m_device3 != nullptr)
-      lock3 = m_device3->LockDevice();
+    D3D6Device* d3d6Device = m_commonD3DDevice->GetD3D6Device();
+    if (d3d6Device != nullptr)
+      lock6 = d3d6Device->LockDevice();
+    D3D5Device* d3d5Device = m_commonD3DDevice->GetD3D5Device();
+    if (d3d5Device != nullptr)
+      lock5 = d3d5Device->LockDevice();
+    D3D3Device* d3d3Device = m_commonD3DDevice->GetD3D3Device();
+    if (d3d3Device != nullptr)
+      lock3 = d3d3Device->LockDevice();
 
-    d3d9::IDirect3DDevice9* m_device9 = GetCommonD3DDevice()->GetD3D9Device();
+    d3d9::IDirect3DDevice9* m_device9 = m_commonD3DDevice->GetD3D9Device();
 
     D3DMATRIX world9, view9, projection9;
     HRESULT hr;
@@ -222,6 +193,18 @@ namespace dxvk {
     }
 
     return D3D_OK;
+  }
+
+  void D3DCommonViewport::RefreshCommonD3DDevice() {
+    if (m_device6 != nullptr) {
+      m_commonD3DDevice = m_device6->GetCommonD3DDevice();
+    } else if (m_device5 != nullptr) {
+      m_commonD3DDevice = m_device5->GetCommonD3DDevice();
+    } else if (m_device3 != nullptr) {
+      m_commonD3DDevice = m_device3->GetCommonD3DDevice();
+    } else {
+      m_commonD3DDevice = nullptr;
+    }
   }
 
 }

--- a/src/ddraw/d3d_common_viewport.h
+++ b/src/ddraw/d3d_common_viewport.h
@@ -33,21 +33,21 @@ namespace dxvk {
       return S_OK;
     }
 
-    D3D6Viewport* GetCurrentD3D6Viewport();
+    void ApplyViewport();
 
-    D3D5Viewport* GetCurrentD3D5Viewport();
+    void DeactivateLights();
 
-    D3D3Viewport* GetCurrentD3D3Viewport();
+    void DeactivateLight(D3DLight* light);
 
-    DDrawCommonSurface* GetCommonRenderTarget();
+    void ApplyAndActivateLights();
 
-    DDrawCommonSurface* GetCommonDepthStencil();
-
-    D3DCommonDevice* GetCommonD3DDevice();
-
-    void UpdateSurfaceDirtyTracking(bool dirtyRenderTarget, bool dirtyDepthStencil, bool dirtyPrimarySurface);
+    void ApplyAndActivateLight(D3DLight* light);
 
     HRESULT TransformVertices(DWORD vertex_count, D3DTRANSFORMDATA *data, DWORD flags, DWORD *offscreen);
+
+    D3DCommonDevice* GetCommonD3DDevice() const {
+      return m_commonD3DDevice;
+    }
 
     d3d9::D3DVIEWPORT9* GetD3D9Viewport() {
       return &m_viewport9;
@@ -117,6 +117,32 @@ namespace dxvk {
       return m_isIdentityMatrix ? nullptr : &m_legacyProjection;
     }
 
+    void SetD3D6Device(D3D6Device* device6) {
+      m_device6 = device6;
+
+      RefreshCommonD3DDevice();
+    }
+
+    void SetD3D5Device(D3D5Device* device5) {
+      m_device5 = device5;
+
+      RefreshCommonD3DDevice();
+    }
+
+    void SetD3D3Device(D3D3Device* device3) {
+      m_device3 = device3;
+
+      RefreshCommonD3DDevice();
+    }
+
+    bool IsBoundToD3D3Device() const {
+      return m_device3 != nullptr;
+    }
+
+    bool HasDevice() const {
+      return m_commonD3DDevice != nullptr;
+    }
+
     void SetIsCurrentViewport(bool isCurrentViewport) {
       m_isCurrentViewport = isCurrentViewport;
     }
@@ -157,39 +183,15 @@ namespace dxvk {
       return m_origin;
     }
 
-    void SetD3D6Device(D3D6Device* device6) {
-      m_device6 = device6;
-    }
-
-    D3D6Device* GetD3D6Device() const {
-      return m_device6;
-    }
-
-    void SetD3D5Device(D3D5Device* device5) {
-      m_device5 = device5;
-    }
-
-    D3D5Device* GetD3D5Device() const {
-      return m_device5;
-    }
-
-    void SetD3D3Device(D3D3Device* device3) {
-      m_device3 = device3;
-    }
-
-    D3D3Device* GetD3D3Device() const {
-      return m_device3;
-    }
-
-    bool HasDevice() const {
-      return m_device6 != nullptr || m_device5 != nullptr || m_device3 != nullptr;
-    }
-
-    void GetD3D9Lights(std::vector<d3d9::D3DLIGHT9>* lights9) {
-      for (auto light: m_lights) {
+    void GetD3D9ActiveLights(std::vector<d3d9::D3DLIGHT9>* lights9) {
+      for (auto light : m_lights) {
         if (light->IsActive())
           lights9->push_back(*light->GetD3D9Light());
       }
+    }
+
+    bool HasLights() const {
+      return m_lights.size() > 0;
     }
 
     std::vector<Com<D3DLight>>& GetLights() {
@@ -197,6 +199,8 @@ namespace dxvk {
     }
 
   private:
+
+    void RefreshCommonD3DDevice();
 
     bool                  m_isViewportSet     = false;
     bool                  m_isCurrentViewport = false;
@@ -213,6 +217,11 @@ namespace dxvk {
     D3DVECTOR             m_legacyClip        = { };
     D3DMATRIX             m_legacyProjection  = { };
 
+    D3DCommonDevice*      m_commonD3DDevice   = nullptr;
+    D3D6Device*           m_device6           = nullptr;
+    D3D5Device*           m_device5           = nullptr;
+    D3D3Device*           m_device3           = nullptr;
+
     d3d9::D3DVIEWPORT9    m_viewport9         = { };
 
     D3D6Viewport*         m_d3d6Viewport      = nullptr;
@@ -222,11 +231,6 @@ namespace dxvk {
     // Track the origin viewport, as in the viewport
     // that gets created through a CreateViewport call
     IUnknown*             m_origin            = nullptr;
-
-    // Track all devices this viewport is attached to
-    D3D6Device*           m_device6           = nullptr;
-    D3D5Device*           m_device5           = nullptr;
-    D3D3Device*           m_device3           = nullptr;
 
     std::vector<Com<D3DLight>> m_lights;
 

--- a/src/ddraw/d3d_light.cpp
+++ b/src/ddraw/d3d_light.cpp
@@ -6,17 +6,13 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> D3DLight::s_lightCount = 0;
+  std::atomic<uint32_t> D3DLight::s_light9Index = 0;
 
   D3DLight::D3DLight(IUnknown* pParent)
     : DDrawChildObject<IUnknown, IDirect3DLight>(pParent) {
-    m_lightCount = ++s_lightCount;
-
-    Logger::debug(str::format("D3DLight: Created a new light nr. [[1-", m_lightCount, "]]"));
   }
 
   D3DLight::~D3DLight() {
-    Logger::debug(str::format("D3DLight: Light nr. [[1-", m_lightCount, "]] bites the dust"));
   }
 
   HRESULT STDMETHODCALLTYPE D3DLight::QueryInterface(REFIID riid, void** ppvObject) {
@@ -103,13 +99,18 @@ namespace dxvk {
     // D3DLIGHT structure lights are, apparently, considered to be active by default
     m_isActive            = isD3DLight2 ? (m_flags & D3DLIGHT_ACTIVE) : true;
 
+    D3DCommonViewport* commonViewport = nullptr;
+    if (m_viewport6 != nullptr) {
+      commonViewport = m_viewport6->GetCommonViewport();
+    } else if (m_viewport5 != nullptr) {
+      commonViewport = m_viewport5->GetCommonViewport();
+    } else if (m_viewport3 != nullptr) {
+      commonViewport = m_viewport3->GetCommonViewport();
+    }
+
     // Update the D3D9 light directly if it's actively being used
-    if (m_viewport6 != nullptr && m_viewport6->GetCommonViewport()->IsCurrentViewport())
-      m_viewport6->ApplyAndActivateLight(m_lightCount, this);
-    else if (m_viewport5 != nullptr && m_viewport5->GetCommonViewport()->IsCurrentViewport())
-      m_viewport5->ApplyAndActivateLight(m_lightCount, this);
-    else if (m_viewport3 != nullptr && m_viewport3->GetCommonViewport()->IsCurrentViewport())
-      m_viewport3->ApplyAndActivateLight(m_lightCount, this);
+    if (commonViewport != nullptr && commonViewport->IsCurrentViewport())
+      commonViewport->ApplyAndActivateLight(this);
 
     return D3D_OK;
   }

--- a/src/ddraw/d3d_light.h
+++ b/src/ddraw/d3d_light.h
@@ -45,12 +45,15 @@ namespace dxvk {
       return m_viewport6 != nullptr || m_viewport5 != nullptr || m_viewport3 != nullptr;
     }
 
-    DWORD GetIndex() const {
-      return m_lightCount;
-    }
-
     bool IsActive() const {
       return m_isActive;
+    }
+
+    DWORD GetIndex() {
+      if (unlikely(!m_light9Index))
+        m_light9Index = ++s_light9Index;
+
+      return m_light9Index;
     }
 
   private:
@@ -66,8 +69,8 @@ namespace dxvk {
 
     d3d9::D3DLIGHT9  m_light9          = { };
 
-    uint32_t         m_lightCount      = 0;
-    static std::atomic<uint32_t> s_lightCount;
+    uint32_t         m_light9Index     = 0;
+    static std::atomic<uint32_t> s_light9Index;
 
   };
 

--- a/src/ddraw/d3d_process_vertices.h
+++ b/src/ddraw/d3d_process_vertices.h
@@ -53,12 +53,13 @@ namespace dxvk {
   using PositionArray = std::array<FLOAT, 8>;
   using TexCoordArray = std::array<std::array<FLOAT, 4>, ddrawCaps::MaxSimultaneousTextures>;
 
+#ifdef DXVK_SWVP_SSE2
   struct alignas(16) SIMDRow {
     __m128 lo; // Elements 0, 1, 2, 3
     __m128 hi; // Elements 4, 5, 6, 7
   };
 
-  inline void swap_rows_sse(SIMDRow& a, SIMDRow& b) {
+  inline void SwapRowsSSE(SIMDRow& a, SIMDRow& b) {
     __m128 temp_lo = a.lo;
     __m128 temp_hi = a.hi;
     a.lo = b.lo;
@@ -67,7 +68,7 @@ namespace dxvk {
     b.hi = temp_hi;
   }
 
-  inline void InvertMatrix_SSE2(D3DMATRIX *out, const D3DMATRIX *m) {
+  inline void InvertMatrix(D3DMATRIX *out, const D3DMATRIX *m) {
     SIMDRow r[4];
 
     auto get_val = [](const SIMDRow& row, int col) -> float {
@@ -91,14 +92,14 @@ namespace dxvk {
     r[3].lo = _mm_setr_ps(m->_41, m->_42, m->_43, m->_44);
     r[3].hi = _mm_setr_ps(0.0f, 0.0f, 0.0f, 1.0f);
 
-    if (std::abs(get_val(r[3], 0)) > std::abs(get_val(r[2], 0)))
-      swap_rows_sse(r[3], r[2]);
-    if (std::abs(get_val(r[2], 0)) > std::abs(get_val(r[1], 0)))
-      swap_rows_sse(r[2], r[1]);
-    if (std::abs(get_val(r[1], 0)) > std::abs(get_val(r[0], 0)))
-      swap_rows_sse(r[1], r[0]);
+    if (std::fabs(get_val(r[3], 0)) > std::fabs(get_val(r[2], 0)))
+      SwapRowsSSE(r[3], r[2]);
+    if (std::fabs(get_val(r[2], 0)) > std::fabs(get_val(r[1], 0)))
+      SwapRowsSSE(r[2], r[1]);
+    if (std::fabs(get_val(r[1], 0)) > std::fabs(get_val(r[0], 0)))
+      SwapRowsSSE(r[1], r[0]);
 
-    float pivot0 = get_val(r[0], 0);
+    const float pivot0 = get_val(r[0], 0);
     if (pivot0 == 0.0f)
       return;
 
@@ -112,27 +113,27 @@ namespace dxvk {
     eliminate_row(r[2], r[0], get_val(r[2], 0) / pivot0);
     eliminate_row(r[3], r[0], get_val(r[3], 0) / pivot0);
 
-    if (std::abs(get_val(r[3], 1)) > std::abs(get_val(r[2], 1)))
-      swap_rows_sse(r[3], r[2]);
-    if (std::abs(get_val(r[2], 1)) > std::abs(get_val(r[1], 1)))
-      swap_rows_sse(r[2], r[1]);
+    if (std::fabs(get_val(r[3], 1)) > std::fabs(get_val(r[2], 1)))
+      SwapRowsSSE(r[3], r[2]);
+    if (std::fabs(get_val(r[2], 1)) > std::fabs(get_val(r[1], 1)))
+      SwapRowsSSE(r[2], r[1]);
 
-    float pivot1 = get_val(r[1], 1);
+    const float pivot1 = get_val(r[1], 1);
     if (pivot1 == 0.0f)
       return;
 
     eliminate_row(r[2], r[1], get_val(r[2], 1) / pivot1);
     eliminate_row(r[3], r[1], get_val(r[3], 1) / pivot1);
 
-    if (std::abs(get_val(r[3], 2)) > std::abs(get_val(r[2], 2)))
-      swap_rows_sse(r[3], r[2]);
-    float pivot2 = get_val(r[2], 2);
+    if (std::fabs(get_val(r[3], 2)) > std::fabs(get_val(r[2], 2)))
+      SwapRowsSSE(r[3], r[2]);
+    const float pivot2 = get_val(r[2], 2);
     if (pivot2 == 0.0f)
       return;
 
     eliminate_row(r[3], r[2], get_val(r[3], 2) / pivot2);
 
-    float pivot3 = get_val(r[3], 3);
+    const float pivot3 = get_val(r[3], 3);
     if (pivot3 == 0.0f)
       return;
 
@@ -140,28 +141,28 @@ namespace dxvk {
     r[3].lo = _mm_mul_ps(r[3].lo, v_inv_pivot3);
     r[3].hi = _mm_mul_ps(r[3].hi, v_inv_pivot3);
 
-    float m2_3 = get_val(r[2], 3);
+    const float m2_3 = get_val(r[2], 3);
     r[2].lo = _mm_sub_ps(r[2].lo, _mm_mul_ps(_mm_set1_ps(m2_3), r[3].lo));
     r[2].hi = _mm_sub_ps(r[2].hi, _mm_mul_ps(_mm_set1_ps(m2_3), r[3].hi));
 
-    float s2 = get_val(r[2], 2);
+    const float s2 = get_val(r[2], 2);
     r[2].lo = _mm_mul_ps(r[2].lo, _mm_set1_ps(1.0f / s2));
     r[2].hi = _mm_mul_ps(r[2].hi, _mm_set1_ps(1.0f / s2));
 
-    float m1_3 = get_val(r[1], 3);
-    float m1_2 = get_val(r[1], 2);
+    const float m1_3 = get_val(r[1], 3);
+    const float m1_2 = get_val(r[1], 2);
     r[1].lo = _mm_sub_ps(r[1].lo, _mm_mul_ps(_mm_set1_ps(m1_3), r[3].lo));
     r[1].hi = _mm_sub_ps(r[1].hi, _mm_mul_ps(_mm_set1_ps(m1_3), r[3].hi));
     r[1].lo = _mm_sub_ps(r[1].lo, _mm_mul_ps(_mm_set1_ps(m1_2), r[2].lo));
     r[1].hi = _mm_sub_ps(r[1].hi, _mm_mul_ps(_mm_set1_ps(m1_2), r[2].hi));
 
-    float s1 = get_val(r[1], 1);
+    const float s1 = get_val(r[1], 1);
     r[1].lo = _mm_mul_ps(r[1].lo, _mm_set1_ps(1.0f / s1));
     r[1].hi = _mm_mul_ps(r[1].hi, _mm_set1_ps(1.0f / s1));
 
-    float m0_3 = get_val(r[0], 3);
-    float m0_2 = get_val(r[0], 2);
-    float m0_1 = get_val(r[0], 1);
+    const float m0_3 = get_val(r[0], 3);
+    const float m0_2 = get_val(r[0], 2);
+    const float m0_1 = get_val(r[0], 1);
     r[0].lo = _mm_sub_ps(r[0].lo, _mm_mul_ps(_mm_set1_ps(m0_3), r[3].lo));
     r[0].hi = _mm_sub_ps(r[0].hi, _mm_mul_ps(_mm_set1_ps(m0_3), r[3].hi));
     r[0].lo = _mm_sub_ps(r[0].lo, _mm_mul_ps(_mm_set1_ps(m0_2), r[2].lo));
@@ -169,7 +170,7 @@ namespace dxvk {
     r[0].lo = _mm_sub_ps(r[0].lo, _mm_mul_ps(_mm_set1_ps(m0_1), r[1].lo));
     r[0].hi = _mm_sub_ps(r[0].hi, _mm_mul_ps(_mm_set1_ps(m0_1), r[1].hi));
 
-    float s0 = get_val(r[0], 0);
+    const float s0 = get_val(r[0], 0);
     r[0].lo = _mm_mul_ps(r[0].lo, _mm_set1_ps(1.0f / s0));
     r[0].hi = _mm_mul_ps(r[0].hi, _mm_set1_ps(1.0f / s0));
 
@@ -180,7 +181,7 @@ namespace dxvk {
     out->_41 = get_val(r[3], 4); out->_42 = get_val(r[3], 5); out->_43 = get_val(r[3], 6); out->_44 = get_val(r[3], 7);
   }
 
-  inline __m128 cross_product_sse2(__m128 a, __m128 b) {
+  inline __m128 CrossProduct(__m128 a, __m128 b) {
     __m128 a_yzx = _mm_shuffle_ps(a, a, _MM_SHUFFLE(3, 0, 2, 1));
     __m128 b_zxy = _mm_shuffle_ps(b, b, _MM_SHUFFLE(3, 1, 0, 2));
     __m128 a_zxy = _mm_shuffle_ps(a, a, _MM_SHUFFLE(3, 1, 0, 2));
@@ -189,26 +190,25 @@ namespace dxvk {
     return _mm_sub_ps(_mm_mul_ps(a_yzx, b_zxy), _mm_mul_ps(a_zxy, b_yzx));
   }
 
-  inline void InvertMatrixLegacy_SSE2(D3DMATRIX *out, const D3DMATRIX *in) {
+  inline void InvertMatrixLegacy(D3DMATRIX *out, const D3DMATRIX *in) {
     __m128 r1 = _mm_loadu_ps(&in->_11);
     __m128 r2 = _mm_loadu_ps(&in->_21);
     __m128 r3 = _mm_loadu_ps(&in->_31);
 
-    __m128 v_a = cross_product_sse2(r2, r3);
-    __m128 v_b = cross_product_sse2(r3, r1);
-    __m128 v_c = cross_product_sse2(r1, r2);
+    __m128 v_a = CrossProduct(r2, r3);
+    __m128 v_b = CrossProduct(r3, r1);
+    __m128 v_c = CrossProduct(r1, r2);
 
     __m128 dot = _mm_mul_ps(r1, v_a);
 
-    float det;
     float temp_det[4];
     _mm_storeu_ps(temp_det, dot);
-    det = temp_det[0] + temp_det[1] + temp_det[2];
+    const float det = temp_det[0] + temp_det[1] + temp_det[2];
 
-    if (std::fabs(det) <= std::numeric_limits<float>::min() * 10)
+    if (std::fabs(det) <= std::numeric_limits<float>::min() * 10.0f)
       return;
 
-    float inv_det = 1.0f / det;
+    const float inv_det = 1.0f / det;
 
     v_a = _mm_mul_ps(v_a, _mm_set1_ps(inv_det));
     v_b = _mm_mul_ps(v_b, _mm_set1_ps(inv_det));
@@ -224,25 +224,7 @@ namespace dxvk {
     out->_31 = va[2]; out->_32 = vb[2]; out->_33 = vc[2];
   }
 
-  inline void ComputeNormalMatrix(D3DMATRIX &normal_matrix, bool isLegacy, const D3DMATRIX &wv) {
-    D3DMATRIX mv = wv;
-    if (isLegacy)
-      InvertMatrixLegacy_SSE2(&mv, &mv);
-    else
-      InvertMatrix_SSE2(&mv, &mv);
-
-    normal_matrix._11 = mv._11;
-    normal_matrix._12 = mv._21;
-    normal_matrix._13 = mv._31;
-    normal_matrix._21 = mv._12;
-    normal_matrix._22 = mv._22;
-    normal_matrix._23 = mv._32;
-    normal_matrix._31 = mv._13;
-    normal_matrix._32 = mv._23;
-    normal_matrix._33 = mv._33;
-  }
-
-  inline D3DMATRIX D3DMatrixMultiply4x4_SSE2(const D3DMATRIX& a, const D3DMATRIX& b) {
+  inline D3DMATRIX D3DMatrixMultiply4x4(const D3DMATRIX& a, const D3DMATRIX& b) {
     D3DMATRIX result;
 
     const __m128 b0 = _mm_loadu_ps(&b._11);
@@ -250,13 +232,13 @@ namespace dxvk {
     const __m128 b2 = _mm_loadu_ps(&b._31);
     const __m128 b3 = _mm_loadu_ps(&b._41);
 
-    #define MULROW(dst, src)                                            \
-    do {                                                                \
-        __m128 r = _mm_mul_ps(_mm_set1_ps((src)[0]), b0);               \
-        r = _mm_add_ps(r, _mm_mul_ps(_mm_set1_ps((src)[1]), b1));       \
-        r = _mm_add_ps(r, _mm_mul_ps(_mm_set1_ps((src)[2]), b2));       \
-        r = _mm_add_ps(r, _mm_mul_ps(_mm_set1_ps((src)[3]), b3));       \
-        _mm_storeu_ps((dst), r);                                        \
+    #define MULROW(dst, src)                                          \
+    do {                                                              \
+      __m128 r = _mm_mul_ps(_mm_set1_ps((src)[0]), b0);               \
+      r = _mm_add_ps(r, _mm_mul_ps(_mm_set1_ps((src)[1]), b1));       \
+      r = _mm_add_ps(r, _mm_mul_ps(_mm_set1_ps((src)[2]), b2));       \
+      r = _mm_add_ps(r, _mm_mul_ps(_mm_set1_ps((src)[3]), b3));       \
+      _mm_storeu_ps((dst), r);                                        \
     } while (0)
 
     MULROW(&result._11, &a._11);
@@ -268,8 +250,7 @@ namespace dxvk {
     return result;
   }
 
-  inline D3DVECTOR4 D3DVec4Transform_SSE2(const D3DMATRIX& m, const D3DVECTOR4& v)
-  {
+  inline D3DVECTOR4 D3DVec4Transform(const D3DMATRIX& m, const D3DVECTOR4& v) {
     D3DVECTOR4 result;
 
     const __m128 r0 = _mm_loadu_ps(&m._11);
@@ -287,7 +268,7 @@ namespace dxvk {
     return result;
   }
 
-  inline D3DVECTOR D3DVec3Transform_SSE2(const D3DMATRIX& m, const D3DVECTOR& v) {
+  inline D3DVECTOR D3DVec3Transform(const D3DMATRIX& m, const D3DVECTOR& v) {
     const __m128 vx = _mm_set1_ps(v.x);
     const __m128 vy = _mm_set1_ps(v.y);
     const __m128 vz = _mm_set1_ps(v.z);
@@ -306,7 +287,7 @@ namespace dxvk {
     return D3DVECTOR{tmp.x, tmp.y, tmp.z};
   }
 
-  inline D3DVECTOR D3DVec4to3Transform_SSE2(const D3DMATRIX& m, const D3DVECTOR4& v) {
+  inline D3DVECTOR D3DVec4to3Transform(const D3DMATRIX& m, const D3DVECTOR4& v) {
     const __m128 r0 = _mm_loadu_ps(&m._11);
     const __m128 r1 = _mm_loadu_ps(&m._21);
     const __m128 r2 = _mm_loadu_ps(&m._31);
@@ -323,7 +304,7 @@ namespace dxvk {
     return D3DVECTOR{tmp.x, tmp.y, tmp.z};
   }
 
-  inline float D3DVec3Dot_SSE2(const D3DVECTOR* a, const D3DVECTOR* b) {
+  inline float D3DVec3Dot(const D3DVECTOR* a, const D3DVECTOR* b) {
     if (a == nullptr || b == nullptr)
       return 0.0f;
 
@@ -337,8 +318,9 @@ namespace dxvk {
     return _mm_cvtss_f32(t);
   }
 
-  inline __m128 D3DVec3Normalize_SSECore(__m128 v) {
-    __m128 mul = _mm_mul_ps(v, v);
+  inline D3DVECTOR D3DVec3Normalize(const D3DVECTOR& v) {
+    __m128 vec = _mm_setr_ps(v.x, v.y, v.z, 0.0f);
+    __m128 mul = _mm_mul_ps(vec, vec);
     __m128 sum = _mm_add_ps(mul, _mm_shuffle_ps(mul, mul, _MM_SHUFFLE(1,0,3,2)));
     sum = _mm_add_ss(sum, _mm_shuffle_ps(sum, sum, _MM_SHUFFLE(2,3,0,1)));
 
@@ -348,13 +330,7 @@ namespace dxvk {
 
     inv = _mm_mul_ss(inv, _mm_sub_ss(three, _mm_mul_ss(_mm_mul_ss(sum, inv), inv)));
     inv = _mm_mul_ss(inv, half);
-
-    return _mm_shuffle_ps(inv, inv, 0x00);
-  }
-
-  inline D3DVECTOR D3DVec3Normalize(const D3DVECTOR& v) {
-    __m128 vec = _mm_setr_ps(v.x, v.y, v.z, 0.0f);
-    __m128 inv = D3DVec3Normalize_SSECore(vec);
+    inv = _mm_shuffle_ps(inv, inv, 0x00);
 
     vec = _mm_mul_ps(vec, inv);
 
@@ -366,7 +342,7 @@ namespace dxvk {
     return out;
   }
 
-  inline void D3DColorClamp_SSE2(D3DCOLORVALUE& color) {
+  inline void D3DColorClamp(D3DCOLORVALUE& color) {
     __m128 c = _mm_loadu_ps(&color.r);
 
     c = _mm_min_ps(c, _mm_set1_ps(1.0f));
@@ -375,7 +351,7 @@ namespace dxvk {
     _mm_storeu_ps(&color.r, c);
   }
 
-  inline void ColorVMultiplyAdd_SSE2(D3DCOLORVALUE& out, const D3DCOLORVALUE& color, float value) {
+  inline void ColorVMultiplyAdd(D3DCOLORVALUE& out, const D3DCOLORVALUE& color, float value) {
     __m128 va = _mm_loadu_ps(&color.r);
     __m128 vb = _mm_loadu_ps(&out.r);
 
@@ -388,7 +364,7 @@ namespace dxvk {
     out.a = alpha;
   }
 
-  inline float D3DSSE_Mad2_Add_Scalar_SSE2(float a1, float a2, float b1, float b2, float c) {
+  inline float D3DMad2AddScalar(float a1, float a2, float b1, float b2, float c) {
     __m128 r = _mm_mul_ss(_mm_set_ss(a1), _mm_set_ss(a2));
     r = _mm_add_ss(r, _mm_mul_ss(_mm_set_ss(b1), _mm_set_ss(b2)));
     r = _mm_add_ss(r, _mm_set_ss(c));
@@ -396,7 +372,7 @@ namespace dxvk {
     return _mm_cvtss_f32(r);
   }
 
-  inline void D3DColorMulRGB_SetAlpha_SSE2(D3DCOLORVALUE& a, const D3DCOLORVALUE& b, bool legacy) {
+  inline void D3DColorMulRGBSetAlpha(D3DCOLORVALUE& a, const D3DCOLORVALUE& b, bool legacy) {
     __m128 va = _mm_loadu_ps(&a.r);
     __m128 vb = _mm_loadu_ps(&b.r);
 
@@ -409,44 +385,228 @@ namespace dxvk {
     else
       a.a = b.a;
   }
+#else
+  inline void InvertMatrix(D3DMATRIX *out, const D3DMATRIX *m) {
+    float tmp[4][8];
 
-  // D3DCOLOR is DWORD packed ARGB, uint8_t per component
-  // D3DCOLORVALUE is struct with float per component normalized to 0.0f - 1.0f
-  inline D3DCOLOR ColorVToColor(const D3DCOLORVALUE& c) {
-    return D3DCOLOR_ARGB(
-      static_cast<int>(roundf(c.a * 255.0f)),
-      static_cast<int>(roundf(c.r * 255.0f)),
-      static_cast<int>(roundf(c.g * 255.0f)),
-      static_cast<int>(roundf(c.b * 255.0f))
-    );
+    tmp[0][0] = m->_11; tmp[0][1] = m->_12; tmp[0][2] = m->_13; tmp[0][3] = m->_14;
+    tmp[0][4] = 1.0f;   tmp[0][5] = 0.0f;   tmp[0][6] = 0.0f;   tmp[0][7] = 0.0f;
+    tmp[1][0] = m->_21; tmp[1][1] = m->_22; tmp[1][2] = m->_23; tmp[1][3] = m->_24;
+    tmp[1][4] = 0.0f;   tmp[1][5] = 1.0f;   tmp[1][6] = 0.0f;   tmp[1][7] = 0.0f;
+    tmp[2][0] = m->_31; tmp[2][1] = m->_32; tmp[2][2] = m->_33; tmp[2][3] = m->_34;
+    tmp[2][4] = 0.0f;   tmp[2][5] = 0.0f;   tmp[2][6] = 1.0f;   tmp[2][7] = 0.0f;
+    tmp[3][0] = m->_41; tmp[3][1] = m->_42; tmp[3][2] = m->_43; tmp[3][3] = m->_44;
+    tmp[3][4] = 0.0f;   tmp[3][5] = 0.0f;   tmp[3][6] = 0.0f;   tmp[3][7] = 1.0f;
+
+    for (int i = 0; i < 4; ++i) {
+      int max_row = i;
+      float max_val = std::fabs(tmp[i][i]);
+      for (int k = i + 1; k < 4; ++k) {
+        const float val = std::fabs(tmp[k][i]);
+        if (val > max_val) {
+          max_val = val;
+          max_row = k;
+        }
+      }
+
+      if (max_val < std::numeric_limits<float>::min() * 10.0f)
+        return;
+
+      if (max_row != i) {
+        for (int j = 0; j < 8; ++j) {
+          std::swap(tmp[i][j], tmp[max_row][j]);
+        }
+      }
+
+      const float pivot = tmp[i][i];
+      for (int j = i; j < 8; ++j) {
+        tmp[i][j] /= pivot;
+      }
+
+      for (int k = 0; k < 4; ++k) {
+        if (k != i) {
+          const float factor = tmp[k][i];
+          for (int j = 0; j < 8; ++j) {
+            tmp[k][j] -= factor * tmp[i][j];
+          }
+        }
+      }
+    }
+
+    out->_11 = tmp[0][4]; out->_12 = tmp[0][5]; out->_13 = tmp[0][6]; out->_14 = tmp[0][7];
+    out->_21 = tmp[1][4]; out->_22 = tmp[1][5]; out->_23 = tmp[1][6]; out->_24 = tmp[1][7];
+    out->_31 = tmp[2][4]; out->_32 = tmp[2][5]; out->_33 = tmp[2][6]; out->_34 = tmp[2][7];
+    out->_41 = tmp[3][4]; out->_42 = tmp[3][5]; out->_43 = tmp[3][6]; out->_44 = tmp[3][7];
   }
 
-  inline D3DCOLORVALUE ColorToColorV(const D3DCOLOR& c) {
-    D3DCOLORVALUE result;
-
-    result.a = ((c >> 24) & 0xFF) / 255.0f;
-    result.r = ((c >> 16) & 0xFF) / 255.0f;
-    result.g = ((c >> 8)  & 0xFF) / 255.0f;
-    result.b = ((c >> 0)  & 0xFF) / 255.0f;
-
-    return result;
+  inline D3DVECTOR CrossProduct(const D3DVECTOR& a, const D3DVECTOR& b) {
+    return D3DVECTOR{
+      a.y * b.z - a.z * b.y,
+      a.z * b.x - a.x * b.z,
+      a.x * b.y - a.y * b.x
+    };
   }
 
-  inline D3DCOLORVALUE ColorVClamp(const D3DCOLORVALUE& color, float min, float max) {
-    D3DCOLORVALUE result;
+  inline void InvertMatrixLegacy(D3DMATRIX *out, const D3DMATRIX *in) {
+    D3DVECTOR r1 = { in->_11, in->_12, in->_13 };
+    D3DVECTOR r2 = { in->_21, in->_22, in->_23 };
+    D3DVECTOR r3 = { in->_31, in->_32, in->_33 };
 
-    result.r = std::clamp(color.r, min, max);
-    result.g = std::clamp(color.g, min, max);
-    result.b = std::clamp(color.b, min, max);
-    result.a = std::clamp(color.a, min, max);
+    D3DVECTOR v_a = CrossProduct(r2, r3);
+    D3DVECTOR v_b = CrossProduct(r3, r1);
+    D3DVECTOR v_c = CrossProduct(r1, r2);
 
-    return result;
+    const float det = r1.x * v_a.x + r1.y * v_a.y + r1.z * v_a.z;
+
+    if (std::fabs(det) <= std::numeric_limits<float>::min() * 10.0f)
+      return;
+
+    const float inv_det = 1.0f / det;
+
+    out->_11 = v_a.x * inv_det; out->_12 = v_b.x * inv_det; out->_13 = v_c.x * inv_det;
+    out->_21 = v_a.y * inv_det; out->_22 = v_b.y * inv_det; out->_23 = v_c.y * inv_det;
+    out->_31 = v_a.z * inv_det; out->_32 = v_b.z * inv_det; out->_33 = v_c.z * inv_det;
+  }
+
+  inline D3DMATRIX D3DMatrixMultiply4x4(const D3DMATRIX& a, const D3DMATRIX& b) {
+    return D3DMATRIX{
+      a._11 * b._11 + a._12 * b._21 + a._13 * b._31 + a._14 * b._41,
+      a._11 * b._12 + a._12 * b._22 + a._13 * b._32 + a._14 * b._42,
+      a._11 * b._13 + a._12 * b._23 + a._13 * b._33 + a._14 * b._43,
+      a._11 * b._14 + a._12 * b._24 + a._13 * b._34 + a._14 * b._44,
+      a._21 * b._11 + a._22 * b._21 + a._23 * b._31 + a._24 * b._41,
+      a._21 * b._12 + a._22 * b._22 + a._23 * b._32 + a._24 * b._42,
+      a._21 * b._13 + a._22 * b._23 + a._23 * b._33 + a._24 * b._43,
+      a._21 * b._14 + a._22 * b._24 + a._23 * b._34 + a._24 * b._44,
+      a._31 * b._11 + a._32 * b._21 + a._33 * b._31 + a._34 * b._41,
+      a._31 * b._12 + a._32 * b._22 + a._33 * b._32 + a._34 * b._42,
+      a._31 * b._13 + a._32 * b._23 + a._33 * b._33 + a._34 * b._43,
+      a._31 * b._14 + a._32 * b._24 + a._33 * b._34 + a._34 * b._44,
+      a._41 * b._11 + a._42 * b._21 + a._43 * b._31 + a._44 * b._41,
+      a._41 * b._12 + a._42 * b._22 + a._43 * b._32 + a._44 * b._42,
+      a._41 * b._13 + a._42 * b._23 + a._43 * b._33 + a._44 * b._43,
+      a._41 * b._14 + a._42 * b._24 + a._43 * b._34 + a._44 * b._44
+    };
+  }
+
+  inline D3DVECTOR4 D3DVec4Transform(const D3DMATRIX& m, const D3DVECTOR4& v)   {
+    return D3DVECTOR4{
+      m._11 * v.x + m._21 * v.y + m._31 * v.z + m._41 * v.w,
+      m._12 * v.x + m._22 * v.y + m._32 * v.z + m._42 * v.w,
+      m._13 * v.x + m._23 * v.y + m._33 * v.z + m._43 * v.w,
+      m._14 * v.x + m._24 * v.y + m._34 * v.z + m._44 * v.w
+    };
+  }
+
+  inline D3DVECTOR D3DVec3Transform(const D3DMATRIX& m, const D3DVECTOR& v) {
+    return D3DVECTOR{
+      m._11 * v.x + m._21 * v.y + m._31 * v.z,
+      m._12 * v.x + m._22 * v.y + m._32 * v.z,
+      m._13 * v.x + m._23 * v.y + m._33 * v.z
+    };
+  }
+
+  inline D3DVECTOR D3DVec4to3Transform(const D3DMATRIX& m, const D3DVECTOR4& v) {
+    return D3DVECTOR{
+      m._11 * v.x + m._21 * v.y + m._31 * v.z + m._41 * v.w,
+      m._12 * v.x + m._22 * v.y + m._32 * v.z + m._42 * v.w,
+      m._13 * v.x + m._23 * v.y + m._33 * v.z + m._43 * v.w
+    };
+  }
+
+  inline float D3DVec3Dot(const D3DVECTOR* a, const D3DVECTOR* b) {
+    if (a == nullptr || b == nullptr)
+      return 0.0f;
+
+    return (a->x * b->x) + (a->y * b->y) + (a->z * b->z);
+  }
+
+  inline D3DVECTOR D3DVec3Normalize(const D3DVECTOR& v) {
+    const float dot = v.x * v.x + v.y * v.y + v.z * v.z;
+
+    if (dot <= 0.0f) {
+      return D3DVECTOR{0.0f, 0.0f, 0.0f};
+    }
+
+    const float inv_mag = 1.0f / std::sqrtf(dot);
+
+    return D3DVECTOR{v.x * inv_mag, v.y * inv_mag, v.z * inv_mag};
+  }
+
+  inline void D3DColorClamp(D3DCOLORVALUE& color) {
+    color.r = std::clamp(color.r, 0.0f, 1.0f);
+    color.g = std::clamp(color.g, 0.0f, 1.0f);
+    color.b = std::clamp(color.b, 0.0f, 1.0f);
+    color.a = std::clamp(color.a, 0.0f, 1.0f);
   }
 
   inline void ColorVMultiplyAdd(D3DCOLORVALUE& out, const D3DCOLORVALUE& color, float value) {
     out.r += color.r * value;
     out.g += color.g * value;
     out.b += color.b * value;
+  }
+
+  inline float D3DMad2AddScalar(float a1, float a2, float b1, float b2, float c) {
+    return a1 * a2 + b1 * b2  + c;
+  }
+
+  inline void D3DColorMulRGBSetAlpha(D3DCOLORVALUE& a, const D3DCOLORVALUE& b, bool legacy) {
+    a.r *= b.r;
+    a.g *= b.g;
+    a.b *= b.b;
+
+    if (legacy)
+      a.a = 0.0f;
+    else
+      a.a = b.a;
+  }
+#endif
+
+  inline void ComputeNormalMatrix(D3DMATRIX& normal_matrix, bool isLegacy, const D3DMATRIX& wv) {
+    D3DMATRIX mv = wv;
+    if (isLegacy)
+      InvertMatrixLegacy(&mv, &mv);
+    else
+      InvertMatrix(&mv, &mv);
+
+    normal_matrix._11 = mv._11;
+    normal_matrix._12 = mv._21;
+    normal_matrix._13 = mv._31;
+    normal_matrix._21 = mv._12;
+    normal_matrix._22 = mv._22;
+    normal_matrix._23 = mv._32;
+    normal_matrix._31 = mv._13;
+    normal_matrix._32 = mv._23;
+    normal_matrix._33 = mv._33;
+  }
+
+  // D3DCOLOR is DWORD packed ARGB, uint8_t per component
+  // D3DCOLORVALUE is RGBA struct with float per component normalized to 0.0f - 1.0f
+  inline D3DCOLOR ColorVToColor(const D3DCOLORVALUE& c) {
+    return D3DCOLOR_ARGB(
+      static_cast<int>(std::roundf(c.a * 255.0f)),
+      static_cast<int>(std::roundf(c.r * 255.0f)),
+      static_cast<int>(std::roundf(c.g * 255.0f)),
+      static_cast<int>(std::roundf(c.b * 255.0f))
+    );
+  }
+
+  inline D3DCOLORVALUE ColorToColorV(const D3DCOLOR& c) {
+    return D3DCOLORVALUE{
+      ((c >> 16) & 0xFF) / 255.0f,
+      ((c >> 8)  & 0xFF) / 255.0f,
+      ((c >> 0)  & 0xFF) / 255.0f,
+      ((c >> 24) & 0xFF) / 255.0f,
+    };
+  }
+
+  inline D3DCOLORVALUE ColorVClamp(const D3DCOLORVALUE& color, float min, float max) {
+    return D3DCOLORVALUE{
+      std::clamp(color.r, min, max),
+      std::clamp(color.g, min, max),
+      std::clamp(color.b, min, max),
+      std::clamp(color.a, min, max),
+    };
   }
 
   inline void MaterialColorSource(
@@ -497,19 +657,12 @@ namespace dxvk {
     return materialColor;
   }
 
-  inline Vector4 NormalizeVec3(const Vector4& v) {
-    Vector4 result = normalize(Vector4(v.x, v.y, v.z, 0.0f));
-    result.w = 0.0f;
-
-    return result;
-  }
-
   inline void ApplyLight(
         const PVLIGHT* light9, bool localViewer, D3DCOLORVALUE& diffuse, D3DCOLORVALUE& specular,
         const D3DVECTOR* normals, const D3DVECTOR* hitDirection, const D3DVECTOR* position,
         float attenuation, float materialPower, bool isLegacy) {
-    const float direction_dot = std::clamp(D3DVec3Dot_SSE2(hitDirection, normals), 0.0f, 1.0f);
-    ColorVMultiplyAdd_SSE2(diffuse, light9->Diffuse, direction_dot * attenuation);
+    const float direction_dot = std::clamp(D3DVec3Dot(hitDirection, normals), 0.0f, 1.0f);
+    ColorVMultiplyAdd(diffuse, light9->Diffuse, direction_dot * attenuation);
 
     D3DVECTOR mid = *hitDirection;
     if (localViewer) {
@@ -521,15 +674,15 @@ namespace dxvk {
     }
 
     mid = D3DVec3Normalize(mid);
-    const float direction_transformed_dot = D3DVec3Dot_SSE2(normals, &mid);
+    const float direction_transformed_dot = D3DVec3Dot(normals, &mid);
     if (direction_transformed_dot > 0.0f && (!isLegacy || materialPower > 0.0f) && direction_dot > 0.0f)
-      ColorVMultiplyAdd_SSE2(specular, light9->Specular, powf(direction_transformed_dot, materialPower) * attenuation);
+      ColorVMultiplyAdd(specular, light9->Specular, powf(direction_transformed_dot, materialPower) * attenuation);
   }
 
   inline void ApplyFog(
         float* specularAlpha, D3DFOGMODE vertexMode, float density,
         float start, float end, bool useRange, const D3DVECTOR& position) {
-    const float coord = useRange ? sqrtf(D3DVec3Dot_SSE2(&position, &position)) : fabsf(position.z);
+    const float coord = useRange ? std::sqrtf(D3DVec3Dot(&position, &position)) : fabsf(position.z);
 
     switch (vertexMode) {
       // (end - coord) / (end - start)
@@ -775,9 +928,9 @@ namespace dxvk {
     }
 
     const bool needsCorrection = pvData->isLegacy && pvData->correction != nullptr;
-    const D3DMATRIX wv         = D3DMatrixMultiply4x4_SSE2(world9, view9);
-    const D3DMATRIX wvp        = !needsCorrection ? D3DMatrixMultiply4x4_SSE2(wv, projection9)
-                                                  : D3DMatrixMultiply4x4_SSE2(D3DMatrixMultiply4x4_SSE2(wv, projection9), *pvData->correction);
+    const D3DMATRIX wv         = D3DMatrixMultiply4x4(world9, view9);
+    const D3DMATRIX wvp        = !needsCorrection ? D3DMatrixMultiply4x4(wv, projection9)
+                                                  : D3DMatrixMultiply4x4(D3DMatrixMultiply4x4(wv, projection9), *pvData->correction);
 
     D3DFOGMODE fogVertexMode;
     float fogStart, fogEnd, fogDensity;
@@ -827,18 +980,18 @@ namespace dxvk {
 
         switch (l->Type) {
             case D3DLIGHT_DIRECTIONAL:
-              l->LightDirection = D3DVec3Normalize(D3DVec4to3Transform_SSE2(view9, {-light.Direction.x, -light.Direction.y, -light.Direction.z, 0.0f}));
+              l->LightDirection = D3DVec3Normalize(D3DVec4to3Transform(view9, {-light.Direction.x, -light.Direction.y, -light.Direction.z, 0.0f}));
               break;
             case D3DLIGHT_POINT:
-              l->LightPosition = D3DVec4to3Transform_SSE2(view9, {light.Position.x, light.Position.y, light.Position.z, 1.0f});
+              l->LightPosition = D3DVec4to3Transform(view9, {light.Position.x, light.Position.y, light.Position.z, 1.0f});
               l->Attenuation0 = light.Attenuation0;
               l->Attenuation1 = light.Attenuation1;
               l->Attenuation2 = light.Attenuation2;
               l->Range = light.Range;
               break;
             case D3DLIGHT_SPOT:
-              l->LightDirection = D3DVec3Normalize(D3DVec4to3Transform_SSE2(view9, {light.Direction.x, light.Direction.y, light.Direction.z, 0.0f}));
-              l->LightPosition = D3DVec4to3Transform_SSE2(view9, {light.Position.x, light.Position.y, light.Position.z, 1.0f});
+              l->LightDirection = D3DVec3Normalize(D3DVec4to3Transform(view9, {light.Direction.x, light.Direction.y, light.Direction.z, 0.0f}));
+              l->LightPosition = D3DVec4to3Transform(view9, {light.Position.x, light.Position.y, light.Position.z, 1.0f});
               l->cosHalfPhi = cosf(light.Phi / 2.0f);
               l->cosHalfTheta = cosf(light.Theta / 2.0f);
               l->Attenuation0 = light.Attenuation0;
@@ -871,7 +1024,7 @@ namespace dxvk {
       PositionArray outPosition;
       memcpy(outPosition.data(), inPosition.data(), sizeof(PositionArray));
       if (likely(!(pvData->inFVF & D3DFVF_XYZRHW))) {
-        D3DVECTOR4 h = D3DVec4Transform_SSE2(wvp, D3DVECTOR4{inPosition[0], inPosition[1], inPosition[2], 1.0f});
+        D3DVECTOR4 h = D3DVec4Transform(wvp, D3DVECTOR4{inPosition[0], inPosition[1], inPosition[2], 1.0f});
 
         // Hidden & Dangerous (D3D6) relies on division by zero and NAN/INF output
         const float rhw = 1.0f / h.w;
@@ -883,17 +1036,17 @@ namespace dxvk {
         if (likely(pvData->outFVF & D3DFVF_XYZRHW))
           outPosition[3] = rhw;
 
-        // Hack for Resident Evil quad alignment problem
-        if (unlikely(options->vertexOffset != 0.0f)) {
-          outPosition[0] += options->vertexOffset;
-          outPosition[1] += options->vertexOffset;
+        // Alternate pixel center workaround for the Resident Evil quad alignment problem
+        if (unlikely(options->alternatePixelCenter == AlternatePixelCenter::Legacy)) {
+          outPosition[0] -= 0.5f;
+          outPosition[1] -= 0.5f;
         }
       }
 
       D3DCOLORVALUE diffuse  = {0.0f, 0.0f, 0.0f, 0.0f};
       D3DCOLORVALUE specular = {0.0f, 0.0f, 0.0f, 0.0f};
 
-      D3DVECTOR4 WVPosition = D3DVec4Transform_SSE2(wv, D3DVECTOR4{inPosition[0], inPosition[1], inPosition[2], 1.0f});
+      D3DVECTOR4 WVPosition = D3DVec4Transform(wv, D3DVECTOR4{inPosition[0], inPosition[1], inPosition[2], 1.0f});
       const D3DVECTOR WVPosition3 = {WVPosition.x, WVPosition.y, WVPosition.z};
       const float positionScale = 1.0f / WVPosition.w;
       WVPosition.x *= positionScale;
@@ -909,7 +1062,7 @@ namespace dxvk {
         if (inNormals != nullptr) {
           D3DMATRIX normalMatrix{};
           ComputeNormalMatrix(normalMatrix, pvData->isLegacy, wv);
-          normals = D3DVec3Transform_SSE2(normalMatrix, *inNormals);
+          normals = D3DVec3Transform(normalMatrix, *inNormals);
           if (isEnabledNormalizeNormals)
             normals = D3DVec3Normalize(normals);
         }
@@ -930,8 +1083,8 @@ namespace dxvk {
             case D3DLIGHT_SPOT: {
               hitDirection = D3DVECTOR{light.LightPosition.x - WVPosition.x, light.LightPosition.y - WVPosition.y,
                                        light.LightPosition.z - WVPosition.z};
-              Vector4 destination(1.0f, 0.0f, D3DVec3Dot_SSE2(&hitDirection, &hitDirection), 0.0f);
-              destination.y = sqrtf(destination.z);
+              Vector4 destination(1.0f, 0.0f, D3DVec3Dot(&hitDirection, &hitDirection), 0.0f);
+              destination.y = std::sqrtf(destination.z);
               if (pvData->isLegacy) {
                 destination.y = (light.Range - destination.y) / light.Range;
                 if (destination.y <= 0.0f)
@@ -951,7 +1104,7 @@ namespace dxvk {
 
               if (lightType == D3DLIGHT_SPOT) {
                 const D3DVECTOR revHit = {-hitDirection.x, -hitDirection.y, -hitDirection.z};
-                const float rho = D3DVec3Dot_SSE2(&revHit, &light.LightDirection);
+                const float rho = D3DVec3Dot(&revHit, &light.LightDirection);
                 if (rho <= light.cosHalfPhi)
                   attenuation = 0.0f;
                 else if (rho <= light.cosHalfTheta)
@@ -964,7 +1117,7 @@ namespace dxvk {
               continue;
           }
 
-          ColorVMultiplyAdd_SSE2(ambient, light.Ambient, attenuation);
+          ColorVMultiplyAdd(ambient, light.Ambient, attenuation);
           if (inNormals != nullptr)
             ApplyLight(&light, isEnabledLocalViewer, diffuse, specular, &normals,
                      &hitDirection, &NVWPosition, attenuation, materialPower, pvData->isLegacy);
@@ -973,12 +1126,12 @@ namespace dxvk {
         D3DCOLORVALUE materialAmbient  = ColorFromMaterialSource(inDiffuse, inSpecular, sourceAmbient, material9.Ambient);
         D3DCOLORVALUE materialEmissive = ColorFromMaterialSource(inDiffuse, inSpecular, sourceEmissive, material9.Emissive);
 
-        diffuse.r = D3DSSE_Mad2_Add_Scalar_SSE2(ambient.r, materialAmbient.r, diffuse.r, materialDiffuse.r, materialEmissive.r);
-        diffuse.g = D3DSSE_Mad2_Add_Scalar_SSE2(ambient.g, materialAmbient.g, diffuse.g, materialDiffuse.g, materialEmissive.g);
-        diffuse.b = D3DSSE_Mad2_Add_Scalar_SSE2(ambient.b, materialAmbient.b, diffuse.b, materialDiffuse.b, materialEmissive.b);
+        diffuse.r = D3DMad2AddScalar(ambient.r, materialAmbient.r, diffuse.r, materialDiffuse.r, materialEmissive.r);
+        diffuse.g = D3DMad2AddScalar(ambient.g, materialAmbient.g, diffuse.g, materialDiffuse.g, materialEmissive.g);
+        diffuse.b = D3DMad2AddScalar(ambient.b, materialAmbient.b, diffuse.b, materialDiffuse.b, materialEmissive.b);
         diffuse.a = materialDiffuse.a;
 
-        D3DColorMulRGB_SetAlpha_SSE2(specular, materialSpecular, pvData->isLegacy);
+        D3DColorMulRGBSetAlpha(specular, materialSpecular, pvData->isLegacy);
       } else {
         diffuse  = materialDiffuse;
         specular = materialSpecular;
@@ -987,8 +1140,8 @@ namespace dxvk {
       if (isEnabledFog)
         ApplyFog(&specular.a, fogVertexMode, fogDensity, fogStart, fogEnd, isEnabledFogRange, WVPosition3);
 
-      D3DColorClamp_SSE2(diffuse);
-      D3DColorClamp_SSE2(specular);
+      D3DColorClamp(diffuse);
+      D3DColorClamp(specular);
 
       const D3DCOLOR outDiffuse  = ColorVToColor(diffuse);
       const D3DCOLOR outSpecular = ColorVToColor(specular);

--- a/src/ddraw/ddraw.sym
+++ b/src/ddraw/ddraw.sym
@@ -10,7 +10,7 @@
     DirectDrawCreate;
     DirectDrawCreateClipper;
     DirectDrawCreateEx;
-  	DirectDrawEnumerateA;
+    DirectDrawEnumerateA;
     DirectDrawEnumerateExA;
     DirectDrawEnumerateExW;
     DirectDrawEnumerateW;

--- a/src/ddraw/ddraw/ddraw_interface.cpp
+++ b/src/ddraw/ddraw/ddraw_interface.cpp
@@ -17,8 +17,6 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> DDrawInterface::s_intfCount = 0;
-
   DDrawInterface::DDrawInterface(
         DDrawCommonInterface* commonIntf,
         Com<IDirectDraw>&& proxyIntf)
@@ -28,9 +26,9 @@ namespace dxvk {
     if (likely(m_commonIntf == nullptr)) {
       // We need a temporary D3D9 interface to retrieve the options
       Com<d3d9::IDirect3D9> d3d9Intf = d3d9::Direct3DCreate9(D3D_SDK_VERSION);
-      Com<IDxvkD3D8InterfaceBridge> d3d9Bridge;
+      Com<IDxvkLegacyD3DInterfaceBridge> d3d9Bridge;
 
-      if (unlikely(FAILED(d3d9Intf->QueryInterface(__uuidof(IDxvkD3D8InterfaceBridge), reinterpret_cast<void**>(&d3d9Bridge))))) {
+      if (unlikely(FAILED(d3d9Intf->QueryInterface(__uuidof(IDxvkLegacyD3DInterfaceBridge), reinterpret_cast<void**>(&d3d9Bridge))))) {
         throw DxvkError("DDrawInterface: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
       }
 
@@ -41,10 +39,6 @@ namespace dxvk {
       m_commonIntf->SetOrigin(this);
 
     m_commonIntf->SetDDInterface(this);
-
-    m_intfCount = ++s_intfCount;
-
-    Logger::debug(str::format("DDrawInterface: Created a new interface nr. <<1-", m_intfCount, ">>"));
   }
 
   DDrawInterface::~DDrawInterface() {
@@ -52,8 +46,6 @@ namespace dxvk {
       m_commonIntf->SetOrigin(nullptr);
 
     m_commonIntf->SetDDInterface(nullptr);
-
-    Logger::debug(str::format("DDrawInterface: Interface nr. <<1-", m_intfCount, ">> bites the dust"));
   }
 
   HRESULT STDMETHODCALLTYPE DDrawInterface::QueryInterface(REFIID riid, void** ppvObject) {
@@ -211,57 +203,72 @@ namespace dxvk {
 
     InitReturnPtr(lplpDDSurface);
 
-    // Because we are removing the DDSCAPS_WRITEONLY flag below, we need
-    // to first validate the combinations that would otherwise cause issues
-    HRESULT hr = ValidateSurfaceFlags(lpDDSurfaceDesc);
-    if (unlikely(FAILED(hr)))
-      return hr;
+    if (likely(lpDDSurfaceDesc->dwFlags & DDSD_CAPS)) {
+      // Because we are removing the DDSCAPS_WRITEONLY flag below, we need
+      // to first validate the combinations that would otherwise cause issues
+      HRESULT hr = ValidateSurfaceFlags(lpDDSurfaceDesc);
+      if (unlikely(FAILED(hr)))
+        return hr;
 
-    // We need to ensure we can always read from surfaces for upload to
-    // D3D9, so always strip the DDSCAPS_WRITEONLY flag on creation
-    lpDDSurfaceDesc->ddsCaps.dwCaps &= ~DDSCAPS_WRITEONLY;
-
-    // Work around a WineD3D bug/limitation that prevents
-    // read back from L6V5U5 and X8L8V8U8 video memory surfaces
-    //
-    // Note: Doing this for other surfaces/formats is a bad idea,
-    // because some games expect these flags to remain in place, and
-    // may crash in case they find that's not the case
-    if (unlikely((lpDDSurfaceDesc->ddpfPixelFormat.dwFlags & DDPF_BUMPLUMINANCE)
-              && (lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_VIDEOMEMORY))) {
-      Logger::warn("DDrawInterface::CreateSurface: Video memory DDPF_BUMPLUMINANCE surface");
-      lpDDSurfaceDesc->ddsCaps.dwCaps &= ~DDSCAPS_VIDEOMEMORY &
-                                         ~DDSCAPS_LOCALVIDMEM &
-                                         ~DDSCAPS_NONLOCALVIDMEM;
-      lpDDSurfaceDesc->ddsCaps.dwCaps |= DDSCAPS_SYSTEMMEMORY;
+      // We need to ensure we can always read from surfaces for upload to
+      // D3D9, so always strip the DDSCAPS_WRITEONLY flag on creation
+      lpDDSurfaceDesc->ddsCaps.dwCaps &= ~DDSCAPS_WRITEONLY;
     }
 
-    if (unlikely(lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_ZBUFFER)) {
-      if (unlikely(m_commonIntf->GetOptions()->useD16forD24X8
-                && lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFF
-                && lpDDSurfaceDesc->ddpfPixelFormat.dwStencilBitMask == 0x0)) {
-        // Games such as Need for Speed: Porsche are broken with 32-bit color
-        // on night tracks with "projected" lights, because they clearly were
-        // designed with 16-bit Z buffers in mind. Fix it up by silently swapping
-        // D16 for D24X8 on depth stencil creation.
-        Logger::info("DDrawInterface::CreateSurface: Using D16 instead of D24X8");
-        lpDDSurfaceDesc->ddpfPixelFormat.dwZBufferBitDepth = 16;
-        lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFF;
-      } else if (unlikely(lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFFFF)) {
-        if (m_commonIntf->GetOptions()->useD24X8forD32) {
-          // In case of up-front unsupported and unadvertised D32 depth stencil use,
-          // replace it with D24X8, as some games, such as Sacrifice, rely on it
-          // to properly enable 32-bit display modes (and revert to 16-bit otherwise)
-          Logger::info("DDrawInterface::CreateSurface: Using D24X8 instead of D32");
-          lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFFFF;
-        } else {
-          Logger::warn("DDrawInterface::CreateSurface: Use of unsupported D32");
+    if (likely(lpDDSurfaceDesc->dwFlags & DDSD_PIXELFORMAT)) {
+      // WineD3D will fail to create 8-bit texture surfaces at times, for whatever reason...
+      if (unlikely((lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_TEXTURE)
+               &&  (lpDDSurfaceDesc->ddpfPixelFormat.dwFlags & DDPF_RGB)
+               &&   lpDDSurfaceDesc->ddpfPixelFormat.dwRGBBitCount == 8
+               && !(lpDDSurfaceDesc->ddpfPixelFormat.dwFlags & DDPF_PALETTEINDEXED8))) {
+        static bool s_8bitTextureWarningShown;
+
+        if (!std::exchange(s_8bitTextureWarningShown, true))
+          Logger::warn("DDrawInterface::CreateSurface: Use of potentially unsupported 8-bit texture surface");
+      }
+
+      // Work around a WineD3D bug/limitation that prevents
+      // read back from L6V5U5 and X8L8V8U8 video memory surfaces
+      //
+      // Note: Doing this for other surfaces/formats is a bad idea,
+      // because some games expect these flags to remain in place, and
+      // may crash in case they find that's not the case
+      if (unlikely((lpDDSurfaceDesc->ddpfPixelFormat.dwFlags == (DDPF_BUMPDUDV | DDPF_BUMPLUMINANCE))
+                && (lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_VIDEOMEMORY))) {
+        Logger::warn("DDrawInterface::CreateSurface: Video memory DDPF_BUMPLUMINANCE surface");
+        lpDDSurfaceDesc->ddsCaps.dwCaps &= ~DDSCAPS_VIDEOMEMORY &
+                                           ~DDSCAPS_LOCALVIDMEM &
+                                           ~DDSCAPS_NONLOCALVIDMEM;
+        lpDDSurfaceDesc->ddsCaps.dwCaps |= DDSCAPS_SYSTEMMEMORY;
+      }
+
+      if (unlikely(lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_ZBUFFER)) {
+        if (unlikely(m_commonIntf->GetOptions()->useD16forD24X8
+                  && lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFF
+                  && lpDDSurfaceDesc->ddpfPixelFormat.dwStencilBitMask == 0x0)) {
+          // Games such as Need for Speed: Porsche are broken with 32-bit color
+          // on night tracks with "projected" lights, because they clearly were
+          // designed with 16-bit Z buffers in mind. Fix it up by silently swapping
+          // D16 for D24X8 on depth stencil creation.
+          Logger::debug("DDrawInterface::CreateSurface: Using D16 instead of D24X8");
+          lpDDSurfaceDesc->ddpfPixelFormat.dwZBufferBitDepth = 16;
+          lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFF;
+        } else if (unlikely(lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFFFF)) {
+          if (m_commonIntf->GetOptions()->useD24X8forD32) {
+            // In case of up-front unsupported and unadvertised D32 depth stencil use,
+            // replace it with D24X8, as some games, such as Sacrifice, rely on it
+            // to properly enable 32-bit display modes (and revert to 16-bit otherwise)
+            Logger::debug("DDrawInterface::CreateSurface: Using D24X8 instead of D32");
+            lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFFFF;
+          } else {
+            Logger::warn("DDrawInterface::CreateSurface: Use of unsupported D32");
+          }
         }
       }
     }
 
     Com<IDirectDrawSurface> ddrawSurfaceProxied;
-    hr = m_proxy->CreateSurface(lpDDSurfaceDesc, &ddrawSurfaceProxied, pUnkOuter);
+    HRESULT hr = m_proxy->CreateSurface(lpDDSurfaceDesc, &ddrawSurfaceProxied, pUnkOuter);
     // Some games simply try creating surfaces with various formats until something works...
     if (unlikely(FAILED(hr)))
       return hr;
@@ -275,10 +282,8 @@ namespace dxvk {
 
         // Shadow surface creation for the primary surface
         // (it needs to be based on the same incoming desc)
-        if (unlikely(!surface->GetCommonSurface()->Is8BitFormat() &&
-                      m_commonIntf->GetOptions()->forceLegacyPresent)) {
-          Logger::debug("DDrawInterface::CreateSurface: Creating shadow surface");
-
+        if (unlikely(m_commonIntf->GetOptions()->forceLegacyPresent &&
+                    !surface->GetCommonSurface()->SkipD3D9Operations())) {
           DDSURFACEDESC shadowDesc = *lpDDSurfaceDesc;
           const DDSURFACEDESC* primaryDesc = surface->GetCommonSurface()->GetDesc();
 
@@ -341,7 +346,35 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDrawInterface::EnumDisplayModes(DWORD dwFlags, LPDDSURFACEDESC lpDDSurfaceDesc, LPVOID lpContext, LPDDENUMMODESCALLBACK lpEnumModesCallback) {
-    return m_proxy->EnumDisplayModes(dwFlags, lpDDSurfaceDesc, lpContext, lpEnumModesCallback);
+    if (unlikely(lpEnumModesCallback == nullptr))
+      return DDERR_INVALIDPARAMS;
+
+    std::vector<DDSURFACEDESC> displayModes;
+    HRESULT hr = m_proxy->EnumDisplayModes(dwFlags, lpDDSurfaceDesc, reinterpret_cast<void*>(&displayModes), EnumDisplayModesCallback);
+    if (unlikely(FAILED(hr)))
+      return hr;
+
+    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
+
+    hr = DDENUMRET_OK;
+
+    auto displayModeIt = displayModes.begin();
+    while (displayModeIt != displayModes.end() && hr == DDENUMRET_OK) {
+      DDSURFACEDESC dmDesc = *displayModeIt;
+
+      if (unlikely(d3dOptions->mask8BitModes && dmDesc.ddpfPixelFormat.dwRGBBitCount == 8)) {
+        static bool s_maskModeWarningShown;
+
+        if (!std::exchange(s_maskModeWarningShown, true))
+          Logger::warn("DDrawInterface::EnumDisplayModes: Masking 8-bit display modes");
+      } else {
+        hr = lpEnumModesCallback(&dmDesc, lpContext);
+      }
+
+      ++displayModeIt;
+    }
+
+    return DD_OK;
   }
 
   HRESULT STDMETHODCALLTYPE DDrawInterface::EnumSurfaces(DWORD dwFlags, LPDDSURFACEDESC lpDDSD, LPVOID lpContext, LPDDENUMSURFACESCALLBACK lpEnumSurfacesCallback) {
@@ -473,8 +506,17 @@ namespace dxvk {
 
     const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
 
-    if (unlikely(d3dOptions->mask8BitModes && lpDDSurfaceDesc->ddpfPixelFormat.dwRGBBitCount == 8))
+    if (unlikely(d3dOptions->mask8BitModes
+              && lpDDSurfaceDesc->dwFlags & DDSD_PIXELFORMAT
+              && lpDDSurfaceDesc->ddpfPixelFormat.dwRGBBitCount == 8)) {
+      // Report a fake D3DFMT_R5G6B5 back buffer scenario
+      lpDDSurfaceDesc->ddpfPixelFormat.dwFlags = DDPF_RGB;
       lpDDSurfaceDesc->ddpfPixelFormat.dwRGBBitCount = 16;
+      lpDDSurfaceDesc->ddpfPixelFormat.dwRGBAlphaBitMask = 0x0000;
+      lpDDSurfaceDesc->ddpfPixelFormat.dwRBitMask = 0xf800;
+      lpDDSurfaceDesc->ddpfPixelFormat.dwGBitMask = 0x07e0;
+      lpDDSurfaceDesc->ddpfPixelFormat.dwBBitMask = 0x001f;
+    }
 
     return DD_OK;
   }
@@ -578,7 +620,7 @@ namespace dxvk {
     DDrawCommonSurface* ps = m_commonIntf->GetPrimarySurface();
 
     if (likely(ps != nullptr)) {
-      hr = ps->RefreshSurfaceDescripton();
+      hr = ps->RefreshSurfaceDescripton(true);
       if (unlikely(FAILED(hr)))
         Logger::warn("DDrawInterface::SetDisplayMode: Failed to update primary surface desc");
     }

--- a/src/ddraw/ddraw/ddraw_interface.h
+++ b/src/ddraw/ddraw/ddraw_interface.h
@@ -79,9 +79,6 @@ namespace dxvk {
     Com<D3D3Interface, false> m_d3d3Intf;
     Com<D3D5Interface, false> m_d3d5Intf;
 
-    uint32_t                  m_intfCount = 0;
-    static std::atomic<uint32_t> s_intfCount;
-
   };
 
 }

--- a/src/ddraw/ddraw/ddraw_surface.cpp
+++ b/src/ddraw/ddraw/ddraw_surface.cpp
@@ -13,8 +13,6 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> DDrawSurface::s_surfCount = 0;
-
   DDrawSurface::DDrawSurface(
         DDrawCommonSurface* commonSurf,
         Com<IDirectDrawSurface>&& surfProxy,
@@ -59,7 +57,7 @@ namespace dxvk {
       if (likely(m_nextFlippable != nullptr)) {
         // The call to EnumAttachedSurfaces has incremented the public ref
         m_nextFlippable->Release();
-        Logger::debug("DDrawSurface: Retrieved the next swapchain surface");
+        //Logger::debug("DDrawSurface: Retrieved the next swapchain surface");
       }
     }
 
@@ -76,14 +74,12 @@ namespace dxvk {
     if (m_parent != nullptr && m_isChildObject)
       m_parent->AddRef();
 
-    m_surfCount = ++s_surfCount;
-
-    Logger::debug(str::format("DDrawSurface: Created a new surface nr. [[1-", m_surfCount, "]]"));
+    //Logger::debug(str::format("DDrawSurface: Created a new surface nr. [[1-", std::hex, this, "]]"));
 
     if (m_commonSurf->GetOrigin() == nullptr) {
       m_commonSurf->SetOrigin(this);
       m_commonSurf->SetIsAttached(m_parentSurf != nullptr);
-      m_commonSurf->ListSurfaceDetails();
+      //m_commonSurf->ListSurfaceDetails();
     }
   }
 
@@ -116,7 +112,7 @@ namespace dxvk {
 
     m_commonSurf->SetDDSurface(nullptr);
 
-    Logger::debug(str::format("DDrawSurface: Surface nr. [[1-", m_surfCount, "]] bites the dust"));
+    //Logger::debug(str::format("DDrawSurface: Surface nr. [[1-", std::hex, this, "]] bites the dust"));
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::QueryInterface(REFIID riid, void** ppvObject) {
@@ -378,7 +374,7 @@ namespace dxvk {
       DownloadSurfaceData();
     }
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
     if (likely(d3d9Device != nullptr)) {
       const bool exclusiveMode = m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE;
 
@@ -434,7 +430,7 @@ namespace dxvk {
       return DDERR_UNSUPPORTED;
     }
 
-    RECT* sourceFullSurfaceRect = nullptr;
+    const RECT* sourceFullSurfaceRect = nullptr;
     // Write back any dirty surface data from bound D3D9 back buffers or
     // depth stencils, for both the source surface and the current surface
     if (likely(lpDDSrcSurface != nullptr)) {
@@ -450,7 +446,7 @@ namespace dxvk {
       DownloadSurfaceData();
     }
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
     if (likely(d3d9Device != nullptr)) {
       const bool exclusiveMode = m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE;
 
@@ -588,7 +584,7 @@ namespace dxvk {
 
     Com<DDrawSurface> overrideSurf = static_cast<DDrawSurface*>(lpDDSurfaceTargetOverride);
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
     // Overlays can have odd video formats which DXVK doesn't support for RT
     // use, so let DDraw present in case the flipped surface is an overlay
     if (likely(d3d9Device != nullptr && !m_commonSurf->IsOverlay())) {
@@ -647,25 +643,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DDrawSurface::GetAttachedSurface(LPDDSCAPS lpDDSCaps, LPDIRECTDRAWSURFACE *lplpDDAttachedSurface) {
     if (unlikely(lpDDSCaps == nullptr || lplpDDAttachedSurface == nullptr))
       return DDERR_INVALIDPARAMS;
-
-    if (lpDDSCaps->dwCaps & DDSCAPS_PRIMARYSURFACE)
-      Logger::debug("DDrawSurface::GetAttachedSurface: Querying for the primary surface");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_FRONTBUFFER)
-      Logger::debug("DDrawSurface::GetAttachedSurface: Querying for the front buffer");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_BACKBUFFER)
-      Logger::debug("DDrawSurface::GetAttachedSurface: Querying for the back buffer");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_FLIP)
-      Logger::debug("DDrawSurface::GetAttachedSurface: Querying for a flippable surface");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_OFFSCREENPLAIN)
-      Logger::debug("DDrawSurface::GetAttachedSurface: Querying for an offscreen plain surface");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_ZBUFFER)
-      Logger::debug("DDrawSurface::GetAttachedSurface: Querying for a depth stencil");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_MIPMAP)
-      Logger::debug("DDrawSurface::GetAttachedSurface: Querying for a texture mip map");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_TEXTURE)
-      Logger::debug("DDrawSurface::GetAttachedSurface: Querying for a texture");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_OVERLAY)
-      Logger::debug("DDrawSurface::GetAttachedSurface: Querying for an overlay");
 
     Com<IDirectDrawSurface> surface;
     HRESULT hr = m_proxy->GetAttachedSurface(lpDDSCaps, &surface);
@@ -819,7 +796,21 @@ namespace dxvk {
     // Write back any dirty surface data from bound D3D9 back buffers or depth stencils
     DownloadSurfaceData();
 
-    return GetShadowOrProxied()->Lock(lpDestRect, lpDDSurfaceDesc, dwFlags, hEvent);
+    HRESULT hr = GetShadowOrProxied()->Lock(lpDestRect, lpDDSurfaceDesc, dwFlags, hEvent);
+    if (unlikely(FAILED(hr)))
+      return hr;
+
+    // For single surface locks, track the READONLY flag in order to skip dirtying
+    // on Unlock(). Reset the tracking in case of multiple simultaneous locks.
+    if (likely(!m_lockCount)) {
+      m_readOnlyLock = (dwFlags & DDLOCK_READONLY) && !(dwFlags & DDLOCK_WRITEONLY);
+    } else {
+      m_readOnlyLock = false;
+    }
+
+    m_lockCount++;
+
+    return DD_OK;
   }
 
   HRESULT STDMETHODCALLTYPE DDrawSurface::ReleaseDC(HDC hDC) {
@@ -840,7 +831,7 @@ namespace dxvk {
 
     m_commonSurf->DirtyDDrawSurface();
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
     if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
       const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                 !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
@@ -905,7 +896,7 @@ namespace dxvk {
     if (unlikely(FAILED(hr)))
       return hr;
 
-    hr = m_commonSurf->RefreshSurfaceDescripton();
+    hr = m_commonSurf->RefreshSurfaceDescripton(false);
     if (unlikely(FAILED(hr)))
       Logger::err("DDrawSurface::SetColorKey: Failed to retrieve updated surface desc");
 
@@ -914,7 +905,7 @@ namespace dxvk {
       if (unlikely(FAILED(hr))) {
         Logger::warn("DDrawSurface::SetColorKey: Failed to set shadow surface color key");
       } else {
-        hr = m_shadowSurf->GetCommonSurface()->RefreshSurfaceDescripton();
+        hr = m_shadowSurf->GetCommonSurface()->RefreshSurfaceDescripton(false);
         if (unlikely(FAILED(hr)))
           Logger::warn("DDrawSurface::SetColorKey: Failed to retrieve updated shadow surface desc");
       }
@@ -953,9 +944,16 @@ namespace dxvk {
     if (unlikely(FAILED(hr)))
       return hr;
 
-    m_commonSurf->DirtyDDrawSurface();
+    if (!m_readOnlyLock) {
+      m_commonSurf->DirtyDDrawSurface();
+    } else {
+      m_readOnlyLock = false;
+    }
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    if (likely(m_lockCount))
+      m_lockCount--;
+
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
     if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
       const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                 !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
@@ -1003,29 +1001,19 @@ namespace dxvk {
     }
   }
 
-  IDirectDrawSurface* DDrawSurface::GetShadowOrProxied() {
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
-
-    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr))
-      return m_shadowSurf->GetProxied();
-
-    return m_proxy.ptr();
-  }
-
   HRESULT DDrawSurface::InitializeD3D9RenderTarget() {
+    // Currently ignores all P8 surfaces
+    if (unlikely(m_commonSurf->SkipD3D9Operations()))
+      return DD_OK;
+
     m_commonSurf->RefreshD3D9Device();
 
-    m_commonSurf->MarkAsD3D9BackBuffer();
-
     if (unlikely(!m_commonSurf->IsInitialized())) {
-      if (m_commonSurf->IsTexture())
-        UpdateMipMapCount();
-
       HRESULT hr = m_commonSurf->InitializeD3D9(true);
-      if (unlikely(FAILED(hr)))
+      if (unlikely(FAILED(hr))) {
+        Logger::err(str::format("DDrawSurface::InitializeD3D9RenderTarget: Failed to initialize surface nr. [[1-", std::hex, this, "]]"));
         return hr;
-
-      Logger::debug(str::format("DDrawSurface::InitializeD3D9RenderTarget: Initialized surface nr. [[1-", m_surfCount, "]]"));
+      }
 
       return UploadSurfaceData();
     }
@@ -1036,14 +1024,12 @@ namespace dxvk {
   HRESULT DDrawSurface::InitializeD3D9DepthStencil() {
     m_commonSurf->RefreshD3D9Device();
 
-    m_commonSurf->MarkAsD3D9DepthStencil();
-
     if (unlikely(!m_commonSurf->IsInitialized())) {
       HRESULT hr = m_commonSurf->InitializeD3D9(false);
-      if (unlikely(FAILED(hr)))
+      if (unlikely(FAILED(hr))) {
+        Logger::err(str::format("DDrawSurface::InitializeD3D9DepthStencil: Failed to initialize surface nr. [[1-", std::hex, this, "]]"));
         return hr;
-
-      Logger::debug(str::format("DDrawSurface::InitializeD3D9DepthStencil: Initialized surface nr. [[1-", m_surfCount, "]]"));
+      }
 
       return UploadSurfaceData();
     }
@@ -1052,29 +1038,27 @@ namespace dxvk {
   }
 
   HRESULT DDrawSurface::InitializeOrUploadD3D9() {
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    // Currently ignores all P8 surfaces
+    if (unlikely(m_commonSurf->SkipD3D9Operations()))
+      return DD_OK;
+
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
 
     // Fast skip
     if (unlikely(d3d9Device == nullptr))
       return DD_OK;
 
     if (unlikely(!m_commonSurf->IsInitialized())) {
-      if (m_commonSurf->IsTexture())
-        UpdateMipMapCount();
-
       const bool initRenderTarget = m_commonSurf->GetCommonD3DDevice()->IsCurrentRenderTarget(m_commonSurf.ptr());
 
       HRESULT hr = m_commonSurf->InitializeD3D9(initRenderTarget);
-      if (unlikely(FAILED(hr)))
+      if (unlikely(FAILED(hr))) {
+        Logger::err(str::format("DDrawSurface::InitializeOrUploadD3D9: Failed to initialize surface nr. [[1-", std::hex, this, "]]"));
         return hr;
-
-      Logger::debug(str::format("DDrawSurface::InitializeOrUploadD3D9: Initialized surface nr. [[1-", m_surfCount, "]]"));
+      }
     }
 
-    if (likely(m_commonSurf->IsInitialized()))
-      return UploadSurfaceData();
-
-    return DD_OK;
+    return UploadSurfaceData();
   }
 
   void DDrawSurface::DownloadSurfaceData() {
@@ -1086,63 +1070,13 @@ namespace dxvk {
     if (likely(!m_commonIntf->GetOptions()->deviceResourceSharing))
       m_commonSurf->RefreshD3D9Device();
 
-    if (unlikely(m_commonSurf->IsD3D9BackBuffer())) {
-      if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
-        //Logger::debug(str::format("DDrawSurface::DownloadSurfaceData: Downloading nr. [[1-", m_surfCount, "]]"));
-        BlitToDDrawSurface<IDirectDrawSurface, DDSURFACEDESC>(GetShadowOrProxied(), m_commonSurf->GetD3D9Surface(),
-                                                              m_commonSurf->IsDXTFormat());
-        m_commonSurf->UnDirtyD3D9Surface();
-      }
-    } else if (unlikely(m_commonSurf->IsD3D9DepthStencil())) {
-      if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
-        //Logger::debug(str::format("DDrawSurface::DownloadSurfaceData: Downloading nr. [[1-", m_surfCount, "]]"));
-        BlitToDDrawSurface<IDirectDrawSurface, DDSURFACEDESC>(m_proxy.ptr(), m_commonSurf->GetD3D9Surface(),
-                                                              m_commonSurf->IsDXTFormat());
-        m_commonSurf->UnDirtyD3D9Surface();
-      }
+    // TODO: We are technically ignoring mip maps as is, though that will probably never be an issue
+    if (m_commonSurf->IsD3D9SurfaceDirty() && m_commonSurf->IsInitialized()) {
+      //Logger::debug(str::format("DDrawSurface::DownloadSurfaceData: Downloading nr. [[1-", std::hex, this, "]]"));
+      BlitToDDrawSurface<IDirectDrawSurface, DDSURFACEDESC>(GetShadowOrProxied(), m_commonSurf->GetD3D9Surface(),
+                                                            m_commonSurf->IsDXTFormat());
+      m_commonSurf->UnDirtyD3D9Surface();
     }
-  }
-
-  void DDrawSurface::UpdateMipMapCount() {
-    // We need to count the number of actual mips on initialization by going through
-    // the mip chain, since the dwMipMapCount number may or may not be accurate. I am
-    // guessing it was intended more as a hint, not neceesarily a set number.
-    const DDSURFACEDESC* desc  = m_commonSurf->GetDesc();
-
-    IDirectDrawSurface* mipMap = m_proxy.ptr();
-    DDSURFACEDESC mipDesc;
-    uint16_t mipCount = 1;
-
-    while (mipMap != nullptr) {
-      IDirectDrawSurface* parentSurface = mipMap;
-      mipMap = nullptr;
-      parentSurface->EnumAttachedSurfaces(&mipMap, ListMipChainSurfacesCallback);
-      if (mipMap != nullptr) {
-        mipCount++;
-
-        mipDesc = { };
-        mipDesc.dwSize = sizeof(DDSURFACEDESC2);
-        mipMap->GetSurfaceDesc(&mipDesc);
-        // Ignore multiple 1x1 mips, which apparently can get generated if the
-        // application gets the dwMipMapCount wrong vs surface dimensions.
-        if (unlikely(mipDesc.dwWidth == 1 && mipDesc.dwHeight == 1))
-          break;
-      }
-    }
-
-    // Do not worry about maximum supported mip map levels validation,
-    // because D3D9 will handle this for us and cap them appropriately
-    if (mipCount > 1) {
-      Logger::debug(str::format("DDrawSurface::InitializeD3D9: Found ", mipCount, " mip levels"));
-
-      if (unlikely(mipCount != desc->dwMipMapCount))
-        Logger::debug(str::format("DDrawSurface::InitializeD3D9: Mismatch with declared ", desc->dwMipMapCount, " mip levels"));
-    }
-
-    if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps))
-      mipCount = 0;
-
-    m_commonSurf->SetMipCount(mipCount);
   }
 
   inline HRESULT DDrawSurface::UploadSurfaceData() {
@@ -1150,15 +1084,19 @@ namespace dxvk {
     if (!m_commonSurf->IsDDrawSurfaceDirty())
       return DD_OK;
 
-    //Logger::debug(str::format("DDrawSurface::UploadSurfaceData: Uploading nr. [[1-", m_surfCount, "]]"));
+    //Logger::debug(str::format("DDrawSurface::UploadSurfaceData: Uploading nr. [[1-", std::hex, this, "]]"));
 
-    if (m_commonSurf->IsTexture()) {
-      BlitToD3D9Texture<IDirectDrawSurface, DDSURFACEDESC>(m_commonSurf->GetD3D9Texture(), m_proxy.ptr(),
-                                                           m_commonSurf->GetMipCount(), m_commonSurf->IsDXTFormat());
-    // Blit surfaces directly
-    } else {
-      BlitToD3D9Surface<IDirectDrawSurface, DDSURFACEDESC>(m_commonSurf->GetD3D9Surface(), GetShadowOrProxied(),
-                                                           m_commonSurf->IsDXTFormat());
+    D3D9SurfaceType d3d9SurfaceType = m_commonSurf->GetD3D9SurfaceType();
+
+    switch (d3d9SurfaceType) {
+      case D3D9SurfaceType::Texture:
+        BlitToD3D9Texture<IDirectDrawSurface, DDSURFACEDESC>(m_commonSurf->GetD3D9Texture(), m_proxy.ptr(),
+                                                             m_commonSurf->GetMipCount(), m_commonSurf->IsDXTFormat());
+        break;
+      default:
+        BlitToD3D9Surface<IDirectDrawSurface, DDSURFACEDESC>(m_commonSurf->GetD3D9Surface(), GetShadowOrProxied(),
+                                                             m_commonSurf->IsDXTFormat());
+        break;
     }
 
     m_commonSurf->UnDirtyDDrawSurface();
@@ -1250,32 +1188,21 @@ namespace dxvk {
 
     Logger::info(str::format("DDrawSurface::CreateDeviceInternal: Back buffer size: ", desc->dwWidth, "x", desc->dwHeight));
 
-    const DWORD backBufferCount = DetermineBackBufferCount(m_proxy.ptr());
+    const DWORD backBufferCount = DetermineBackBufferCount<IDirectDrawSurface>(m_proxy.ptr());
     Logger::info(str::format("DDrawSurface::CreateDeviceInternal: Back buffer count: ", backBufferCount));
 
-    Com<d3d9::IDirect3D9> d3d9Intf;
-    // D3D3 is "special", so we might not have a valid D3D3 interface to work with
-    // at this point. Create a temporary D3D9 interface should that ever happen.
     D3D3Interface* d3d3Intf = m_commonIntf->GetOrCreateD3D3Interface();
+    // D3D3 is "special", so in odd cases we might not have a valid D3D3 interface to work with
     if (unlikely(d3d3Intf == nullptr)) {
-      Logger::warn("DDrawSurface::CreateDeviceInternal: Creating a temporary D3D9 interface");
-      d3d9Intf = d3d9::Direct3DCreate9(D3D_SDK_VERSION);
-
-      Com<IDxvkD3D8InterfaceBridge> d3d9Bridge;
-
-      if (unlikely(FAILED(d3d9Intf->QueryInterface(__uuidof(IDxvkD3D8InterfaceBridge), reinterpret_cast<void**>(&d3d9Bridge))))) {
-        Logger::err("DDrawSurface::CreateDeviceInternal: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
-        return DDERR_GENERIC;
-      }
-
-      d3d9Bridge->EnableD3D3CompatibilityMode();
-    } else {
-      d3d9Intf = d3d3Intf->GetCommonD3DInterface()->GetD3D9Interface();
+      Logger::err("DDrawSurface::CreateDeviceInternal: Unable to retrieve a valid D3D3 interface");
+      return DDERR_UNSUPPORTED;
     }
+
+    D3DCommonInterface* commonD3DIntf = d3d3Intf->GetCommonD3DInterface();
 
     // Determine the supported AA sample count by querying the D3D9 interface
     const d3d9::D3DMULTISAMPLE_TYPE multiSampleType = d3dOptions->emulateFSAA != FSAAEmulation::Disabled ?
-                                                      GetSupportedMultiSampleType(d3d9Intf.ptr(), backBufferFormat) :
+                                                      commonD3DIntf->GetMultiSampleType(backBufferFormat) :
                                                       d3d9::D3DMULTISAMPLE_NONE;
 
     d3d9::D3DPRESENT_PARAMETERS params;
@@ -1295,7 +1222,7 @@ namespace dxvk {
     params.PresentationInterval       = D3DPRESENT_INTERVAL_DEFAULT; // A D3D3 device always uses VSync
 
     Com<d3d9::IDirect3DDevice9> device9;
-    HRESULT hr = d3d9Intf->CreateDevice(
+    HRESULT hr = commonD3DIntf->GetD3D9Interface()->CreateDevice(
       D3DADAPTER_DEFAULT,
       d3d9::D3DDEVTYPE_HAL,
       hWnd,
@@ -1315,8 +1242,11 @@ namespace dxvk {
 
       // Set the common device on the common interface
       m_commonIntf->SetCommonD3DDevice(device3->GetCommonD3DDevice());
-      // Now that we have a valid D3D9 device pointer, we can initialize the depth stencil (if any)
-      device3->InitializeDS();
+      // Now that we have a valid common D3D device on the DDraw interface,
+      // we can initialize the render target and depth stencil (if any)
+      hr = device3->InitializeRTAndDS();
+      if (unlikely(FAILED(hr)))
+        return hr;
 
       *ppvObject = device3.ref();
     } catch (const DxvkError& e) {
@@ -1325,33 +1255,6 @@ namespace dxvk {
     }
 
     return DD_OK;
-  }
-
-  inline DWORD DDrawSurface::DetermineBackBufferCount(IDirectDrawSurface* renderTarget) {
-    DWORD backBufferCount = 0;
-
-    IDirectDrawSurface* backBuffer = renderTarget;
-    HRESULT hr;
-
-    while (backBuffer != nullptr) {
-      IDirectDrawSurface* parentSurface = backBuffer;
-      backBuffer = nullptr;
-
-      hr = parentSurface->EnumAttachedSurfaces(&backBuffer, ListBackBufferSurfacesCallback);
-      if (unlikely(FAILED(hr))) {
-        Logger::warn("DDrawSurface::DetermineBackBufferCount: Unable to enumerate attached surfaces");
-        break;
-      }
-
-      // The swapchain will eventually return to its origin
-      if (backBuffer == renderTarget)
-        break;
-
-      if (likely(backBuffer != nullptr))
-        backBufferCount++;
-    }
-
-    return std::max<DWORD>(1u, backBufferCount);
   }
 
 }

--- a/src/ddraw/ddraw/ddraw_surface.h
+++ b/src/ddraw/ddraw/ddraw_surface.h
@@ -101,8 +101,6 @@ namespace dxvk {
 
     HRESULT STDMETHODCALLTYPE UpdateOverlayZOrder(DWORD dwFlags, LPDIRECTDRAWSURFACE lpDDSReference);
 
-    IDirectDrawSurface* GetShadowOrProxied();
-
     HRESULT InitializeD3D9RenderTarget();
 
     HRESULT InitializeD3D9DepthStencil();
@@ -111,14 +109,21 @@ namespace dxvk {
 
     void DownloadSurfaceData();
 
-    void UpdateMipMapCount();
-
     void SetShadowSurface(Com<DDrawSurface>&& shadowSurf) {
       m_shadowSurf = shadowSurf;
     }
 
     DDrawSurface* GetShadowSurface() const {
       return m_shadowSurf.ptr();
+    }
+
+    IDirectDrawSurface* GetShadowOrProxied() {
+      d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
+
+      if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr))
+        return m_shadowSurf->GetProxied();
+
+      return m_proxy.ptr();
     }
 
     DDrawCommonSurface* GetCommonSurface() const {
@@ -197,9 +202,10 @@ namespace dxvk {
 
     inline HRESULT CreateDeviceInternal(REFIID riid, void** ppvObject);
 
-    inline DWORD DetermineBackBufferCount(IDirectDrawSurface* renderTarget);
+    bool                      m_isChildObject = false;
 
-    bool                      m_isChildObject = true;
+    bool                      m_readOnlyLock  = false;
+    std::atomic<uint8_t>      m_lockCount     = 0u;
 
     Com<DDrawCommonSurface>   m_commonSurf;
     DDrawCommonInterface*     m_commonIntf    = nullptr;
@@ -226,9 +232,6 @@ namespace dxvk {
     // They are implemented with linked list, so for example only one mip level
     // will be held in a parent texture, and the next mip level will be held in the previous mip.
     std::unordered_map<IDirectDrawSurface*, Com<DDrawSurface, false>> m_attachedSurfaces;
-
-    uint32_t                  m_surfCount     = 0;
-    static std::atomic<uint32_t> s_surfCount;
 
   };
 

--- a/src/ddraw/ddraw2/ddraw2_interface.cpp
+++ b/src/ddraw/ddraw2/ddraw2_interface.cpp
@@ -15,8 +15,6 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> DDraw2Interface::s_intfCount = 0;
-
   DDraw2Interface::DDraw2Interface(
         DDrawCommonInterface* commonIntf,
         Com<IDirectDraw2>&& proxyIntf)
@@ -40,16 +38,10 @@ namespace dxvk {
     // Note: IDirectDraw2 can never be the origin interface
 
     m_commonIntf->SetDD2Interface(this);
-
-    m_intfCount = ++s_intfCount;
-
-    Logger::debug(str::format("DDraw2Interface: Created a new interface nr. <<2-", m_intfCount, ">>"));
   }
 
   DDraw2Interface::~DDraw2Interface() {
     m_commonIntf->SetDD2Interface(nullptr);
-
-    Logger::debug(str::format("DDraw2Interface: Interface nr. <<2-", m_intfCount, ">> bites the dust"));
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Interface::QueryInterface(REFIID riid, void** ppvObject) {
@@ -208,57 +200,72 @@ namespace dxvk {
 
     InitReturnPtr(lplpDDSurface);
 
-    // Because we are removing the DDSCAPS_WRITEONLY flag below, we need
-    // to first validate the combinations that would otherwise cause issues
-    HRESULT hr = ValidateSurfaceFlags(lpDDSurfaceDesc);
-    if (unlikely(FAILED(hr)))
-      return hr;
+    if (likely(lpDDSurfaceDesc->dwFlags & DDSD_CAPS)) {
+      // Because we are removing the DDSCAPS_WRITEONLY flag below, we need
+      // to first validate the combinations that would otherwise cause issues
+      HRESULT hr = ValidateSurfaceFlags(lpDDSurfaceDesc);
+      if (unlikely(FAILED(hr)))
+        return hr;
 
-    // We need to ensure we can always read from surfaces for upload to
-    // D3D9, so always strip the DDSCAPS_WRITEONLY flag on creation
-    lpDDSurfaceDesc->ddsCaps.dwCaps &= ~DDSCAPS_WRITEONLY;
-
-    // Work around a WineD3D bug/limitation that prevents
-    // read back from L6V5U5 and X8L8V8U8 video memory surfaces
-    //
-    // Note: Doing this for other surfaces/formats is a bad idea,
-    // because some games expect these flags to remain in place, and
-    // may crash in case they find that's not the case
-    if (unlikely((lpDDSurfaceDesc->ddpfPixelFormat.dwFlags & DDPF_BUMPLUMINANCE)
-              && (lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_VIDEOMEMORY))) {
-      Logger::warn("DDraw2Interface::CreateSurface: Video memory DDPF_BUMPLUMINANCE surface");
-      lpDDSurfaceDesc->ddsCaps.dwCaps &= ~DDSCAPS_VIDEOMEMORY &
-                                         ~DDSCAPS_LOCALVIDMEM &
-                                         ~DDSCAPS_NONLOCALVIDMEM;
-      lpDDSurfaceDesc->ddsCaps.dwCaps |= DDSCAPS_SYSTEMMEMORY;
+      // We need to ensure we can always read from surfaces for upload to
+      // D3D9, so always strip the DDSCAPS_WRITEONLY flag on creation
+      lpDDSurfaceDesc->ddsCaps.dwCaps &= ~DDSCAPS_WRITEONLY;
     }
 
-    if (unlikely(lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_ZBUFFER)) {
-      if (unlikely(m_commonIntf->GetOptions()->useD16forD24X8
-                && lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFF
-                && lpDDSurfaceDesc->ddpfPixelFormat.dwStencilBitMask == 0x0)) {
-        // Games such as Need for Speed: Porsche are broken with 32-bit color
-        // on night tracks with "projected" lights, because they clearly were
-        // designed with 16-bit Z buffers in mind. Fix it up by silently swapping
-        // D16 for D24X8 on depth stencil creation.
-        Logger::info("DDraw2Interface::CreateSurface: Using D16 instead of D24X8");
-        lpDDSurfaceDesc->ddpfPixelFormat.dwZBufferBitDepth = 16;
-        lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFF;
-      } else if (unlikely(lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFFFF)) {
-        if (m_commonIntf->GetOptions()->useD24X8forD32) {
-          // In case of up-front unsupported and unadvertised D32 depth stencil use,
-          // replace it with D24X8, as some games, such as Sacrifice, rely on it
-          // to properly enable 32-bit display modes (and revert to 16-bit otherwise)
-          Logger::info("DDraw2Interface::CreateSurface: Using D24X8 instead of D32");
-          lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFFFF;
-        } else {
-          Logger::warn("DDraw2Interface::CreateSurface: Use of unsupported D32");
+    if (likely(lpDDSurfaceDesc->dwFlags & DDSD_PIXELFORMAT)) {
+      // WineD3D will fail to create 8-bit texture surfaces at times, for whatever reason...
+      if (unlikely((lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_TEXTURE)
+               &&  (lpDDSurfaceDesc->ddpfPixelFormat.dwFlags & DDPF_RGB)
+               &&   lpDDSurfaceDesc->ddpfPixelFormat.dwRGBBitCount == 8
+               && !(lpDDSurfaceDesc->ddpfPixelFormat.dwFlags & DDPF_PALETTEINDEXED8))) {
+        static bool s_8bitTextureWarningShown;
+
+        if (!std::exchange(s_8bitTextureWarningShown, true))
+          Logger::warn("DDraw2Interface::CreateSurface: Use of potentially unsupported 8-bit texture surface");
+      }
+
+      // Work around a WineD3D bug/limitation that prevents
+      // read back from L6V5U5 and X8L8V8U8 video memory surfaces
+      //
+      // Note: Doing this for other surfaces/formats is a bad idea,
+      // because some games expect these flags to remain in place, and
+      // may crash in case they find that's not the case
+      if (unlikely((lpDDSurfaceDesc->ddpfPixelFormat.dwFlags == (DDPF_BUMPDUDV | DDPF_BUMPLUMINANCE))
+                && (lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_VIDEOMEMORY))) {
+        Logger::warn("DDraw2Interface::CreateSurface: Video memory DDPF_BUMPLUMINANCE surface");
+        lpDDSurfaceDesc->ddsCaps.dwCaps &= ~DDSCAPS_VIDEOMEMORY &
+                                           ~DDSCAPS_LOCALVIDMEM &
+                                           ~DDSCAPS_NONLOCALVIDMEM;
+        lpDDSurfaceDesc->ddsCaps.dwCaps |= DDSCAPS_SYSTEMMEMORY;
+      }
+
+      if (unlikely(lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_ZBUFFER)) {
+        if (unlikely(m_commonIntf->GetOptions()->useD16forD24X8
+                  && lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFF
+                  && lpDDSurfaceDesc->ddpfPixelFormat.dwStencilBitMask == 0x0)) {
+          // Games such as Need for Speed: Porsche are broken with 32-bit color
+          // on night tracks with "projected" lights, because they clearly were
+          // designed with 16-bit Z buffers in mind. Fix it up by silently swapping
+          // D16 for D24X8 on depth stencil creation.
+          Logger::debug("DDraw2Interface::CreateSurface: Using D16 instead of D24X8");
+          lpDDSurfaceDesc->ddpfPixelFormat.dwZBufferBitDepth = 16;
+          lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFF;
+        } else if (unlikely(lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFFFF)) {
+          if (m_commonIntf->GetOptions()->useD24X8forD32) {
+            // In case of up-front unsupported and unadvertised D32 depth stencil use,
+            // replace it with D24X8, as some games, such as Sacrifice, rely on it
+            // to properly enable 32-bit display modes (and revert to 16-bit otherwise)
+            Logger::debug("DDraw2Interface::CreateSurface: Using D24X8 instead of D32");
+            lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFFFF;
+          } else {
+            Logger::warn("DDraw2Interface::CreateSurface: Use of unsupported D32");
+          }
         }
       }
     }
 
     Com<IDirectDrawSurface> ddrawSurfaceProxied;
-    hr = m_proxy->CreateSurface(lpDDSurfaceDesc, &ddrawSurfaceProxied, pUnkOuter);
+    HRESULT hr = m_proxy->CreateSurface(lpDDSurfaceDesc, &ddrawSurfaceProxied, pUnkOuter);
     // Some games simply try creating surfaces with various formats until something works...
     if (unlikely(FAILED(hr)))
       return hr;
@@ -273,10 +280,8 @@ namespace dxvk {
 
         // Shadow surface creation for the primary surface
         // (it needs to be based on the same incoming desc)
-        if (unlikely(!surface->GetCommonSurface()->Is8BitFormat() &&
-                      m_commonIntf->GetOptions()->forceLegacyPresent)) {
-          Logger::debug("DDraw2Interface::CreateSurface: Creating shadow surface");
-
+        if (unlikely(m_commonIntf->GetOptions()->forceLegacyPresent &&
+                    !surface->GetCommonSurface()->SkipD3D9Operations())) {
           DDSURFACEDESC shadowDesc = *lpDDSurfaceDesc;
           const DDSURFACEDESC* primaryDesc = surface->GetCommonSurface()->GetDesc();
 
@@ -340,7 +345,35 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Interface::EnumDisplayModes(DWORD dwFlags, LPDDSURFACEDESC lpDDSurfaceDesc, LPVOID lpContext, LPDDENUMMODESCALLBACK lpEnumModesCallback) {
-    return m_proxy->EnumDisplayModes(dwFlags, lpDDSurfaceDesc, lpContext, lpEnumModesCallback);
+    if (unlikely(lpEnumModesCallback == nullptr))
+      return DDERR_INVALIDPARAMS;
+
+    std::vector<DDSURFACEDESC> displayModes;
+    HRESULT hr = m_proxy->EnumDisplayModes(dwFlags, lpDDSurfaceDesc, reinterpret_cast<void*>(&displayModes), EnumDisplayModesCallback);
+    if (unlikely(FAILED(hr)))
+      return hr;
+
+    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
+
+    hr = DDENUMRET_OK;
+
+    auto displayModeIt = displayModes.begin();
+    while (displayModeIt != displayModes.end() && hr == DDENUMRET_OK) {
+      DDSURFACEDESC dmDesc = *displayModeIt;
+
+      if (unlikely(d3dOptions->mask8BitModes && dmDesc.ddpfPixelFormat.dwRGBBitCount == 8)) {
+        static bool s_maskModeWarningShown;
+
+        if (!std::exchange(s_maskModeWarningShown, true))
+          Logger::warn("DDraw2Interface::EnumDisplayModes: Masking 8-bit display modes");
+      } else {
+        hr = lpEnumModesCallback(&dmDesc, lpContext);
+      }
+
+      ++displayModeIt;
+    }
+
+    return DD_OK;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Interface::EnumSurfaces(DWORD dwFlags, LPDDSURFACEDESC lpDDSD, LPVOID lpContext, LPDDENUMSURFACESCALLBACK lpEnumSurfacesCallback) {
@@ -451,8 +484,17 @@ namespace dxvk {
 
     const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
 
-    if (unlikely(d3dOptions->mask8BitModes && lpDDSurfaceDesc->ddpfPixelFormat.dwRGBBitCount == 8))
+    if (unlikely(d3dOptions->mask8BitModes
+              && lpDDSurfaceDesc->dwFlags & DDSD_PIXELFORMAT
+              && lpDDSurfaceDesc->ddpfPixelFormat.dwRGBBitCount == 8)) {
+      // Report a fake D3DFMT_R5G6B5 back buffer scenario
+      lpDDSurfaceDesc->ddpfPixelFormat.dwFlags = DDPF_RGB;
       lpDDSurfaceDesc->ddpfPixelFormat.dwRGBBitCount = 16;
+      lpDDSurfaceDesc->ddpfPixelFormat.dwRGBAlphaBitMask = 0x0000;
+      lpDDSurfaceDesc->ddpfPixelFormat.dwRBitMask = 0xf800;
+      lpDDSurfaceDesc->ddpfPixelFormat.dwGBitMask = 0x07e0;
+      lpDDSurfaceDesc->ddpfPixelFormat.dwBBitMask = 0x001f;
+    }
 
     return DD_OK;
   }
@@ -557,7 +599,7 @@ namespace dxvk {
     DDrawCommonSurface* ps = m_commonIntf->GetPrimarySurface();
 
     if (likely(ps != nullptr)) {
-      hr = ps->RefreshSurfaceDescripton();
+      hr = ps->RefreshSurfaceDescripton(true);
       if (unlikely(FAILED(hr)))
         Logger::warn("DDraw2Interface::SetDisplayMode: Failed to update primary surface desc");
     }

--- a/src/ddraw/ddraw2/ddraw2_interface.h
+++ b/src/ddraw/ddraw2/ddraw2_interface.h
@@ -81,9 +81,6 @@ namespace dxvk {
 
     Com<DDrawInterface, false> m_parentIntf;
 
-    uint32_t                   m_intfCount = 0;
-    static std::atomic<uint32_t> s_intfCount;
-
   };
 
 }

--- a/src/ddraw/ddraw2/ddraw2_surface.cpp
+++ b/src/ddraw/ddraw2/ddraw2_surface.cpp
@@ -9,8 +9,6 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> DDraw2Surface::s_surfCount = 0;
-
   DDraw2Surface::DDraw2Surface(
         DDrawCommonSurface* commonSurf,
         Com<IDirectDrawSurface2>&& surfProxy,
@@ -92,9 +90,7 @@ namespace dxvk {
 
     m_commonSurf->SetDD2Surface(this);
 
-    m_surfCount = ++s_surfCount;
-
-    Logger::debug(str::format("DDraw2Surface: Created a new surface nr. [[2-", m_surfCount, "]]"));
+    //Logger::debug(str::format("DDraw2Surface: Created a new surface nr. [[2-", std::hex, this, "]]"));
 
     // Note: IDirectDrawSurface2 can't ever be the origin surface
   }
@@ -122,7 +118,7 @@ namespace dxvk {
 
     m_commonSurf->SetDD2Surface(nullptr);
 
-    Logger::debug(str::format("DDraw2Surface: Surface nr. [[2-", m_surfCount, "]] bites the dust"));
+    //Logger::debug(str::format("DDraw2Surface: Surface nr. [[2-", std::hex, this, "]] bites the dust"));
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::QueryInterface(REFIID riid, void** ppvObject) {
@@ -312,7 +308,7 @@ namespace dxvk {
       DownloadSurfaceData();
     }
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
     if (likely(d3d9Device != nullptr)) {
       const bool exclusiveMode = m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE;
 
@@ -372,7 +368,7 @@ namespace dxvk {
       return DDERR_UNSUPPORTED;
     }
 
-    RECT* sourceFullSurfaceRect = nullptr;
+    const RECT* sourceFullSurfaceRect = nullptr;
     // Write back any dirty surface data from bound D3D9 back buffers or
     // depth stencils, for both the source surface and the current surface
     if (likely(lpDDSrcSurface != nullptr)) {
@@ -388,7 +384,7 @@ namespace dxvk {
       DownloadSurfaceData();
     }
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
     if (likely(d3d9Device != nullptr)) {
       const bool exclusiveMode = m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE;
 
@@ -491,7 +487,7 @@ namespace dxvk {
 
     Com<DDraw2Surface> overrideSurf = static_cast<DDraw2Surface*>(lpDDSurfaceTargetOverride);
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
     // Overlays can have odd video formats which DXVK doesn't support for RT
     // use, so let DDraw present in case the flipped surface is an overlay
     if (likely(d3d9Device != nullptr && !m_commonSurf->IsOverlay())) {
@@ -553,25 +549,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DDraw2Surface::GetAttachedSurface(LPDDSCAPS lpDDSCaps, LPDIRECTDRAWSURFACE2 *lplpDDAttachedSurface) {
     if (unlikely(lpDDSCaps == nullptr || lplpDDAttachedSurface == nullptr))
       return DDERR_INVALIDPARAMS;
-
-    if (lpDDSCaps->dwCaps & DDSCAPS_PRIMARYSURFACE)
-      Logger::debug("DDraw2Surface::GetAttachedSurface: Querying for the primary surface");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_FRONTBUFFER)
-      Logger::debug("DDraw2Surface::GetAttachedSurface: Querying for the front buffer");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_BACKBUFFER)
-      Logger::debug("DDraw2Surface::GetAttachedSurface: Querying for the back buffer");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_FLIP)
-      Logger::debug("DDraw2Surface::GetAttachedSurface: Querying for a flippable surface");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_OFFSCREENPLAIN)
-      Logger::debug("DDraw2Surface::GetAttachedSurface: Querying for an offscreen plain surface");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_ZBUFFER)
-      Logger::debug("DDraw2Surface::GetAttachedSurface: Querying for a depth stencil");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_MIPMAP)
-      Logger::debug("DDraw2Surface::GetAttachedSurface: Querying for a texture mip map");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_TEXTURE)
-      Logger::debug("DDraw2Surface::GetAttachedSurface: Querying for a texture");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_OVERLAY)
-      Logger::debug("DDraw2Surface::GetAttachedSurface: Querying for an overlay");
 
     Com<IDirectDrawSurface2> surface;
     HRESULT hr = m_proxy->GetAttachedSurface(lpDDSCaps, &surface);
@@ -725,7 +702,21 @@ namespace dxvk {
     // Write back any dirty surface data from bound D3D9 back buffers or depth stencils
     DownloadSurfaceData();
 
-    return GetShadowOrProxied()->Lock(lpDestRect, lpDDSurfaceDesc, dwFlags, hEvent);
+    HRESULT hr = GetShadowOrProxied()->Lock(lpDestRect, lpDDSurfaceDesc, dwFlags, hEvent);
+    if (unlikely(FAILED(hr)))
+      return hr;
+
+    // For single surface locks, track the READONLY flag in order to skip dirtying
+    // on Unlock(). Reset the tracking in case of multiple simultaneous locks.
+    if (likely(!m_lockCount)) {
+      m_readOnlyLock = (dwFlags & DDLOCK_READONLY) && !(dwFlags & DDLOCK_WRITEONLY);
+    } else {
+      m_readOnlyLock = false;
+    }
+
+    m_lockCount++;
+
+    return DD_OK;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw2Surface::ReleaseDC(HDC hDC) {
@@ -746,7 +737,7 @@ namespace dxvk {
 
     m_commonSurf->DirtyDDrawSurface();
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
     if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
       const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                 !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
@@ -811,7 +802,7 @@ namespace dxvk {
     if (unlikely(FAILED(hr)))
       return hr;
 
-    hr = m_commonSurf->RefreshSurfaceDescripton();
+    hr = m_commonSurf->RefreshSurfaceDescripton(false);
     if (unlikely(FAILED(hr)))
       Logger::err("DDraw2Surface::SetColorKey: Failed to retrieve updated surface desc");
 
@@ -820,7 +811,7 @@ namespace dxvk {
       if (unlikely(FAILED(hr))) {
         Logger::warn("DDraw2Surface::SetColorKey: Failed to set shadow surface color key");
       } else {
-        hr = m_shadowSurf->GetCommonSurface()->RefreshSurfaceDescripton();
+        hr = m_shadowSurf->GetCommonSurface()->RefreshSurfaceDescripton(false);
         if (unlikely(FAILED(hr)))
           Logger::warn("DDraw2Surface::SetColorKey: Failed to retrieve updated shadow surface desc");
       }
@@ -859,9 +850,16 @@ namespace dxvk {
     if (unlikely(FAILED(hr)))
       return hr;
 
-    m_commonSurf->DirtyDDrawSurface();
+    if (!m_readOnlyLock) {
+      m_commonSurf->DirtyDDrawSurface();
+    } else {
+      m_readOnlyLock = false;
+    }
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    if (likely(m_lockCount))
+      m_lockCount--;
+
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
     if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
       const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                 !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
@@ -933,39 +931,28 @@ namespace dxvk {
     return m_proxy->PageUnlock(dwFlags);
   }
 
-  IDirectDrawSurface2* DDraw2Surface::GetShadowOrProxied() {
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
-
-    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr))
-      return m_shadowSurf->GetProxied();
-
-    return m_proxy.ptr();
-  }
-
   HRESULT DDraw2Surface::InitializeOrUploadD3D9() {
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    // Currently ignores all P8 surfaces
+    if (unlikely(m_commonSurf->SkipD3D9Operations()))
+      return DD_OK;
+
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
 
     // Fast skip
     if (unlikely(d3d9Device == nullptr))
       return DD_OK;
 
     if (unlikely(!m_commonSurf->IsInitialized())) {
-      if (m_commonSurf->IsTexture())
-        m_parent->UpdateMipMapCount();
-
       const bool initRenderTarget = m_commonSurf->GetCommonD3DDevice()->IsCurrentRenderTarget(m_commonSurf.ptr());
 
       HRESULT hr = m_commonSurf->InitializeD3D9(initRenderTarget);
-      if (unlikely(FAILED(hr)))
+      if (unlikely(FAILED(hr))) {
+        Logger::err(str::format("DDraw2Surface::InitializeOrUploadD3D9: Failed to initialize surface nr. [[2-", std::hex, this, "]]"));
         return hr;
-
-      Logger::debug(str::format("DDraw2Surface::InitializeOrUploadD3D9: Initialized surface nr. [[2-", m_surfCount, "]]"));
+      }
     }
 
-    if (likely(m_commonSurf->IsInitialized()))
-      return UploadSurfaceData();
-
-    return DD_OK;
+    return UploadSurfaceData();
   }
 
   void DDraw2Surface::DownloadSurfaceData() {
@@ -977,20 +964,12 @@ namespace dxvk {
     if (likely(!m_commonIntf->GetOptions()->deviceResourceSharing))
       m_commonSurf->RefreshD3D9Device();
 
-    if (unlikely(m_commonSurf->IsD3D9BackBuffer())) {
-      if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
-        //Logger::debug(str::format("DDraw2Surface::DownloadSurfaceData: Downloading nr. [[2-", m_surfCount, "]]"));
-        BlitToDDrawSurface<IDirectDrawSurface2, DDSURFACEDESC>(GetShadowOrProxied(), m_commonSurf->GetD3D9Surface(),
-                                                               m_commonSurf->IsDXTFormat());
-        m_commonSurf->UnDirtyD3D9Surface();
-      }
-    } else if (unlikely(m_commonSurf->IsD3D9DepthStencil())) {
-      if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
-        //Logger::debug(str::format("DDraw2Surface::DownloadSurfaceData: Downloading nr. [[2-", m_surfCount, "]]"));
-        BlitToDDrawSurface<IDirectDrawSurface2, DDSURFACEDESC>(m_proxy.ptr(), m_commonSurf->GetD3D9Surface(),
-                                                               m_commonSurf->IsDXTFormat());
-        m_commonSurf->UnDirtyD3D9Surface();
-      }
+    // TODO: We are technically ignoring mip maps as is, though that will probably never be an issue
+    if (m_commonSurf->IsD3D9SurfaceDirty() && m_commonSurf->IsInitialized()) {
+      //Logger::debug(str::format("DDraw2Surface::DownloadSurfaceData: Downloading nr. [[2-", std::hex, this, "]]"));
+      BlitToDDrawSurface<IDirectDrawSurface2, DDSURFACEDESC>(GetShadowOrProxied(), m_commonSurf->GetD3D9Surface(),
+                                                             m_commonSurf->IsDXTFormat());
+      m_commonSurf->UnDirtyD3D9Surface();
     }
   }
 
@@ -999,15 +978,19 @@ namespace dxvk {
     if (!m_commonSurf->IsDDrawSurfaceDirty())
       return DD_OK;
 
-    //Logger::debug(str::format("DDraw2Surface::UploadSurfaceData: Uploading nr. [[2-", m_surfCount, "]]"));
+    //Logger::debug(str::format("DDraw2Surface::UploadSurfaceData: Uploading nr. [[2-", std::hex, this, "]]"));
 
-    if (m_commonSurf->IsTexture()) {
-      BlitToD3D9Texture<IDirectDrawSurface2, DDSURFACEDESC>(m_commonSurf->GetD3D9Texture(), m_proxy.ptr(),
-                                                            m_commonSurf->GetMipCount(), m_commonSurf->IsDXTFormat());
-    // Blit surfaces directly
-    } else {
-      BlitToD3D9Surface<IDirectDrawSurface2, DDSURFACEDESC>(m_commonSurf->GetD3D9Surface(), GetShadowOrProxied(),
-                                                            m_commonSurf->IsDXTFormat());
+    D3D9SurfaceType d3d9SurfaceType = m_commonSurf->GetD3D9SurfaceType();
+
+    switch (d3d9SurfaceType) {
+      case D3D9SurfaceType::Texture:
+        BlitToD3D9Texture<IDirectDrawSurface2, DDSURFACEDESC>(m_commonSurf->GetD3D9Texture(), m_proxy.ptr(),
+                                                              m_commonSurf->GetMipCount(), m_commonSurf->IsDXTFormat());
+        break;
+      default:
+        BlitToD3D9Surface<IDirectDrawSurface2, DDSURFACEDESC>(m_commonSurf->GetD3D9Surface(), GetShadowOrProxied(),
+                                                              m_commonSurf->IsDXTFormat());
+        break;
     }
 
     m_commonSurf->UnDirtyDDrawSurface();

--- a/src/ddraw/ddraw2/ddraw2_surface.h
+++ b/src/ddraw/ddraw2/ddraw2_surface.h
@@ -104,8 +104,6 @@ namespace dxvk {
 
     HRESULT STDMETHODCALLTYPE PageUnlock(DWORD dwFlags);
 
-    IDirectDrawSurface2* GetShadowOrProxied();
-
     HRESULT InitializeOrUploadD3D9();
 
     void DownloadSurfaceData();
@@ -116,6 +114,15 @@ namespace dxvk {
 
     DDraw2Surface* GetShadowSurface() const {
       return m_shadowSurf.ptr();
+    }
+
+    IDirectDrawSurface2* GetShadowOrProxied() {
+      d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
+
+      if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr))
+        return m_shadowSurf->GetProxied();
+
+      return m_proxy.ptr();
     }
 
     DDrawCommonSurface* GetCommonSurface() const {
@@ -164,13 +171,16 @@ namespace dxvk {
 
     inline HRESULT UploadSurfaceData();
 
+    bool                     m_readOnlyLock = false;
+    std::atomic<uint8_t>     m_lockCount    = 0u;
+
     Com<DDrawCommonSurface>  m_commonSurf;
 
-    DDrawCommonInterface*    m_commonIntf = nullptr;
+    DDrawCommonInterface*    m_commonIntf   = nullptr;
 
     Com<DDrawSurface, false> m_originSurf;
 
-    DDraw2Surface*           m_parentSurf = nullptr;
+    DDraw2Surface*           m_parentSurf   = nullptr;
 
     // Offscreen plain surface we use to mask unwanted DDraw interactions, such
     // as forced swapchain presents caused by blits/locks on primary surfaces
@@ -185,9 +195,6 @@ namespace dxvk {
     // They are implemented with linked list, so for example only one mip level
     // will be held in a parent texture, and the next mip level will be held in the previous mip.
     std::unordered_map<IDirectDrawSurface2*, Com<DDraw2Surface, false>> m_attachedSurfaces;
-
-    uint32_t                 m_surfCount  = 0;
-    static std::atomic<uint32_t> s_surfCount;
 
   };
 

--- a/src/ddraw/ddraw2/ddraw3_surface.cpp
+++ b/src/ddraw/ddraw2/ddraw3_surface.cpp
@@ -9,8 +9,6 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> DDraw3Surface::s_surfCount = 0;
-
   DDraw3Surface::DDraw3Surface(
         DDrawCommonSurface* commonSurf,
         Com<IDirectDrawSurface3>&& surfProxy,
@@ -92,9 +90,7 @@ namespace dxvk {
 
     m_commonSurf->SetDD3Surface(this);
 
-    m_surfCount = ++s_surfCount;
-
-    Logger::debug(str::format("DDraw3Surface: Created a new surface nr. [[3-", m_surfCount, "]]"));
+    //Logger::debug(str::format("DDraw3Surface: Created a new surface nr. [[3-", std::hex, this, "]]"));
 
     // Note: IDirectDrawSurface3 can't ever be the origin surface
   }
@@ -122,7 +118,7 @@ namespace dxvk {
 
     m_commonSurf->SetDD3Surface(nullptr);
 
-    Logger::debug(str::format("DDraw3Surface: Surface nr. [[3-", m_surfCount, "]] bites the dust"));
+    //Logger::debug(str::format("DDraw3Surface: Surface nr. [[3-", std::hex, this, "]] bites the dust"));
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::QueryInterface(REFIID riid, void** ppvObject) {
@@ -313,7 +309,7 @@ namespace dxvk {
       DownloadSurfaceData();
     }
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
     if (likely(d3d9Device != nullptr)) {
       const bool exclusiveMode = m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE;
 
@@ -374,7 +370,7 @@ namespace dxvk {
       return DDERR_UNSUPPORTED;
     }
 
-    RECT* sourceFullSurfaceRect = nullptr;
+    const RECT* sourceFullSurfaceRect = nullptr;
     // Write back any dirty surface data from bound D3D9 back buffers or
     // depth stencils, for both the source surface and the current surface
     if (likely(lpDDSrcSurface != nullptr)) {
@@ -390,7 +386,7 @@ namespace dxvk {
       DownloadSurfaceData();
     }
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
     if (likely(d3d9Device != nullptr)) {
       const bool exclusiveMode = m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE;
 
@@ -493,7 +489,7 @@ namespace dxvk {
 
     Com<DDraw3Surface> overrideSurf = static_cast<DDraw3Surface*>(lpDDSurfaceTargetOverride);
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
     // Overlays can have odd video formats which DXVK doesn't support for RT
     // use, so let DDraw present in case the flipped surface is an overlay
     if (likely(d3d9Device != nullptr && !m_commonSurf->IsOverlay())) {
@@ -555,25 +551,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DDraw3Surface::GetAttachedSurface(LPDDSCAPS lpDDSCaps, LPDIRECTDRAWSURFACE3 *lplpDDAttachedSurface) {
     if (unlikely(lpDDSCaps == nullptr || lplpDDAttachedSurface == nullptr))
       return DDERR_INVALIDPARAMS;
-
-    if (lpDDSCaps->dwCaps & DDSCAPS_PRIMARYSURFACE)
-      Logger::debug("DDraw3Surface::GetAttachedSurface: Querying for the primary surface");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_FRONTBUFFER)
-      Logger::debug("DDraw3Surface::GetAttachedSurface: Querying for the front buffer");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_BACKBUFFER)
-      Logger::debug("DDraw3Surface::GetAttachedSurface: Querying for the back buffer");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_FLIP)
-      Logger::debug("DDraw3Surface::GetAttachedSurface: Querying for a flippable surface");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_OFFSCREENPLAIN)
-      Logger::debug("DDraw3Surface::GetAttachedSurface: Querying for an offscreen plain surface");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_ZBUFFER)
-      Logger::debug("DDraw3Surface::GetAttachedSurface: Querying for a depth stencil");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_MIPMAP)
-      Logger::debug("DDraw3Surface::GetAttachedSurface: Querying for a texture mip map");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_TEXTURE)
-      Logger::debug("DDraw3Surface::GetAttachedSurface: Querying for a texture");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_OVERLAY)
-      Logger::debug("DDraw3Surface::GetAttachedSurface: Querying for an overlay");
 
     Com<IDirectDrawSurface3> surface;
     HRESULT hr = m_proxy->GetAttachedSurface(lpDDSCaps, &surface);
@@ -727,7 +704,21 @@ namespace dxvk {
     // Write back any dirty surface data from bound D3D9 back buffers or depth stencils
     DownloadSurfaceData();
 
-    return GetShadowOrProxied()->Lock(lpDestRect, lpDDSurfaceDesc, dwFlags, hEvent);
+    HRESULT hr = GetShadowOrProxied()->Lock(lpDestRect, lpDDSurfaceDesc, dwFlags, hEvent);
+    if (unlikely(FAILED(hr)))
+      return hr;
+
+    // For single surface locks, track the READONLY flag in order to skip dirtying
+    // on Unlock(). Reset the tracking in case of multiple simultaneous locks.
+    if (likely(!m_lockCount)) {
+      m_readOnlyLock = (dwFlags & DDLOCK_READONLY) && !(dwFlags & DDLOCK_WRITEONLY);
+    } else {
+      m_readOnlyLock = false;
+    }
+
+    m_lockCount++;
+
+    return DD_OK;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw3Surface::ReleaseDC(HDC hDC) {
@@ -748,7 +739,7 @@ namespace dxvk {
 
     m_commonSurf->DirtyDDrawSurface();
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
     if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
       const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                 !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
@@ -813,7 +804,7 @@ namespace dxvk {
     if (unlikely(FAILED(hr)))
       return hr;
 
-    hr = m_commonSurf->RefreshSurfaceDescripton();
+    hr = m_commonSurf->RefreshSurfaceDescripton(false);
     if (unlikely(FAILED(hr)))
       Logger::err("DDraw3Surface::SetColorKey: Failed to retrieve updated surface desc");
 
@@ -822,7 +813,7 @@ namespace dxvk {
       if (unlikely(FAILED(hr))) {
         Logger::warn("DDraw3Surface::SetColorKey: Failed to set shadow surface color key");
       } else {
-        hr = m_shadowSurf->GetCommonSurface()->RefreshSurfaceDescripton();
+        hr = m_shadowSurf->GetCommonSurface()->RefreshSurfaceDescripton(false);
         if (unlikely(FAILED(hr)))
           Logger::warn("DDraw3Surface::SetColorKey: Failed to retrieve updated shadow surface desc");
       }
@@ -861,9 +852,16 @@ namespace dxvk {
     if (unlikely(FAILED(hr)))
       return hr;
 
-    m_commonSurf->DirtyDDrawSurface();
+    if (!m_readOnlyLock) {
+      m_commonSurf->DirtyDDrawSurface();
+    } else {
+      m_readOnlyLock = false;
+    }
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    if (likely(m_lockCount))
+      m_lockCount--;
+
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
     if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
       const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                 !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
@@ -942,51 +940,40 @@ namespace dxvk {
     if (unlikely(FAILED(hr)))
       return hr;
 
-    hr = m_commonSurf->RefreshSurfaceDescripton();
+    hr = m_commonSurf->RefreshSurfaceDescripton(true);
     if (unlikely(FAILED(hr))) {
       Logger::err("DDraw3Surface::SetSurfaceDesc: Failed to retrieve updated surface desc");
       return hr;
     }
 
     // We may need to recreate the d3d9 object based on the new desc
-    m_commonSurf->SetD3D9Surface(nullptr);
+    m_commonSurf->ResetD3D9Objects();
 
     return DD_OK;
   }
 
-  IDirectDrawSurface3* DDraw3Surface::GetShadowOrProxied() {
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
-
-    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr))
-      return m_shadowSurf->GetProxied();
-
-    return m_proxy.ptr();
-  }
-
   HRESULT DDraw3Surface::InitializeOrUploadD3D9() {
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    // Currently ignores all P8 surfaces
+    if (unlikely(m_commonSurf->SkipD3D9Operations()))
+      return DD_OK;
+
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
 
     // Fast skip
     if (unlikely(d3d9Device == nullptr))
       return DD_OK;
 
     if (unlikely(!m_commonSurf->IsInitialized())) {
-      if (m_commonSurf->IsTexture())
-        m_parent->UpdateMipMapCount();
-
       const bool initRenderTarget = m_commonSurf->GetCommonD3DDevice()->IsCurrentRenderTarget(m_commonSurf.ptr());
 
       HRESULT hr = m_commonSurf->InitializeD3D9(initRenderTarget);
-      if (unlikely(FAILED(hr)))
+      if (unlikely(FAILED(hr))) {
+        Logger::err(str::format("DDraw3Surface::InitializeOrUploadD3D9: Failed to initialize surface nr. [[3-", std::hex, this, "]]"));
         return hr;
-
-      Logger::debug(str::format("DDraw3Surface::InitializeOrUploadD3D9: Initialized surface nr. [[3-", m_surfCount, "]]"));
+      }
     }
 
-    if (likely(m_commonSurf->IsInitialized()))
-      return UploadSurfaceData();
-
-    return DD_OK;
+    return UploadSurfaceData();
   }
 
   void DDraw3Surface::DownloadSurfaceData() {
@@ -998,20 +985,12 @@ namespace dxvk {
     if (likely(!m_commonIntf->GetOptions()->deviceResourceSharing))
       m_commonSurf->RefreshD3D9Device();
 
-    if (unlikely(m_commonSurf->IsD3D9BackBuffer())) {
-      if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
-        //Logger::debug(str::format("DDraw3Surface::DownloadSurfaceData: Downloading nr. [[3-", m_surfCount, "]]"));
-        BlitToDDrawSurface<IDirectDrawSurface3, DDSURFACEDESC>(GetShadowOrProxied(), m_commonSurf->GetD3D9Surface(),
-                                                               m_commonSurf->IsDXTFormat());
-        m_commonSurf->UnDirtyD3D9Surface();
-      }
-    } else if (unlikely(m_commonSurf->IsD3D9DepthStencil())) {
-      if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
-        //Logger::debug(str::format("DDraw3Surface::DownloadSurfaceData: Downloading nr. [[3-", m_surfCount, "]]"));
-        BlitToDDrawSurface<IDirectDrawSurface3, DDSURFACEDESC>(m_proxy.ptr(), m_commonSurf->GetD3D9Surface(),
-                                                               m_commonSurf->IsDXTFormat());
-        m_commonSurf->UnDirtyD3D9Surface();
-      }
+    // TODO: We are technically ignoring mip maps as is, though that will probably never be an issue
+    if (m_commonSurf->IsD3D9SurfaceDirty() && m_commonSurf->IsInitialized()) {
+      //Logger::debug(str::format("DDraw3Surface::DownloadSurfaceData: Downloading nr. [[3-", std::hex, this, "]]"));
+      BlitToDDrawSurface<IDirectDrawSurface3, DDSURFACEDESC>(GetShadowOrProxied(), m_commonSurf->GetD3D9Surface(),
+                                                             m_commonSurf->IsDXTFormat());
+      m_commonSurf->UnDirtyD3D9Surface();
     }
   }
 
@@ -1020,15 +999,19 @@ namespace dxvk {
     if (!m_commonSurf->IsDDrawSurfaceDirty())
       return DD_OK;
 
-    //Logger::debug(str::format("DDraw3Surface::UploadSurfaceData: Uploading nr. [[3-", m_surfCount, "]]"));
+    //Logger::debug(str::format("DDraw3Surface::UploadSurfaceData: Uploading nr. [[3-", std::hex, this, "]]"));
 
-    if (m_commonSurf->IsTexture()) {
-      BlitToD3D9Texture<IDirectDrawSurface3, DDSURFACEDESC>(m_commonSurf->GetD3D9Texture(), m_proxy.ptr(),
-                                                            m_commonSurf->GetMipCount(), m_commonSurf->IsDXTFormat());
-    // Blit surfaces directly
-    } else {
-      BlitToD3D9Surface<IDirectDrawSurface3, DDSURFACEDESC>(m_commonSurf->GetD3D9Surface(), GetShadowOrProxied(),
-                                                            m_commonSurf->IsDXTFormat());
+    D3D9SurfaceType d3d9SurfaceType = m_commonSurf->GetD3D9SurfaceType();
+
+    switch (d3d9SurfaceType) {
+      case D3D9SurfaceType::Texture:
+        BlitToD3D9Texture<IDirectDrawSurface3, DDSURFACEDESC>(m_commonSurf->GetD3D9Texture(), m_proxy.ptr(),
+                                                              m_commonSurf->GetMipCount(), m_commonSurf->IsDXTFormat());
+        break;
+      default:
+        BlitToD3D9Surface<IDirectDrawSurface3, DDSURFACEDESC>(m_commonSurf->GetD3D9Surface(), GetShadowOrProxied(),
+                                                              m_commonSurf->IsDXTFormat());
+        break;
     }
 
     m_commonSurf->UnDirtyDDrawSurface();

--- a/src/ddraw/ddraw2/ddraw3_surface.h
+++ b/src/ddraw/ddraw2/ddraw3_surface.h
@@ -106,8 +106,6 @@ namespace dxvk {
 
     HRESULT STDMETHODCALLTYPE SetSurfaceDesc(LPDDSURFACEDESC lpDDSD, DWORD dwFlags);
 
-    IDirectDrawSurface3* GetShadowOrProxied();
-
     HRESULT InitializeOrUploadD3D9();
 
     void DownloadSurfaceData();
@@ -118,6 +116,15 @@ namespace dxvk {
 
     DDraw3Surface* GetShadowSurface() const {
       return m_shadowSurf.ptr();
+    }
+
+    IDirectDrawSurface3* GetShadowOrProxied() {
+      d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
+
+      if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr))
+        return m_shadowSurf->GetProxied();
+
+      return m_proxy.ptr();
     }
 
     DDrawCommonSurface* GetCommonSurface() const {
@@ -166,13 +173,16 @@ namespace dxvk {
 
     inline HRESULT UploadSurfaceData();
 
+    bool                     m_readOnlyLock = false;
+    std::atomic<uint8_t>     m_lockCount    = 0u;
+
     Com<DDrawCommonSurface>  m_commonSurf;
 
-    DDrawCommonInterface*    m_commonIntf = nullptr;
+    DDrawCommonInterface*    m_commonIntf   = nullptr;
 
     Com<DDrawSurface, false> m_originSurf;
 
-    DDraw3Surface*           m_parentSurf = nullptr;
+    DDraw3Surface*           m_parentSurf   = nullptr;
 
     // Offscreen plain surface we use to mask unwanted DDraw interactions, such
     // as forced swapchain presents caused by blits/locks on primary surfaces
@@ -187,9 +197,6 @@ namespace dxvk {
     // They are implemented with linked list, so for example only one mip level
     // will be held in a parent texture, and the next mip level will be held in the previous mip.
     std::unordered_map<IDirectDrawSurface3*, Com<DDraw3Surface, false>> m_attachedSurfaces;
-
-    uint32_t                 m_surfCount  = 0;
-    static std::atomic<uint32_t> s_surfCount;
 
   };
 

--- a/src/ddraw/ddraw4/ddraw4_interface.cpp
+++ b/src/ddraw/ddraw4/ddraw4_interface.cpp
@@ -17,8 +17,6 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> DDraw4Interface::s_intfCount = 0;
-
   DDraw4Interface::DDraw4Interface(
         DDrawCommonInterface* commonIntf,
         Com<IDirectDraw4>&& proxyIntf)
@@ -38,16 +36,10 @@ namespace dxvk {
     // Note: IDirectDraw4 can never be the origin interface
 
     m_commonIntf->SetDD4Interface(this);
-
-    m_intfCount = ++s_intfCount;
-
-    Logger::debug(str::format("DDraw4Interface: Created a new interface nr. <<4-", m_intfCount, ">>"));
   }
 
   DDraw4Interface::~DDraw4Interface() {
     m_commonIntf->SetDD4Interface(nullptr);
-
-    Logger::debug(str::format("DDraw4Interface: Interface nr. <<4-", m_intfCount, ">> bites the dust"));
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::QueryInterface(REFIID riid, void** ppvObject) {
@@ -202,59 +194,74 @@ namespace dxvk {
 
     InitReturnPtr(lplpDDSurface);
 
-    // Because we are removing the DDSCAPS_WRITEONLY flag below, we need
-    // to first validate the combinations that would otherwise cause issues
-    HRESULT hr = ValidateSurfaceFlags(lpDDSurfaceDesc);
-    if (unlikely(FAILED(hr)))
-      return hr;
+    if (likely(lpDDSurfaceDesc->dwFlags & DDSD_CAPS)) {
+      // Because we are removing the DDSCAPS_WRITEONLY flag below, we need
+      // to first validate the combinations that would otherwise cause issues
+      HRESULT hr = ValidateSurfaceFlags(lpDDSurfaceDesc);
+      if (unlikely(FAILED(hr)))
+        return hr;
 
-    // We need to ensure we can always read from surfaces for upload to
-    // D3D9, so always strip the DDSCAPS_WRITEONLY flag on creation
-    lpDDSurfaceDesc->ddsCaps.dwCaps &= ~DDSCAPS_WRITEONLY;
-    // Similarly strip the DDSCAPS2_OPAQUE flag on texture creation
-    lpDDSurfaceDesc->ddsCaps.dwCaps2 &= ~DDSCAPS2_OPAQUE;
-
-    // Work around a WineD3D bug/limitation that prevents
-    // read back from L6V5U5 and X8L8V8U8 video memory surfaces
-    //
-    // Note: Doing this for other surfaces/formats is a bad idea,
-    // because some games expect these flags to remain in place, and
-    // may crash in case they find that's not the case
-    if (unlikely((lpDDSurfaceDesc->ddpfPixelFormat.dwFlags & DDPF_BUMPLUMINANCE)
-              && (lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_VIDEOMEMORY))) {
-      Logger::warn("DDraw4Interface::CreateSurface: Video memory DDPF_BUMPLUMINANCE surface");
-      lpDDSurfaceDesc->ddsCaps.dwCaps &= ~DDSCAPS_VIDEOMEMORY &
-                                         ~DDSCAPS_LOCALVIDMEM &
-                                         ~DDSCAPS_NONLOCALVIDMEM;
-      lpDDSurfaceDesc->ddsCaps.dwCaps |= DDSCAPS_SYSTEMMEMORY;
+      // We need to ensure we can always read from surfaces for upload to
+      // D3D9, so always strip the DDSCAPS_WRITEONLY flag on creation
+      lpDDSurfaceDesc->ddsCaps.dwCaps &= ~DDSCAPS_WRITEONLY;
+      // Similarly strip the DDSCAPS2_OPAQUE flag on texture creation
+      lpDDSurfaceDesc->ddsCaps.dwCaps2 &= ~DDSCAPS2_OPAQUE;
     }
 
-    if (unlikely(lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_ZBUFFER)) {
-      if (unlikely(m_commonIntf->GetOptions()->useD16forD24X8
-                && lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFF
-                && lpDDSurfaceDesc->ddpfPixelFormat.dwStencilBitMask == 0x0)) {
-        // Games such as Need for Speed: Porsche are broken with 32-bit color
-        // on night tracks with "projected" lights, because they clearly were
-        // designed with 16-bit Z buffers in mind. Fix it up by silently swapping
-        // D16 for D24X8 on depth stencil creation.
-        Logger::info("DDraw4Interface::CreateSurface: Using D16 instead of D24X8");
-        lpDDSurfaceDesc->ddpfPixelFormat.dwZBufferBitDepth = 16;
-        lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFF;
-      } else if (unlikely(lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFFFF)) {
-        if (m_commonIntf->GetOptions()->useD24X8forD32) {
-          // In case of up-front unsupported and unadvertised D32 depth stencil use,
-          // replace it with D24X8, as some games, such as Sacrifice, rely on it
-          // to properly enable 32-bit display modes (and revert to 16-bit otherwise)
-          Logger::info("DDraw4Interface::CreateSurface: Using D24X8 instead of D32");
-          lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFFFF;
-        } else {
-          Logger::warn("DDraw4Interface::CreateSurface: Use of unsupported D32");
+    if (likely(lpDDSurfaceDesc->dwFlags & DDSD_PIXELFORMAT)) {
+      // WineD3D will fail to create 8-bit texture surfaces at times, for whatever reason...
+      if (unlikely((lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_TEXTURE)
+               &&  (lpDDSurfaceDesc->ddpfPixelFormat.dwFlags & DDPF_RGB)
+               &&   lpDDSurfaceDesc->ddpfPixelFormat.dwRGBBitCount == 8
+               && !(lpDDSurfaceDesc->ddpfPixelFormat.dwFlags & DDPF_PALETTEINDEXED8))) {
+        static bool s_8bitTextureWarningShown;
+
+        if (!std::exchange(s_8bitTextureWarningShown, true))
+          Logger::warn("DDraw4Interface::CreateSurface: Use of potentially unsupported 8-bit texture surface");
+      }
+
+      // Work around a WineD3D bug/limitation that prevents
+      // read back from L6V5U5 and X8L8V8U8 video memory surfaces
+      //
+      // Note: Doing this for other surfaces/formats is a bad idea,
+      // because some games expect these flags to remain in place, and
+      // may crash in case they find that's not the case
+      if (unlikely((lpDDSurfaceDesc->ddpfPixelFormat.dwFlags == (DDPF_BUMPDUDV | DDPF_BUMPLUMINANCE))
+                && (lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_VIDEOMEMORY))) {
+        Logger::warn("DDraw4Interface::CreateSurface: Video memory DDPF_BUMPLUMINANCE surface");
+        lpDDSurfaceDesc->ddsCaps.dwCaps &= ~DDSCAPS_VIDEOMEMORY &
+                                           ~DDSCAPS_LOCALVIDMEM &
+                                           ~DDSCAPS_NONLOCALVIDMEM;
+        lpDDSurfaceDesc->ddsCaps.dwCaps |= DDSCAPS_SYSTEMMEMORY;
+      }
+
+      if (unlikely(lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_ZBUFFER)) {
+        if (unlikely(m_commonIntf->GetOptions()->useD16forD24X8
+                  && lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFF
+                  && lpDDSurfaceDesc->ddpfPixelFormat.dwStencilBitMask == 0x0)) {
+          // Games such as Need for Speed: Porsche are broken with 32-bit color
+          // on night tracks with "projected" lights, because they clearly were
+          // designed with 16-bit Z buffers in mind. Fix it up by silently swapping
+          // D16 for D24X8 on depth stencil creation.
+          Logger::debug("DDraw4Interface::CreateSurface: Using D16 instead of D24X8");
+          lpDDSurfaceDesc->ddpfPixelFormat.dwZBufferBitDepth = 16;
+          lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFF;
+        } else if (unlikely(lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFFFF)) {
+          if (m_commonIntf->GetOptions()->useD24X8forD32) {
+            // In case of up-front unsupported and unadvertised D32 depth stencil use,
+            // replace it with D24X8, as some games, such as Sacrifice, rely on it
+            // to properly enable 32-bit display modes (and revert to 16-bit otherwise)
+            Logger::debug("DDraw4Interface::CreateSurface: Using D24X8 instead of D32");
+            lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFFFF;
+          } else {
+            Logger::warn("DDraw4Interface::CreateSurface: Use of unsupported D32");
+          }
         }
       }
     }
 
     Com<IDirectDrawSurface4> ddrawSurface4Proxied;
-    hr = m_proxy->CreateSurface(lpDDSurfaceDesc, &ddrawSurface4Proxied, pUnkOuter);
+    HRESULT hr = m_proxy->CreateSurface(lpDDSurfaceDesc, &ddrawSurface4Proxied, pUnkOuter);
     // Some games simply try creating surfaces with various formats until something works...
     if (unlikely(FAILED(hr)))
       return hr;
@@ -267,10 +274,8 @@ namespace dxvk {
 
         // Shadow surface creation for the primary surface
         // (it needs to be based on the same incoming desc)
-        if (unlikely(!surface4->GetCommonSurface()->Is8BitFormat() &&
-                      m_commonIntf->GetOptions()->forceLegacyPresent)) {
-          Logger::debug("DDraw4Interface::CreateSurface: Creating shadow surface");
-
+        if (unlikely(m_commonIntf->GetOptions()->forceLegacyPresent &&
+                    !surface4->GetCommonSurface()->SkipD3D9Operations())) {
           DDSURFACEDESC2 shadowDesc = *lpDDSurfaceDesc;
           const DDSURFACEDESC2* primaryDesc = surface4->GetCommonSurface()->GetDesc2();
 
@@ -333,7 +338,35 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::EnumDisplayModes(DWORD dwFlags, LPDDSURFACEDESC2 lpDDSurfaceDesc, LPVOID lpContext, LPDDENUMMODESCALLBACK2 lpEnumModesCallback) {
-    return m_proxy->EnumDisplayModes(dwFlags, lpDDSurfaceDesc, lpContext, lpEnumModesCallback);
+    if (unlikely(lpEnumModesCallback == nullptr))
+      return DDERR_INVALIDPARAMS;
+
+    std::vector<DDSURFACEDESC2> displayModes;
+    HRESULT hr = m_proxy->EnumDisplayModes(dwFlags, lpDDSurfaceDesc, reinterpret_cast<void*>(&displayModes), EnumDisplayModesCallback2);
+    if (unlikely(FAILED(hr)))
+      return hr;
+
+    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
+
+    hr = DDENUMRET_OK;
+
+    auto displayModeIt = displayModes.begin();
+    while (displayModeIt != displayModes.end() && hr == DDENUMRET_OK) {
+      DDSURFACEDESC2 dmDesc = *displayModeIt;
+
+      if (unlikely(d3dOptions->mask8BitModes && dmDesc.ddpfPixelFormat.dwRGBBitCount == 8)) {
+        static bool s_maskModeWarningShown;
+
+        if (!std::exchange(s_maskModeWarningShown, true))
+          Logger::warn("DDraw4Interface::EnumDisplayModes: Masking 8-bit display modes");
+      } else {
+        hr = lpEnumModesCallback(&dmDesc, lpContext);
+      }
+
+      ++displayModeIt;
+    }
+
+    return DD_OK;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Interface::EnumSurfaces(DWORD dwFlags, LPDDSURFACEDESC2 lpDDSD, LPVOID lpContext, LPDDENUMSURFACESCALLBACK2 lpEnumSurfacesCallback) {
@@ -469,8 +502,17 @@ namespace dxvk {
 
     const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
 
-    if (unlikely(d3dOptions->mask8BitModes && lpDDSurfaceDesc->ddpfPixelFormat.dwRGBBitCount == 8))
+    if (unlikely(d3dOptions->mask8BitModes
+              && lpDDSurfaceDesc->dwFlags & DDSD_PIXELFORMAT
+              && lpDDSurfaceDesc->ddpfPixelFormat.dwRGBBitCount == 8)) {
+      // Report a fake D3DFMT_R5G6B5 back buffer scenario
+      lpDDSurfaceDesc->ddpfPixelFormat.dwFlags = DDPF_RGB;
       lpDDSurfaceDesc->ddpfPixelFormat.dwRGBBitCount = 16;
+      lpDDSurfaceDesc->ddpfPixelFormat.dwRGBAlphaBitMask = 0x0000;
+      lpDDSurfaceDesc->ddpfPixelFormat.dwRBitMask = 0xf800;
+      lpDDSurfaceDesc->ddpfPixelFormat.dwGBitMask = 0x07e0;
+      lpDDSurfaceDesc->ddpfPixelFormat.dwBBitMask = 0x001f;
+    }
 
     return DD_OK;
   }
@@ -575,7 +617,7 @@ namespace dxvk {
     DDrawCommonSurface* ps = m_commonIntf->GetPrimarySurface();
 
     if (likely(ps != nullptr)) {
-      hr = ps->RefreshSurfaceDescripton();
+      hr = ps->RefreshSurfaceDescripton(true);
       if (unlikely(FAILED(hr)))
         Logger::warn("DDraw4Interface::SetDisplayMode: Failed to update primary surface desc");
     }

--- a/src/ddraw/ddraw4/ddraw4_interface.h
+++ b/src/ddraw/ddraw4/ddraw4_interface.h
@@ -88,9 +88,6 @@ namespace dxvk {
 
     Com<D3D6Interface, false> m_d3d6Intf;
 
-    uint32_t                  m_intfCount = 0;
-    static std::atomic<uint32_t> s_intfCount;
-
   };
 
 }

--- a/src/ddraw/ddraw4/ddraw4_surface.cpp
+++ b/src/ddraw/ddraw4/ddraw4_surface.cpp
@@ -10,8 +10,6 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> DDraw4Surface::s_surfCount = 0;
-
   DDraw4Surface::DDraw4Surface(
         DDrawCommonSurface* commonSurf,
         Com<IDirectDrawSurface4>&& surfProxy,
@@ -56,7 +54,7 @@ namespace dxvk {
       if (likely(m_nextFlippable != nullptr)) {
         // The call to EnumAttachedSurfaces has incremented the public ref
         m_nextFlippable->Release();
-        Logger::debug("DDraw4Surface: Retrieved the next swapchain surface");
+        //Logger::debug("DDraw4Surface: Retrieved the next swapchain surface");
       }
     }
 
@@ -73,14 +71,12 @@ namespace dxvk {
     if (m_parent != nullptr && m_isChildObject)
       m_parent->AddRef();
 
-    m_surfCount = ++s_surfCount;
-
-    Logger::debug(str::format("DDraw4Surface: Created a new surface nr. [[4-", m_surfCount, "]]"));
+    //Logger::debug(str::format("DDraw4Surface: Created a new surface nr. [[4-", std::hex, this, "]]"));
 
     if (m_commonSurf->GetOrigin() == nullptr) {
       m_commonSurf->SetOrigin(this);
       m_commonSurf->SetIsAttached(m_parentSurf != nullptr);
-      m_commonSurf->ListSurfaceDetails();
+      //m_commonSurf->ListSurfaceDetails();
     }
   }
 
@@ -113,7 +109,7 @@ namespace dxvk {
 
     m_commonSurf->SetDD4Surface(nullptr);
 
-    Logger::debug(str::format("DDraw4Surface: Surface nr. [[4-", m_surfCount, "]] bites the dust"));
+    //Logger::debug(str::format("DDraw4Surface: Surface nr. [[4-", std::hex, this, "]] bites the dust"));
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::QueryInterface(REFIID riid, void** ppvObject) {
@@ -317,7 +313,7 @@ namespace dxvk {
       DownloadSurfaceData();
     }
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
     if (likely(d3d9Device != nullptr)) {
       const bool exclusiveMode = m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE;
 
@@ -373,7 +369,7 @@ namespace dxvk {
       return DDERR_UNSUPPORTED;
     }
 
-    RECT* sourceFullSurfaceRect = nullptr;
+    const RECT* sourceFullSurfaceRect = nullptr;
     // Write back any dirty surface data from bound D3D9 back buffers or
     // depth stencils, for both the source surface and the current surface
     if (likely(lpDDSrcSurface != nullptr)) {
@@ -389,7 +385,7 @@ namespace dxvk {
       DownloadSurfaceData();
     }
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
     if (likely(d3d9Device != nullptr)) {
       const bool exclusiveMode = m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE;
 
@@ -528,7 +524,7 @@ namespace dxvk {
 
     Com<DDraw4Surface> overrideSurf = static_cast<DDraw4Surface*>(lpDDSurfaceTargetOverride);
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
     // Overlays can have odd video formats which DXVK doesn't support for RT
     // use, so let DDraw present in case the flipped surface is an overlay
     if (likely(d3d9Device != nullptr && !m_commonSurf->IsOverlay())) {
@@ -622,26 +618,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DDraw4Surface::GetAttachedSurface(LPDDSCAPS2 lpDDSCaps, LPDIRECTDRAWSURFACE4 *lplpDDAttachedSurface) {
     if (unlikely(lpDDSCaps == nullptr || lplpDDAttachedSurface == nullptr))
       return DDERR_INVALIDPARAMS;
-
-    if (lpDDSCaps->dwCaps & DDSCAPS_PRIMARYSURFACE)
-      Logger::debug("DDraw4Surface::GetAttachedSurface: Querying for the primary surface");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_FRONTBUFFER)
-      Logger::debug("DDraw4Surface::GetAttachedSurface: Querying for the front buffer");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_BACKBUFFER)
-      Logger::debug("DDraw4Surface::GetAttachedSurface: Querying for the back buffer");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_FLIP)
-      Logger::debug("DDraw4Surface::GetAttachedSurface: Querying for a flippable surface");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_OFFSCREENPLAIN)
-      Logger::debug("DDraw4Surface::GetAttachedSurface: Querying for an offscreen plain surface");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_ZBUFFER)
-      Logger::debug("DDraw4Surface::GetAttachedSurface: Querying for a depth stencil");
-    else if ((lpDDSCaps->dwCaps  & DDSCAPS_MIPMAP)
-          || (lpDDSCaps->dwCaps2 & DDSCAPS2_MIPMAPSUBLEVEL))
-      Logger::debug("DDraw4Surface::GetAttachedSurface: Querying for a texture mip map");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_TEXTURE)
-      Logger::debug("DDraw4Surface::GetAttachedSurface: Querying for a texture");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_OVERLAY)
-      Logger::debug("DDraw4Surface::GetAttachedSurface: Querying for an overlay");
 
     Com<IDirectDrawSurface4> surface;
     HRESULT hr = m_proxy->GetAttachedSurface(lpDDSCaps, &surface);
@@ -795,7 +771,21 @@ namespace dxvk {
     // Write back any dirty surface data from bound D3D9 back buffers or depth stencils
     DownloadSurfaceData();
 
-    return GetShadowOrProxied()->Lock(lpDestRect, lpDDSurfaceDesc, dwFlags, hEvent);
+    HRESULT hr = GetShadowOrProxied()->Lock(lpDestRect, lpDDSurfaceDesc, dwFlags, hEvent);
+    if (unlikely(FAILED(hr)))
+      return hr;
+
+    // For single surface locks, track the READONLY flag in order to skip dirtying
+    // on Unlock(). Reset the tracking in case of multiple simultaneous locks.
+    if (likely(!m_lockCount)) {
+      m_readOnlyLock = (dwFlags & DDLOCK_READONLY) && !(dwFlags & DDLOCK_WRITEONLY);
+    } else {
+      m_readOnlyLock = false;
+    }
+
+    m_lockCount++;
+
+    return DD_OK;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw4Surface::ReleaseDC(HDC hDC) {
@@ -816,7 +806,7 @@ namespace dxvk {
 
     m_commonSurf->DirtyDDrawSurface();
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
     if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
       const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                 !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
@@ -881,7 +871,7 @@ namespace dxvk {
     if (unlikely(FAILED(hr)))
       return hr;
 
-    hr = m_commonSurf->RefreshSurfaceDescripton();
+    hr = m_commonSurf->RefreshSurfaceDescripton(false);
     if (unlikely(FAILED(hr)))
       Logger::err("DDraw4Surface::SetColorKey: Failed to retrieve updated surface desc");
 
@@ -890,7 +880,7 @@ namespace dxvk {
       if (unlikely(FAILED(hr))) {
         Logger::warn("DDraw4Surface::SetColorKey: Failed to set shadow surface color key");
       } else {
-        hr = m_shadowSurf->GetCommonSurface()->RefreshSurfaceDescripton();
+        hr = m_shadowSurf->GetCommonSurface()->RefreshSurfaceDescripton(false);
         if (unlikely(FAILED(hr)))
           Logger::warn("DDraw4Surface::SetColorKey: Failed to retrieve updated shadow surface desc");
       }
@@ -929,9 +919,16 @@ namespace dxvk {
     if (unlikely(FAILED(hr)))
       return hr;
 
-    m_commonSurf->DirtyDDrawSurface();
+    if (!m_readOnlyLock) {
+      m_commonSurf->DirtyDDrawSurface();
+    } else {
+      m_readOnlyLock = false;
+    }
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    if (likely(m_lockCount))
+      m_lockCount--;
+
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
     if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
       const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                 !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
@@ -1010,14 +1007,14 @@ namespace dxvk {
     if (unlikely(FAILED(hr)))
       return hr;
 
-    hr = m_commonSurf->RefreshSurfaceDescripton();
+    hr = m_commonSurf->RefreshSurfaceDescripton(true);
     if (unlikely(FAILED(hr))) {
       Logger::err("DDraw4Surface::SetSurfaceDesc: Failed to retrieve updated surface desc");
       return hr;
     }
 
     // We may need to recreate the d3d9 object based on the new desc
-    m_commonSurf->SetD3D9Surface(nullptr);
+    m_commonSurf->ResetD3D9Objects();
 
     return DD_OK;
   }
@@ -1049,29 +1046,19 @@ namespace dxvk {
     return DD_OK;
   }
 
-  IDirectDrawSurface4* DDraw4Surface::GetShadowOrProxied() {
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
-
-    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr))
-      return m_shadowSurf->GetProxied();
-
-    return m_proxy.ptr();
-  }
-
   HRESULT DDraw4Surface::InitializeD3D9RenderTarget() {
+    // Currently ignores all P8 surfaces
+    if (unlikely(m_commonSurf->SkipD3D9Operations()))
+      return DD_OK;
+
     m_commonSurf->RefreshD3D9Device();
 
-    m_commonSurf->MarkAsD3D9BackBuffer();
-
     if (unlikely(!m_commonSurf->IsInitialized())) {
-      if (m_commonSurf->IsTexture())
-        UpdateMipMapCount();
-
       HRESULT hr = m_commonSurf->InitializeD3D9(true);
-      if (unlikely(FAILED(hr)))
+      if (unlikely(FAILED(hr))) {
+        Logger::err(str::format("DDraw4Surface::InitializeD3D9RenderTarget: Failed to initialize surface nr. [[4-", std::hex, this, "]]"));
         return hr;
-
-      Logger::debug(str::format("DDraw4Surface::InitializeD3D9RenderTarget: Initialized surface nr. [[4-", m_surfCount, "]]"));
+      }
 
       return UploadSurfaceData();
     }
@@ -1082,14 +1069,12 @@ namespace dxvk {
   HRESULT DDraw4Surface::InitializeD3D9DepthStencil() {
     m_commonSurf->RefreshD3D9Device();
 
-    m_commonSurf->MarkAsD3D9DepthStencil();
-
     if (unlikely(!m_commonSurf->IsInitialized())) {
       HRESULT hr = m_commonSurf->InitializeD3D9(false);
-      if (unlikely(FAILED(hr)))
+      if (unlikely(FAILED(hr))) {
+        Logger::err(str::format("DDraw4Surface::InitializeD3D9DepthStencil: Failed to initialize surface nr. [[4-", std::hex, this, "]]"));
         return hr;
-
-      Logger::debug(str::format("DDraw4Surface::InitializeD3D9DepthStencil: Initialized surface nr. [[4-", m_surfCount, "]]"));
+      }
 
       return UploadSurfaceData();
     }
@@ -1098,29 +1083,27 @@ namespace dxvk {
   }
 
   HRESULT DDraw4Surface::InitializeOrUploadD3D9() {
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    // Currently ignores all P8 surfaces
+    if (unlikely(m_commonSurf->SkipD3D9Operations()))
+      return DD_OK;
+
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
 
     // Fast skip
     if (unlikely(d3d9Device == nullptr))
       return DD_OK;
 
     if (unlikely(!m_commonSurf->IsInitialized())) {
-      if (m_commonSurf->IsTexture())
-        UpdateMipMapCount();
-
       const bool initRenderTarget = m_commonSurf->GetCommonD3DDevice()->IsCurrentRenderTarget(m_commonSurf.ptr());
 
       HRESULT hr = m_commonSurf->InitializeD3D9(initRenderTarget);
-      if (unlikely(FAILED(hr)))
+      if (unlikely(FAILED(hr))) {
+        Logger::err(str::format("DDraw4Surface::InitializeOrUploadD3D9: Failed to initialize surface nr. [[4-", std::hex, this, "]]"));
         return hr;
-
-      Logger::debug(str::format("DDraw4Surface::InitializeOrUploadD3D9: Initialized surface nr. [[4-", m_surfCount, "]]"));
+      }
     }
 
-    if (likely(m_commonSurf->IsInitialized()))
-      return UploadSurfaceData();
-
-    return DD_OK;
+    return UploadSurfaceData();
   }
 
   void DDraw4Surface::DownloadSurfaceData() {
@@ -1132,63 +1115,13 @@ namespace dxvk {
     if (likely(!m_commonIntf->GetOptions()->deviceResourceSharing))
       m_commonSurf->RefreshD3D9Device();
 
-    if (unlikely(m_commonSurf->IsD3D9BackBuffer())) {
-      if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
-        //Logger::debug(str::format("DDraw4Surface::DownloadSurfaceData: Downloading nr. [[4-", m_surfCount, "]]"));
-        BlitToDDrawSurface<IDirectDrawSurface4, DDSURFACEDESC2>(GetShadowOrProxied(), m_commonSurf->GetD3D9Surface(),
-                                                                m_commonSurf->IsDXTFormat());
-        m_commonSurf->UnDirtyD3D9Surface();
-      }
-    } else if (unlikely(m_commonSurf->IsD3D9DepthStencil())) {
-      if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
-        //Logger::debug(str::format("DDraw4Surface::DownloadSurfaceData: Downloading nr. [[4-", m_surfCount, "]]"));
-        BlitToDDrawSurface<IDirectDrawSurface4, DDSURFACEDESC2>(m_proxy.ptr(), m_commonSurf->GetD3D9Surface(),
-                                                                m_commonSurf->IsDXTFormat());
-        m_commonSurf->UnDirtyD3D9Surface();
-      }
+    // TODO: We are technically ignoring mip maps as is, though that will probably never be an issue
+    if (m_commonSurf->IsD3D9SurfaceDirty() && m_commonSurf->IsInitialized()) {
+      //Logger::debug(str::format("DDraw4Surface::DownloadSurfaceData: Downloading nr. [[4-", std::hex, this, "]]"));
+      BlitToDDrawSurface<IDirectDrawSurface4, DDSURFACEDESC2>(GetShadowOrProxied(), m_commonSurf->GetD3D9Surface(),
+                                                              m_commonSurf->IsDXTFormat());
+      m_commonSurf->UnDirtyD3D9Surface();
     }
-  }
-
-  inline void DDraw4Surface::UpdateMipMapCount() {
-    // We need to count the number of actual mips on initialization by going through
-    // the mip chain, since the dwMipMapCount number may or may not be accurate. I am
-    // guessing it was intended more as a hint, not neceesarily a set number.
-    const DDSURFACEDESC2* desc2  = m_commonSurf->GetDesc2();
-
-    IDirectDrawSurface4* mipMap = m_proxy.ptr();
-    DDSURFACEDESC2 mipDesc2;
-    uint16_t mipCount = 1;
-
-    while (mipMap != nullptr) {
-      IDirectDrawSurface4* parentSurface = mipMap;
-      mipMap = nullptr;
-      parentSurface->EnumAttachedSurfaces(&mipMap, ListMipChainSurfaces4Callback);
-      if (mipMap != nullptr) {
-        mipCount++;
-
-        mipDesc2 = { };
-        mipDesc2.dwSize = sizeof(DDSURFACEDESC2);
-        mipMap->GetSurfaceDesc(&mipDesc2);
-        // Ignore multiple 1x1 mips, which apparently can get generated if the
-        // application gets the dwMipMapCount wrong vs surface dimensions.
-        if (unlikely(mipDesc2.dwWidth == 1 && mipDesc2.dwHeight == 1))
-          break;
-      }
-    }
-
-    // Do not worry about maximum supported mip map levels validation,
-    // because D3D9 will handle this for us and cap them appropriately
-    if (mipCount > 1) {
-      Logger::debug(str::format("DDraw4Surface::UpdateMipMapCount: Found ", mipCount, " mip levels"));
-
-      if (unlikely(mipCount != desc2->dwMipMapCount))
-        Logger::debug(str::format("DDraw4Surface::UpdateMipMapCount: Mismatch with declared ", desc2->dwMipMapCount, " mip levels"));
-    }
-
-    if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps))
-      mipCount = 0;
-
-    m_commonSurf->SetMipCount(mipCount);
   }
 
   inline HRESULT DDraw4Surface::UploadSurfaceData() {
@@ -1196,15 +1129,19 @@ namespace dxvk {
     if (!m_commonSurf->IsDDrawSurfaceDirty())
       return DD_OK;
 
-    //Logger::debug(str::format("DDraw4Surface::UploadSurfaceData: Uploading nr. [[4-", m_surfCount, "]]"));
+    //Logger::debug(str::format("DDraw4Surface::UploadSurfaceData: Uploading nr. [[4-", std::hex, this, "]]"));
 
-    if (m_commonSurf->IsTexture()) {
-      BlitToD3D9Texture<IDirectDrawSurface4, DDSURFACEDESC2>(m_commonSurf->GetD3D9Texture(), m_proxy.ptr(),
-                                                             m_commonSurf->GetMipCount(), m_commonSurf->IsDXTFormat());
-    // Blit surfaces directly
-    } else {
-      BlitToD3D9Surface<IDirectDrawSurface4, DDSURFACEDESC2>(m_commonSurf->GetD3D9Surface(), GetShadowOrProxied(),
-                                                             m_commonSurf->IsDXTFormat());
+    D3D9SurfaceType d3d9SurfaceType = m_commonSurf->GetD3D9SurfaceType();
+
+    switch (d3d9SurfaceType) {
+      case D3D9SurfaceType::Texture:
+        BlitToD3D9Texture<IDirectDrawSurface4, DDSURFACEDESC2>(m_commonSurf->GetD3D9Texture(), m_proxy.ptr(),
+                                                               m_commonSurf->GetMipCount(), m_commonSurf->IsDXTFormat());
+        break;
+      default:
+        BlitToD3D9Surface<IDirectDrawSurface4, DDSURFACEDESC2>(m_commonSurf->GetD3D9Surface(), GetShadowOrProxied(),
+                                                               m_commonSurf->IsDXTFormat());
+        break;
     }
 
     m_commonSurf->UnDirtyDDrawSurface();

--- a/src/ddraw/ddraw4/ddraw4_surface.h
+++ b/src/ddraw/ddraw4/ddraw4_surface.h
@@ -117,8 +117,6 @@ namespace dxvk {
 
     HRESULT STDMETHODCALLTYPE ChangeUniquenessValue();
 
-    IDirectDrawSurface4* GetShadowOrProxied();
-
     HRESULT InitializeD3D9RenderTarget();
 
     HRESULT InitializeD3D9DepthStencil();
@@ -133,6 +131,15 @@ namespace dxvk {
 
     DDraw4Surface* GetShadowSurface() const {
       return m_shadowSurf.ptr();
+    }
+
+    IDirectDrawSurface4* GetShadowOrProxied() {
+      d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
+
+      if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr))
+        return m_shadowSurf->GetProxied();
+
+      return m_proxy.ptr();
     }
 
     DDrawCommonSurface* GetCommonSurface() const {
@@ -183,11 +190,12 @@ namespace dxvk {
 
   private:
 
-    inline void UpdateMipMapCount();
-
     inline HRESULT UploadSurfaceData();
 
-    bool                    m_isChildObject = true;
+    bool                    m_isChildObject = false;
+
+    bool                    m_readOnlyLock  = false;
+    std::atomic<uint8_t>    m_lockCount     = 0u;
 
     Com<DDrawCommonSurface> m_commonSurf;
     DDrawCommonInterface*   m_commonIntf    = nullptr;
@@ -213,9 +221,6 @@ namespace dxvk {
     // They are implemented with linked list, so for example only one mip level
     // will be held in a parent texture, and the next mip level will be held in the previous mip.
     std::unordered_map<IDirectDrawSurface4*, Com<DDraw4Surface, false>> m_attachedSurfaces;
-
-    uint32_t                m_surfCount     = 0;
-    static std::atomic<uint32_t> s_surfCount;
 
   };
 

--- a/src/ddraw/ddraw7/ddraw7_interface.cpp
+++ b/src/ddraw/ddraw7/ddraw7_interface.cpp
@@ -16,8 +16,6 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> DDraw7Interface::s_intfCount = 0;
-
   DDraw7Interface::DDraw7Interface(
         DDrawCommonInterface* commonIntf,
         Com<IDirectDraw7>&& proxyIntf)
@@ -28,9 +26,9 @@ namespace dxvk {
     Com<d3d9::IDirect3D9> d3d9Intf = d3d9::Direct3DCreate9(D3D_SDK_VERSION);
 
     if (m_commonIntf == nullptr) {
-      Com<IDxvkD3D8InterfaceBridge> d3d9Bridge;
+      Com<IDxvkLegacyD3DInterfaceBridge> d3d9Bridge;
 
-      if (unlikely(FAILED(d3d9Intf->QueryInterface(__uuidof(IDxvkD3D8InterfaceBridge), reinterpret_cast<void**>(&d3d9Bridge))))) {
+      if (unlikely(FAILED(d3d9Intf->QueryInterface(__uuidof(IDxvkLegacyD3DInterfaceBridge), reinterpret_cast<void**>(&d3d9Bridge))))) {
         throw DxvkError("DDraw7Interface: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
       }
 
@@ -49,10 +47,6 @@ namespace dxvk {
       m_commonIntf->SetOrigin(this);
 
     m_commonIntf->SetDD7Interface(this);
-
-    m_intfCount = ++s_intfCount;
-
-    Logger::debug(str::format("DDraw7Interface: Created a new interface nr. <<7-", m_intfCount, ">>"));
   }
 
   DDraw7Interface::~DDraw7Interface() {
@@ -60,8 +54,6 @@ namespace dxvk {
       m_commonIntf->SetOrigin(nullptr);
 
     m_commonIntf->SetDD7Interface(nullptr);
-
-    Logger::debug(str::format("DDraw7Interface: Interface nr. <<7-", m_intfCount, ">> bites the dust"));
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::QueryInterface(REFIID riid, void** ppvObject) {
@@ -193,59 +185,74 @@ namespace dxvk {
 
     InitReturnPtr(lplpDDSurface);
 
-    // Because we are removing the DDSCAPS_WRITEONLY flag below, we need
-    // to first validate the combinations that would otherwise cause issues
-    HRESULT hr = ValidateSurfaceFlags(lpDDSurfaceDesc);
-    if (unlikely(FAILED(hr)))
-      return hr;
+    if (likely(lpDDSurfaceDesc->dwFlags & DDSD_CAPS)) {
+      // Because we are removing the DDSCAPS_WRITEONLY flag below, we need
+      // to first validate the combinations that would otherwise cause issues
+      HRESULT hr = ValidateSurfaceFlags(lpDDSurfaceDesc);
+      if (unlikely(FAILED(hr)))
+        return hr;
 
-    // We need to ensure we can always read from surfaces for upload to
-    // D3D9, so always strip the DDSCAPS_WRITEONLY flag on creation
-    lpDDSurfaceDesc->ddsCaps.dwCaps &= ~DDSCAPS_WRITEONLY;
-    // Similarly strip the DDSCAPS2_OPAQUE flag on texture creation
-    lpDDSurfaceDesc->ddsCaps.dwCaps2 &= ~DDSCAPS2_OPAQUE;
-
-    // Work around a WineD3D bug/limitation that prevents
-    // read back from L6V5U5 and X8L8V8U8 video memory surfaces
-    //
-    // Note: Doing this for other surfaces/formats is a bad idea,
-    // because some games expect these flags to remain in place, and
-    // may crash in case they find that's not the case
-    if (unlikely((lpDDSurfaceDesc->ddpfPixelFormat.dwFlags & DDPF_BUMPLUMINANCE)
-              && (lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_VIDEOMEMORY))) {
-      Logger::warn("DDraw7Interface::CreateSurface: Video memory DDPF_BUMPLUMINANCE surface");
-      lpDDSurfaceDesc->ddsCaps.dwCaps &= ~DDSCAPS_VIDEOMEMORY &
-                                         ~DDSCAPS_LOCALVIDMEM &
-                                         ~DDSCAPS_NONLOCALVIDMEM;
-      lpDDSurfaceDesc->ddsCaps.dwCaps |= DDSCAPS_SYSTEMMEMORY;
+      // We need to ensure we can always read from surfaces for upload to
+      // D3D9, so always strip the DDSCAPS_WRITEONLY flag on creation
+      lpDDSurfaceDesc->ddsCaps.dwCaps &= ~DDSCAPS_WRITEONLY;
+      // Similarly strip the DDSCAPS2_OPAQUE flag on texture creation
+      lpDDSurfaceDesc->ddsCaps.dwCaps2 &= ~DDSCAPS2_OPAQUE;
     }
 
-    if (unlikely(lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_ZBUFFER)) {
-      if (unlikely(m_commonIntf->GetOptions()->useD16forD24X8
-                && lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFF
-                && lpDDSurfaceDesc->ddpfPixelFormat.dwStencilBitMask == 0x0)) {
-        // Games such as Need for Speed: Porsche are broken with 32-bit color
-        // on night tracks with "projected" lights, because they clearly were
-        // designed with 16-bit Z buffers in mind. Fix it up by silently swapping
-        // D16 for D24X8 on depth stencil creation.
-        Logger::info("DDraw7Interface::CreateSurface: Using D16 instead of D24X8");
-        lpDDSurfaceDesc->ddpfPixelFormat.dwZBufferBitDepth = 16;
-        lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFF;
-      } else if (unlikely(lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFFFF)) {
-        if (m_commonIntf->GetOptions()->useD24X8forD32) {
-          // In case of up-front unsupported and unadvertised D32 depth stencil use,
-          // replace it with D24X8, as some games, such as Sacrifice, rely on it
-          // to properly enable 32-bit display modes (and revert to 16-bit otherwise)
-          Logger::info("DDraw7Interface::CreateSurface: Using D24X8 instead of D32");
-          lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFFFF;
-        } else {
-          Logger::warn("DDraw7Interface::CreateSurface: Use of unsupported D32");
+    if (likely(lpDDSurfaceDesc->dwFlags & DDSD_PIXELFORMAT)) {
+      // WineD3D will fail to create 8-bit texture surfaces at times, for whatever reason...
+      if (unlikely((lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_TEXTURE)
+               &&  (lpDDSurfaceDesc->ddpfPixelFormat.dwFlags & DDPF_RGB)
+               &&   lpDDSurfaceDesc->ddpfPixelFormat.dwRGBBitCount == 8
+               && !(lpDDSurfaceDesc->ddpfPixelFormat.dwFlags & DDPF_PALETTEINDEXED8))) {
+        static bool s_8bitTextureWarningShown;
+
+        if (!std::exchange(s_8bitTextureWarningShown, true))
+          Logger::warn("DDraw7Interface::CreateSurface: Use of potentially unsupported 8-bit texture surface");
+      }
+
+      // Work around a WineD3D bug/limitation that prevents
+      // read back from L6V5U5 and X8L8V8U8 video memory surfaces
+      //
+      // Note: Doing this for other surfaces/formats is a bad idea,
+      // because some games expect these flags to remain in place, and
+      // may crash in case they find that's not the case
+      if (unlikely((lpDDSurfaceDesc->ddpfPixelFormat.dwFlags == (DDPF_BUMPDUDV | DDPF_BUMPLUMINANCE))
+                && (lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_VIDEOMEMORY))) {
+        Logger::warn("DDraw7Interface::CreateSurface: Video memory DDPF_BUMPLUMINANCE surface");
+        lpDDSurfaceDesc->ddsCaps.dwCaps &= ~DDSCAPS_VIDEOMEMORY &
+                                           ~DDSCAPS_LOCALVIDMEM &
+                                           ~DDSCAPS_NONLOCALVIDMEM;
+        lpDDSurfaceDesc->ddsCaps.dwCaps |= DDSCAPS_SYSTEMMEMORY;
+      }
+
+      if (unlikely(lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_ZBUFFER)) {
+        if (unlikely(m_commonIntf->GetOptions()->useD16forD24X8
+                  && lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFF
+                  && lpDDSurfaceDesc->ddpfPixelFormat.dwStencilBitMask == 0x0)) {
+          // Games such as Need for Speed: Porsche are broken with 32-bit color
+          // on night tracks with "projected" lights, because they clearly were
+          // designed with 16-bit Z buffers in mind. Fix it up by silently swapping
+          // D16 for D24X8 on depth stencil creation.
+          Logger::debug("DDraw7Interface::CreateSurface: Using D16 instead of D24X8");
+          lpDDSurfaceDesc->ddpfPixelFormat.dwZBufferBitDepth = 16;
+          lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFF;
+        } else if (unlikely(lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask == 0xFFFFFFFF)) {
+          if (m_commonIntf->GetOptions()->useD24X8forD32) {
+            // In case of up-front unsupported and unadvertised D32 depth stencil use,
+            // replace it with D24X8, as some games, such as Sacrifice, rely on it
+            // to properly enable 32-bit display modes (and revert to 16-bit otherwise)
+            Logger::debug("DDraw7Interface::CreateSurface: Using D24X8 instead of D32");
+            lpDDSurfaceDesc->ddpfPixelFormat.dwZBitMask = 0xFFFFFF;
+          } else {
+            Logger::warn("DDraw7Interface::CreateSurface: Use of unsupported D32");
+          }
         }
       }
     }
 
     Com<IDirectDrawSurface7> ddraw7SurfaceProxied;
-    hr = m_proxy->CreateSurface(lpDDSurfaceDesc, &ddraw7SurfaceProxied, pUnkOuter);
+    HRESULT hr = m_proxy->CreateSurface(lpDDSurfaceDesc, &ddraw7SurfaceProxied, pUnkOuter);
     // Some games simply try creating surfaces with various formats until something works...
     if (unlikely(FAILED(hr)))
       return hr;
@@ -258,10 +265,8 @@ namespace dxvk {
 
         // Shadow surface creation for the primary surface
         // (it needs to be based on the same incoming desc)
-        if (unlikely(!surface7->GetCommonSurface()->Is8BitFormat() &&
-                      m_commonIntf->GetOptions()->forceLegacyPresent)) {
-          Logger::debug("DDraw7Interface::CreateSurface: Creating shadow surface");
-
+        if (unlikely(m_commonIntf->GetOptions()->forceLegacyPresent &&
+                    !surface7->GetCommonSurface()->SkipD3D9Operations())) {
           DDSURFACEDESC2 shadowDesc = *lpDDSurfaceDesc;
           const DDSURFACEDESC2* primaryDesc = surface7->GetCommonSurface()->GetDesc2();
 
@@ -324,7 +329,35 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::EnumDisplayModes(DWORD dwFlags, LPDDSURFACEDESC2 lpDDSurfaceDesc, LPVOID lpContext, LPDDENUMMODESCALLBACK2 lpEnumModesCallback) {
-    return m_proxy->EnumDisplayModes(dwFlags, lpDDSurfaceDesc, lpContext, lpEnumModesCallback);
+    if (unlikely(lpEnumModesCallback == nullptr))
+      return DDERR_INVALIDPARAMS;
+
+    std::vector<DDSURFACEDESC2> displayModes;
+    HRESULT hr = m_proxy->EnumDisplayModes(dwFlags, lpDDSurfaceDesc, reinterpret_cast<void*>(&displayModes), EnumDisplayModesCallback2);
+    if (unlikely(FAILED(hr)))
+      return hr;
+
+    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
+
+    hr = DDENUMRET_OK;
+
+    auto displayModeIt = displayModes.begin();
+    while (displayModeIt != displayModes.end() && hr == DDENUMRET_OK) {
+      DDSURFACEDESC2 dmDesc = *displayModeIt;
+
+      if (unlikely(d3dOptions->mask8BitModes && dmDesc.ddpfPixelFormat.dwRGBBitCount == 8)) {
+        static bool s_maskModeWarningShown;
+
+        if (!std::exchange(s_maskModeWarningShown, true))
+          Logger::warn("DDraw7Interface::EnumDisplayModes: Masking 8-bit display modes");
+      } else {
+        hr = lpEnumModesCallback(&dmDesc, lpContext);
+      }
+
+      ++displayModeIt;
+    }
+
+    return DD_OK;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Interface::EnumSurfaces(DWORD dwFlags, LPDDSURFACEDESC2 lpDDSD, LPVOID lpContext, LPDDENUMSURFACESCALLBACK7 lpEnumSurfacesCallback) {
@@ -460,8 +493,17 @@ namespace dxvk {
 
     const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
 
-    if (unlikely(d3dOptions->mask8BitModes && lpDDSurfaceDesc->ddpfPixelFormat.dwRGBBitCount == 8))
+    if (unlikely(d3dOptions->mask8BitModes
+              && lpDDSurfaceDesc->dwFlags & DDSD_PIXELFORMAT
+              && lpDDSurfaceDesc->ddpfPixelFormat.dwRGBBitCount == 8)) {
+      // Report a fake D3DFMT_R5G6B5 back buffer scenario
+      lpDDSurfaceDesc->ddpfPixelFormat.dwFlags = DDPF_RGB;
       lpDDSurfaceDesc->ddpfPixelFormat.dwRGBBitCount = 16;
+      lpDDSurfaceDesc->ddpfPixelFormat.dwRGBAlphaBitMask = 0x0000;
+      lpDDSurfaceDesc->ddpfPixelFormat.dwRBitMask = 0xf800;
+      lpDDSurfaceDesc->ddpfPixelFormat.dwGBitMask = 0x07e0;
+      lpDDSurfaceDesc->ddpfPixelFormat.dwBBitMask = 0x001f;
+    }
 
     return DD_OK;
   }
@@ -566,7 +608,7 @@ namespace dxvk {
     DDrawCommonSurface* ps = m_commonIntf->GetPrimarySurface();
 
     if (likely(ps != nullptr)) {
-      hr = ps->RefreshSurfaceDescripton();
+      hr = ps->RefreshSurfaceDescripton(true);
       if (unlikely(FAILED(hr)))
         Logger::warn("DDraw7Interface::SetDisplayMode: Failed to update primary surface desc");
     }

--- a/src/ddraw/ddraw7/ddraw7_interface.h
+++ b/src/ddraw/ddraw7/ddraw7_interface.h
@@ -92,9 +92,6 @@ namespace dxvk {
 
     Com<D3D7Interface, false> m_d3d7Intf;
 
-    uint32_t                  m_intfCount = 0;
-    static std::atomic<uint32_t> s_intfCount;
-
   };
 
 }

--- a/src/ddraw/ddraw7/ddraw7_surface.cpp
+++ b/src/ddraw/ddraw7/ddraw7_surface.cpp
@@ -10,8 +10,6 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> DDraw7Surface::s_surfCount = 0;
-
   DDraw7Surface::DDraw7Surface(
         DDrawCommonSurface* commonSurf,
         Com<IDirectDrawSurface7>&& surfProxy,
@@ -56,7 +54,7 @@ namespace dxvk {
       if (likely(m_nextFlippable != nullptr)) {
         // The call to EnumAttachedSurfaces has incremented the public ref
         m_nextFlippable->Release();
-        Logger::debug("DDraw7Surface: Retrieved the next swapchain surface");
+        //Logger::debug("DDraw7Surface: Retrieved the next swapchain surface");
       }
     }
 
@@ -76,14 +74,12 @@ namespace dxvk {
     // Cube map face surfaces
     m_cubeMapSurfaces.fill(nullptr);
 
-    m_surfCount = ++s_surfCount;
-
-    Logger::debug(str::format("DDraw7Surface: Created a new surface nr. [[7-", m_surfCount, "]]"));
+    //Logger::debug(str::format("DDraw7Surface: Created a new surface nr. [[7-", std::hex, this, "]]"));
 
     if (m_commonSurf->GetOrigin() == nullptr) {
       m_commonSurf->SetOrigin(this);
       m_commonSurf->SetIsAttached(m_parentSurf != nullptr);
-      m_commonSurf->ListSurfaceDetails();
+      //m_commonSurf->ListSurfaceDetails();
     }
   }
 
@@ -116,7 +112,7 @@ namespace dxvk {
 
     m_commonSurf->SetDD7Surface(nullptr);
 
-    Logger::debug(str::format("DDraw7Surface: Surface nr. [[7-", m_surfCount, "]] bites the dust"));
+    //Logger::debug(str::format("DDraw7Surface: Surface nr. [[7-", std::hex, this, "]] bites the dust"));
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::QueryInterface(REFIID riid, void** ppvObject) {
@@ -283,7 +279,7 @@ namespace dxvk {
       DownloadSurfaceData();
     }
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
     if (likely(d3d9Device != nullptr)) {
       const bool exclusiveMode = m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE;
 
@@ -339,7 +335,7 @@ namespace dxvk {
       return DDERR_UNSUPPORTED;
     }
 
-    RECT* sourceFullSurfaceRect = nullptr;
+    const RECT* sourceFullSurfaceRect = nullptr;
     // Write back any dirty surface data from bound D3D9 back buffers or
     // depth stencils, for both the source surface and the current surface
     if (likely(lpDDSrcSurface != nullptr)) {
@@ -355,7 +351,7 @@ namespace dxvk {
       DownloadSurfaceData();
     }
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
     if (likely(d3d9Device != nullptr)) {
       const bool exclusiveMode = m_commonIntf->GetCooperativeLevel() & DDSCL_EXCLUSIVE;
 
@@ -489,7 +485,7 @@ namespace dxvk {
 
     Com<DDraw7Surface> overrideSurf = static_cast<DDraw7Surface*>(lpDDSurfaceTargetOverride);
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
     // Overlays can have odd video formats which DXVK doesn't support for RT
     // use, so let DDraw present in case the flipped surface is an overlay
     if (likely(d3d9Device != nullptr && !m_commonSurf->IsOverlay())) {
@@ -583,28 +579,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DDraw7Surface::GetAttachedSurface(LPDDSCAPS2 lpDDSCaps, LPDIRECTDRAWSURFACE7 *lplpDDAttachedSurface) {
     if (unlikely(lpDDSCaps == nullptr || lplpDDAttachedSurface == nullptr))
       return DDERR_INVALIDPARAMS;
-
-    if (lpDDSCaps->dwCaps & DDSCAPS_PRIMARYSURFACE)
-      Logger::debug("DDraw7Surface::GetAttachedSurface: Querying for the primary surface");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_FRONTBUFFER)
-      Logger::debug("DDraw7Surface::GetAttachedSurface: Querying for the front buffer");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_BACKBUFFER)
-      Logger::debug("DDraw7Surface::GetAttachedSurface: Querying for the back buffer");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_FLIP)
-      Logger::debug("DDraw7Surface::GetAttachedSurface: Querying for a flippable surface");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_OFFSCREENPLAIN)
-      Logger::debug("DDraw7Surface::GetAttachedSurface: Querying for an offscreen plain surface");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_ZBUFFER)
-      Logger::debug("DDraw7Surface::GetAttachedSurface: Querying for a depth stencil");
-    else if ((lpDDSCaps->dwCaps  & DDSCAPS_MIPMAP)
-          || (lpDDSCaps->dwCaps2 & DDSCAPS2_MIPMAPSUBLEVEL))
-      Logger::debug("DDraw7Surface::GetAttachedSurface: Querying for a texture mip map");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_TEXTURE)
-      Logger::debug("DDraw7Surface::GetAttachedSurface: Querying for a texture");
-    else if (lpDDSCaps->dwCaps2 & DDSCAPS2_CUBEMAP)
-      Logger::debug("DDraw7Surface::GetAttachedSurface: Querying for a cube map");
-    else if (lpDDSCaps->dwCaps & DDSCAPS_OVERLAY)
-      Logger::debug("DDraw7Surface::GetAttachedSurface: Querying for an overlay");
 
     Com<IDirectDrawSurface7> surface;
     HRESULT hr = m_proxy->GetAttachedSurface(lpDDSCaps, &surface);
@@ -758,7 +732,21 @@ namespace dxvk {
     // Write back any dirty surface data from bound D3D9 back buffers or depth stencils
     DownloadSurfaceData();
 
-    return GetShadowOrProxied()->Lock(lpDestRect, lpDDSurfaceDesc, dwFlags, hEvent);
+    HRESULT hr = GetShadowOrProxied()->Lock(lpDestRect, lpDDSurfaceDesc, dwFlags, hEvent);
+    if (unlikely(FAILED(hr)))
+      return hr;
+
+    // For single surface locks, track the READONLY flag in order to skip dirtying
+    // on Unlock(). Reset the tracking in case of multiple simultaneous locks.
+    if (likely(!m_lockCount)) {
+      m_readOnlyLock = (dwFlags & DDLOCK_READONLY) && !(dwFlags & DDLOCK_WRITEONLY);
+    } else {
+      m_readOnlyLock = false;
+    }
+
+    m_lockCount++;
+
+    return DD_OK;
   }
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::ReleaseDC(HDC hDC) {
@@ -779,7 +767,7 @@ namespace dxvk {
 
     m_commonSurf->DirtyDDrawSurface();
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
     if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
       const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                 !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
@@ -844,7 +832,7 @@ namespace dxvk {
     if (unlikely(FAILED(hr)))
       return hr;
 
-    hr = m_commonSurf->RefreshSurfaceDescripton();
+    hr = m_commonSurf->RefreshSurfaceDescripton(false);
     if (unlikely(FAILED(hr)))
       Logger::err("DDraw7Surface::SetColorKey: Failed to retrieve updated surface desc");
 
@@ -853,7 +841,7 @@ namespace dxvk {
       if (unlikely(FAILED(hr))) {
         Logger::warn("DDraw7Surface::SetColorKey: Failed to set shadow surface color key");
       } else {
-        hr = m_shadowSurf->GetCommonSurface()->RefreshSurfaceDescripton();
+        hr = m_shadowSurf->GetCommonSurface()->RefreshSurfaceDescripton(false);
         if (unlikely(FAILED(hr)))
           Logger::warn("DDraw7Surface::SetColorKey: Failed to retrieve updated shadow surface desc");
       }
@@ -892,9 +880,16 @@ namespace dxvk {
     if (unlikely(FAILED(hr)))
       return hr;
 
-    m_commonSurf->DirtyDDrawSurface();
+    if (!m_readOnlyLock) {
+      m_commonSurf->DirtyDDrawSurface();
+    } else {
+      m_readOnlyLock = false;
+    }
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    if (likely(m_lockCount))
+      m_lockCount--;
+
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
     if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
       const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                 !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
@@ -973,14 +968,14 @@ namespace dxvk {
     if (unlikely(FAILED(hr)))
       return hr;
 
-    hr = m_commonSurf->RefreshSurfaceDescripton();
+    hr = m_commonSurf->RefreshSurfaceDescripton(true);
     if (unlikely(FAILED(hr))) {
       Logger::err("DDraw4Surface::SetSurfaceDesc: Failed to retrieve updated surface desc");
       return hr;
     }
 
     // We may need to recreate the d3d9 object based on the new desc
-    m_commonSurf->SetD3D9Surface(nullptr);
+    m_commonSurf->ResetD3D9Objects();
 
     return DD_OK;
   }
@@ -1016,6 +1011,7 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::SetPriority(DWORD prio) {
     m_commonSurf->RefreshD3D9Device();
+
     if (unlikely(!m_commonSurf->IsInitialized()))
       return m_proxy->SetPriority(prio);
 
@@ -1033,6 +1029,7 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::GetPriority(LPDWORD prio) {
     m_commonSurf->RefreshD3D9Device();
+
     if (unlikely(!m_commonSurf->IsInitialized()))
       return m_proxy->GetPriority(prio);
 
@@ -1049,6 +1046,7 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::SetLOD(DWORD lod) {
     m_commonSurf->RefreshD3D9Device();
+
     if (unlikely(!m_commonSurf->IsInitialized()))
       return m_proxy->SetLOD(lod);
 
@@ -1073,6 +1071,7 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE DDraw7Surface::GetLOD(LPDWORD lod) {
     m_commonSurf->RefreshD3D9Device();
+
     if (unlikely(!m_commonSurf->IsInitialized()))
       return m_proxy->GetLOD(lod);
 
@@ -1094,32 +1093,22 @@ namespace dxvk {
     return DD_OK;
   }
 
-  IDirectDrawSurface7* DDraw7Surface::GetShadowOrProxied() {
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
-
-    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr))
-      return m_shadowSurf->GetProxied();
-
-    return m_proxy.ptr();
-  }
-
   HRESULT DDraw7Surface::InitializeD3D9RenderTarget() {
+    // Currently ignores all P8 surfaces
+    if (unlikely(m_commonSurf->SkipD3D9Operations()))
+      return DD_OK;
+
     m_commonSurf->RefreshD3D9Device();
 
-    m_commonSurf->MarkAsD3D9BackBuffer();
-
     if (unlikely(!m_commonSurf->IsInitialized())) {
-      if (m_commonSurf->IsTextureOrCubeMap())
-        UpdateMipMapCount();
-
       HRESULT hr = m_commonSurf->InitializeD3D9(true);
-      if (unlikely(FAILED(hr)))
+      if (unlikely(FAILED(hr))) {
+        Logger::err(str::format("DDraw7Surface::InitializeD3D9RenderTarget: Failed to initialize surface nr. [[7-", std::hex, this, "]]"));
         return hr;
+      }
 
-      if (unlikely(m_commonSurf->IsCubeMap()))
+      if (unlikely(m_commonSurf->GetD3D9SurfaceType() == D3D9SurfaceType::CubeTexture))
         InitializeAllCubeMapSurfaces();
-
-      Logger::debug(str::format("DDraw7Surface::InitializeD3D9RenderTarget: Initialized surface nr. [[7-", m_surfCount, "]]"));
 
       return UploadSurfaceData();
     }
@@ -1130,14 +1119,12 @@ namespace dxvk {
   HRESULT DDraw7Surface::InitializeD3D9DepthStencil() {
     m_commonSurf->RefreshD3D9Device();
 
-    m_commonSurf->MarkAsD3D9DepthStencil();
-
     if (unlikely(!m_commonSurf->IsInitialized())) {
       HRESULT hr = m_commonSurf->InitializeD3D9(false);
-      if (unlikely(FAILED(hr)))
+      if (unlikely(FAILED(hr))) {
+        Logger::err(str::format("DDraw7Surface::InitializeD3D9DepthStencil: Failed to initialize surface nr. [[7-", std::hex, this, "]]"));
         return hr;
-
-      Logger::debug(str::format("DDraw7Surface::InitializeD3D9DepthStencil: Initialized surface nr. [[7-", m_surfCount, "]]"));
+      }
 
       return UploadSurfaceData();
     }
@@ -1146,32 +1133,30 @@ namespace dxvk {
   }
 
   HRESULT DDraw7Surface::InitializeOrUploadD3D9() {
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->RefreshD3D9Device();
+    // Currently ignores all P8 surfaces
+    if (unlikely(m_commonSurf->SkipD3D9Operations()))
+      return DD_OK;
+
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
 
     // Fast skip
     if (unlikely(d3d9Device == nullptr))
       return DD_OK;
 
     if (unlikely(!m_commonSurf->IsInitialized())) {
-      if (m_commonSurf->IsTextureOrCubeMap())
-        UpdateMipMapCount();
-
       const bool initRenderTarget = m_commonSurf->GetCommonD3DDevice()->IsCurrentRenderTarget(m_commonSurf.ptr());
 
       HRESULT hr = m_commonSurf->InitializeD3D9(initRenderTarget);
-      if (unlikely(FAILED(hr)))
+      if (unlikely(FAILED(hr))) {
+        Logger::err(str::format("DDraw7Surface::InitializeOrUploadD3D9: Failed to initialize surface nr. [[7-", std::hex, this, "]]"));
         return hr;
+      }
 
-      if (unlikely(m_commonSurf->IsCubeMap()))
+      if (unlikely(m_commonSurf->GetD3D9SurfaceType() == D3D9SurfaceType::CubeTexture))
         InitializeAllCubeMapSurfaces();
-
-      Logger::debug(str::format("DDraw7Surface::InitializeOrUploadD3D9: Initialized surface nr. [[7-", m_surfCount, "]]"));
     }
 
-    if (likely(m_commonSurf->IsInitialized()))
-      return UploadSurfaceData();
-
-    return DD_OK;
+    return UploadSurfaceData();
   }
 
   void DDraw7Surface::DownloadSurfaceData() {
@@ -1183,63 +1168,13 @@ namespace dxvk {
     if (likely(!m_commonIntf->GetOptions()->deviceResourceSharing))
       m_commonSurf->RefreshD3D9Device();
 
-    if (unlikely(m_commonSurf->IsD3D9BackBuffer())) {
-      if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
-        //Logger::debug(str::format("DDraw7Surface::DownloadSurfaceData: Downloading nr. [[7-", m_surfCount, "]]"));
-        BlitToDDrawSurface<IDirectDrawSurface7, DDSURFACEDESC2>(GetShadowOrProxied(), m_commonSurf->GetD3D9Surface(),
-                                                                m_commonSurf->IsDXTFormat());
-        m_commonSurf->UnDirtyD3D9Surface();
-      }
-    } else if (unlikely(m_commonSurf->IsD3D9DepthStencil())) {
-      if (m_commonSurf->IsInitialized() && m_commonSurf->IsD3D9SurfaceDirty()) {
-        //Logger::debug(str::format("DDraw7Surface::DownloadSurfaceData: Downloading nr. [[7-", m_surfCount, "]]"));
-        BlitToDDrawSurface<IDirectDrawSurface7, DDSURFACEDESC2>(m_proxy.ptr(), m_commonSurf->GetD3D9Surface(),
-                                                                m_commonSurf->IsDXTFormat());
-        m_commonSurf->UnDirtyD3D9Surface();
-      }
+    // TODO: We are technically ignoring mip maps as is, though that will probably never be an issue
+    if (m_commonSurf->IsD3D9SurfaceDirty() && m_commonSurf->IsInitialized()) {
+      //Logger::debug(str::format("DDraw7Surface::DownloadSurfaceData: Downloading nr. [[7-", std::hex, this, "]]"));
+      BlitToDDrawSurface<IDirectDrawSurface7, DDSURFACEDESC2>(GetShadowOrProxied(), m_commonSurf->GetD3D9Surface(),
+                                                              m_commonSurf->IsDXTFormat());
+      m_commonSurf->UnDirtyD3D9Surface();
     }
-  }
-
-  inline void DDraw7Surface::UpdateMipMapCount() {
-    // We need to count the number of actual mips on initialization by going through
-    // the mip chain, since the dwMipMapCount number may or may not be accurate. I am
-    // guessing it was intended more as a hint, not neceesarily a set number.
-    const DDSURFACEDESC2* desc2  = m_commonSurf->GetDesc2();
-
-    IDirectDrawSurface7* mipMap = m_proxy.ptr();
-    DDSURFACEDESC2 mipDesc2;
-    uint16_t mipCount = 1;
-
-    while (mipMap != nullptr) {
-      IDirectDrawSurface7* parentSurface = mipMap;
-      mipMap = nullptr;
-      parentSurface->EnumAttachedSurfaces(&mipMap, ListMipChainSurfaces7Callback);
-      if (mipMap != nullptr) {
-        mipCount++;
-
-        mipDesc2 = { };
-        mipDesc2.dwSize = sizeof(DDSURFACEDESC2);
-        mipMap->GetSurfaceDesc(&mipDesc2);
-        // Ignore multiple 1x1 mips, which apparently can get generated if the
-        // application gets the dwMipMapCount wrong vs surface dimensions.
-        if (unlikely(mipDesc2.dwWidth == 1 && mipDesc2.dwHeight == 1))
-          break;
-      }
-    }
-
-    // Do not worry about maximum supported mip map levels validation,
-    // because D3D9 will handle this for us and cap them appropriately
-    if (mipCount > 1) {
-      Logger::debug(str::format("DDraw7Surface::UpdateMipMapCount: Found ", mipCount, " mip levels"));
-
-      if (unlikely(mipCount != desc2->dwMipMapCount))
-        Logger::debug(str::format("DDraw7Surface::UpdateMipMapCount: Mismatch with declared ", desc2->dwMipMapCount, " mip levels"));
-    }
-
-    if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps))
-      mipCount = 0;
-
-    m_commonSurf->SetMipCount(mipCount);
   }
 
   inline void DDraw7Surface::InitializeAndAttachCubeFace(
@@ -1261,8 +1196,8 @@ namespace dxvk {
       cubeTex9->GetCubeMapSurface(face, 0, &face9);
       face7->GetCommonSurface()->SetD3D9Surface(std::move(face9));
       m_attachedSurfaces.emplace(std::piecewise_construct,
-                                std::forward_as_tuple(face7->GetProxied()),
-                                std::forward_as_tuple(face7.ref()));
+                                 std::forward_as_tuple(face7->GetProxied()),
+                                 std::forward_as_tuple(face7.ref()));
     }
   }
 
@@ -1310,40 +1245,44 @@ namespace dxvk {
     if (!m_commonSurf->IsDDrawSurfaceDirty())
       return DD_OK;
 
-    //Logger::debug(str::format("DDraw7Surface::UploadSurfaceData: Uploading nr. [[7-", m_surfCount, "]]"));
+    //Logger::debug(str::format("DDraw7Surface::UploadSurfaceData: Uploading nr. [[7-", std::hex, this, "]]"));
 
-    // Cube maps will also get marked as textures, so need to be handled first
-    if (unlikely(m_commonSurf->IsCubeMap())) {
-      // In theory we won't know which faces have been generated,
-      // so check them one by one, and upload as needed
-      const uint16_t mipCount    = m_commonSurf->GetMipCount();
-      const bool     isDXTFormat = m_commonSurf->IsDXTFormat();
-      if (likely(m_cubeMapSurfaces[0] != nullptr)) {
-        BlitToD3D9CubeMap(m_commonSurf->GetD3D9CubeTexture(), m_cubeMapSurfaces[0], mipCount, isDXTFormat);
+    D3D9SurfaceType d3d9SurfaceType = m_commonSurf->GetD3D9SurfaceType();
+
+    switch (d3d9SurfaceType) {
+      case D3D9SurfaceType::CubeTexture: {
+        // In theory we won't know which faces have been generated,
+        // so check them one by one, and upload as needed
+        const uint16_t mipCount    = m_commonSurf->GetMipCount();
+        const bool     isDXTFormat = m_commonSurf->IsDXTFormat();
+        if (likely(m_cubeMapSurfaces[0] != nullptr)) {
+          BlitToD3D9CubeMap(m_commonSurf->GetD3D9CubeTexture(), m_cubeMapSurfaces[0], mipCount, isDXTFormat);
+        }
+        if (likely(m_cubeMapSurfaces[1] != nullptr)) {
+          BlitToD3D9CubeMap(m_commonSurf->GetD3D9CubeTexture(), m_cubeMapSurfaces[1], mipCount, isDXTFormat);
+        }
+        if (likely(m_cubeMapSurfaces[2] != nullptr)) {
+          BlitToD3D9CubeMap(m_commonSurf->GetD3D9CubeTexture(), m_cubeMapSurfaces[2], mipCount, isDXTFormat);
+        }
+        if (likely(m_cubeMapSurfaces[3] != nullptr)) {
+          BlitToD3D9CubeMap(m_commonSurf->GetD3D9CubeTexture(), m_cubeMapSurfaces[3], mipCount, isDXTFormat);
+        }
+        if (likely(m_cubeMapSurfaces[4] != nullptr)) {
+          BlitToD3D9CubeMap(m_commonSurf->GetD3D9CubeTexture(), m_cubeMapSurfaces[4], mipCount, isDXTFormat);
+        }
+        if (likely(m_cubeMapSurfaces[5] != nullptr)) {
+          BlitToD3D9CubeMap(m_commonSurf->GetD3D9CubeTexture(), m_cubeMapSurfaces[5], mipCount, isDXTFormat);
+        }
+        break;
       }
-      if (likely(m_cubeMapSurfaces[1] != nullptr)) {
-        BlitToD3D9CubeMap(m_commonSurf->GetD3D9CubeTexture(), m_cubeMapSurfaces[1], mipCount, isDXTFormat);
-      }
-      if (likely(m_cubeMapSurfaces[2] != nullptr)) {
-        BlitToD3D9CubeMap(m_commonSurf->GetD3D9CubeTexture(), m_cubeMapSurfaces[2], mipCount, isDXTFormat);
-      }
-      if (likely(m_cubeMapSurfaces[3] != nullptr)) {
-        BlitToD3D9CubeMap(m_commonSurf->GetD3D9CubeTexture(), m_cubeMapSurfaces[3], mipCount, isDXTFormat);
-      }
-      if (likely(m_cubeMapSurfaces[4] != nullptr)) {
-        BlitToD3D9CubeMap(m_commonSurf->GetD3D9CubeTexture(), m_cubeMapSurfaces[4], mipCount, isDXTFormat);
-      }
-      if (likely(m_cubeMapSurfaces[5] != nullptr)) {
-        BlitToD3D9CubeMap(m_commonSurf->GetD3D9CubeTexture(), m_cubeMapSurfaces[5], mipCount, isDXTFormat);
-      }
-    // Blit all the mips for textures
-    } else if (m_commonSurf->IsTexture()) {
-      BlitToD3D9Texture<IDirectDrawSurface7, DDSURFACEDESC2>(m_commonSurf->GetD3D9Texture(), m_proxy.ptr(),
-                                                             m_commonSurf->GetMipCount(), m_commonSurf->IsDXTFormat());
-    // Blit surfaces directly
-    } else {
-      BlitToD3D9Surface<IDirectDrawSurface7, DDSURFACEDESC2>(m_commonSurf->GetD3D9Surface(), GetShadowOrProxied(),
-                                                             m_commonSurf->IsDXTFormat());
+      case D3D9SurfaceType::Texture:
+        BlitToD3D9Texture<IDirectDrawSurface7, DDSURFACEDESC2>(m_commonSurf->GetD3D9Texture(), m_proxy.ptr(),
+                                                               m_commonSurf->GetMipCount(), m_commonSurf->IsDXTFormat());
+        break;
+      default:
+        BlitToD3D9Surface<IDirectDrawSurface7, DDSURFACEDESC2>(m_commonSurf->GetD3D9Surface(), GetShadowOrProxied(),
+                                                               m_commonSurf->IsDXTFormat());
+        break;
     }
 
     m_commonSurf->UnDirtyDDrawSurface();

--- a/src/ddraw/ddraw7/ddraw7_surface.h
+++ b/src/ddraw/ddraw7/ddraw7_surface.h
@@ -126,8 +126,6 @@ namespace dxvk {
 
     HRESULT STDMETHODCALLTYPE GetLOD(LPDWORD lod);
 
-    IDirectDrawSurface7* GetShadowOrProxied();
-
     HRESULT InitializeD3D9RenderTarget();
 
     HRESULT InitializeD3D9DepthStencil();
@@ -142,6 +140,15 @@ namespace dxvk {
 
     DDraw7Surface* GetShadowSurface() const {
       return m_shadowSurf.ptr();
+    }
+
+    IDirectDrawSurface7* GetShadowOrProxied() {
+      d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
+
+      if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr))
+        return m_shadowSurf->GetProxied();
+
+      return m_proxy.ptr();
     }
 
     DDrawCommonSurface* GetCommonSurface() const {
@@ -192,8 +199,6 @@ namespace dxvk {
 
   private:
 
-    inline void UpdateMipMapCount();
-
     inline void InitializeAndAttachCubeFace(
         IDirectDrawSurface7* surf,
         d3d9::IDirect3DCubeTexture9* cubeTex9,
@@ -204,6 +209,9 @@ namespace dxvk {
     inline HRESULT UploadSurfaceData();
 
     bool                                m_isChildObject   = false;
+
+    bool                                m_readOnlyLock    = false;
+    std::atomic<uint8_t>                m_lockCount       = 0u;
 
     Com<DDrawCommonSurface>             m_commonSurf;
     DDrawCommonInterface*               m_commonIntf      = nullptr;
@@ -227,9 +235,6 @@ namespace dxvk {
     // They are implemented with linked list, so for example only one mip level
     // will be held in a parent texture, and the next mip level will be held in the previous mip.
     std::unordered_map<IDirectDrawSurface7*, Com<DDraw7Surface, false>> m_attachedSurfaces;
-
-    uint32_t                            m_surfCount       = 0;
-    static std::atomic<uint32_t>        s_surfCount;
 
   };
 

--- a/src/ddraw/ddraw_caps.h
+++ b/src/ddraw/ddraw_caps.h
@@ -19,6 +19,7 @@ namespace dxvk::ddrawCaps {
   // Actual index buffer sizes are 2x, so 0.25 kb, 0.5 kb, 1kb, 2 kb, 4kb, 8 kb, 16kb, 32 kb, 64 kb and 128 kb
   // Note: The DXVK backend gives us 256 byte chunks anyway as a minimum, so there's no point going below that
   static constexpr UINT     IndexCount[IndexBufferCount] = {128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, D3DMAXNUMVERTICES};
+  static constexpr UINT     MaxIndexCount           = IndexCount[IndexBufferCount - 1];
 
   static constexpr uint8_t  NumberOfFOURCCCodes     = 6;
   static constexpr DWORD    SupportedFourCCs[]      =

--- a/src/ddraw/ddraw_class_factory.cpp
+++ b/src/ddraw/ddraw_class_factory.cpp
@@ -6,6 +6,9 @@ namespace dxvk {
     : m_createInstance ( createInstance ) {
   }
 
+  DDrawClassFactory::~DDrawClassFactory() {
+  }
+
   HRESULT STDMETHODCALLTYPE DDrawClassFactory::QueryInterface(REFIID riid, void** ppvObject) {
     if (unlikely(ppvObject == nullptr))
       return E_POINTER;

--- a/src/ddraw/ddraw_class_factory.h
+++ b/src/ddraw/ddraw_class_factory.h
@@ -12,6 +12,8 @@ namespace dxvk {
 
     DDrawClassFactory(FunctionType createInstance);
 
+    ~DDrawClassFactory();
+
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject);
 
     HRESULT STDMETHODCALLTYPE CreateInstance(IUnknown *pUnkOuter, REFIID riid, void **ppvObject);

--- a/src/ddraw/ddraw_clipper.cpp
+++ b/src/ddraw/ddraw_clipper.cpp
@@ -8,11 +8,9 @@ namespace dxvk {
         IUnknown* pParent)
     : DDrawWrappedObject<IUnknown, IDirectDrawClipper>(pParent, std::move(clipperProxy))
     , m_commonIntf ( commonIntf ) {
-    Logger::debug("DDrawClipper: Created a new clipper");
   }
 
   DDrawClipper::~DDrawClipper() {
-    Logger::debug("DDrawClipper: A clipper bites the dust");
   }
 
   HRESULT STDMETHODCALLTYPE DDrawClipper::Initialize(LPDIRECTDRAW lpDD, DWORD dwFlags) {

--- a/src/ddraw/ddraw_common_surface.cpp
+++ b/src/ddraw/ddraw_common_surface.cpp
@@ -82,129 +82,101 @@ namespace dxvk {
     return nullptr;
   }
 
-  HRESULT DDrawCommonSurface::RefreshSurfaceDescripton() {
-    HRESULT hr;
-
-    DDSURFACEDESC2 desc2;
-    desc2.dwSize = sizeof(DDSURFACEDESC2);
-
+  HRESULT DDrawCommonSurface::RefreshSurfaceDescripton(const bool refreshFormat) {
     if (m_surf7 != nullptr) {
-      hr = m_surf7->GetProxied()->GetSurfaceDesc(&desc2);
+      DDSURFACEDESC2 desc2;
+      desc2.dwSize = sizeof(DDSURFACEDESC2);
+      HRESULT hr = m_surf7->GetProxied()->GetSurfaceDesc(&desc2);
       if (unlikely(FAILED(hr)))
         return hr;
       m_desc2 = desc2;
-      RefreshStaticDescData();
+      RefreshStaticDescData(refreshFormat);
     } else if (m_surf4 != nullptr) {
-      hr = m_surf4->GetProxied()->GetSurfaceDesc(&desc2);
+      DDSURFACEDESC2 desc2;
+      desc2.dwSize = sizeof(DDSURFACEDESC2);
+      HRESULT hr = m_surf4->GetProxied()->GetSurfaceDesc(&desc2);
       if (unlikely(FAILED(hr)))
         return hr;
       m_desc2 = desc2;
-      RefreshStaticDescData();
+      RefreshStaticDescData(refreshFormat);
     }
 
-    DDSURFACEDESC desc;
-    desc.dwSize = sizeof(DDSURFACEDESC);
-
+    // IDirectDrawSurface2/3 surfaces will always keep their IDirectDrawSurface parent surface around
     if (m_surf != nullptr) {
-      hr = m_surf->GetProxied()->GetSurfaceDesc(&desc);
+      DDSURFACEDESC desc;
+      desc.dwSize = sizeof(DDSURFACEDESC);
+      HRESULT hr = m_surf->GetProxied()->GetSurfaceDesc(&desc);
       if (unlikely(FAILED(hr)))
         return hr;
       m_desc = desc;
-      RefreshStaticDescData();
-    } else if (m_surf2 != nullptr) {
-      hr = m_surf2->GetProxied()->GetSurfaceDesc(&desc);
-      if (unlikely(FAILED(hr)))
-        return hr;
-      m_desc = desc;
-      RefreshStaticDescData();
-    } else if (m_surf3 != nullptr) {
-      hr = m_surf3->GetProxied()->GetSurfaceDesc(&desc);
-      if (unlikely(FAILED(hr)))
-        return hr;
-      m_desc = desc;
-      RefreshStaticDescData();
+      RefreshStaticDescData(refreshFormat);
     }
 
     return DD_OK;
   }
 
-  d3d9::IDirect3DDevice9* DDrawCommonSurface::RefreshD3D9Device() {
+  void DDrawCommonSurface::RefreshD3D9Device() {
     D3DCommonDevice* commonD3DDevice = m_commonIntf->GetCommonD3DDevice();
 
     if (unlikely(m_commonD3DDevice != commonD3DDevice)) {
       // Check if the device has been recreated and reset all D3D9 resources
       if (m_commonD3DDevice != nullptr) {
         Logger::debug("DDrawCommonSurface: Device has changed, clearing all D3D9 resources");
-        m_cubeMap9 = nullptr;
-        m_texture9 = nullptr;
-        m_surface9 = nullptr;
-        // Also reset all D3D9 related tracking flags
-        m_isD3D9BackBuffer = false;
-        m_isD3D9DepthStencil = false;
-        m_dirtyD3D9 = false;
+        ResetD3D9Objects();
       }
 
       m_commonD3DDevice = commonD3DDevice;
     }
+  }
 
-    return m_commonD3DDevice != nullptr ? m_commonD3DDevice->GetD3D9Device() : nullptr;
+  d3d9::IDirect3DDevice9* DDrawCommonSurface::GetRefreshedD3D9Device() {
+    RefreshD3D9Device();
+
+    if (likely(m_commonD3DDevice != nullptr))
+      return m_commonD3DDevice->GetD3D9Device();
+
+    return nullptr;
   }
 
   HRESULT DDrawCommonSurface::InitializeD3D9(const bool initRenderTarget) {
-    const DWORD dwWidth  = (m_desc2.dwFlags & DDSD_WIDTH)  ? m_desc2.dwWidth  : m_desc.dwWidth;
-    const DWORD dwHeight = (m_desc2.dwFlags & DDSD_HEIGHT) ? m_desc2.dwHeight : m_desc.dwHeight;
-    const DWORD dwCaps   = (m_desc2.dwFlags & DDSD_CAPS)   ? m_desc2.ddsCaps.dwCaps  : m_desc.ddsCaps.dwCaps;
-    const DWORD dwCaps2  = (m_desc2.dwFlags & DDSD_CAPS)   ? m_desc2.ddsCaps.dwCaps2 : 0;
-
-    if (unlikely(dwHeight == 0 || dwWidth == 0)) {
-      Logger::err("DDrawCommonSurface::InitializeD3D9: Surface has 0 height or width");
-      return DDERR_UNSUPPORTED;
-    }
-
     if (unlikely(m_format9 == d3d9::D3DFMT_UNKNOWN)) {
       Logger::err("DDrawCommonSurface::InitializeD3D9: Surface has an unknown format");
       return DDERR_UNSUPPORTED;
     }
 
-    // Don't initialize P8 textures/surfaces since we don't support them.
-    // Some applications do require them to be created by ddraw, otherwise
-    // they will simply fail to start, so just ignore them for now.
-    if (unlikely(m_format9 == d3d9::D3DFMT_P8)) {
-      static bool s_formatP8ErrorShown;
+    const DWORD dwWidth  = static_cast<DWORD>(m_rect.right);
+    const DWORD dwHeight = static_cast<DWORD>(m_rect.bottom);
 
-      if (!std::exchange(s_formatP8ErrorShown, true))
-        Logger::warn("DDrawCommonSurface::InitializeD3D9: Unsupported format D3DFMT_P8");
-
-      return DD_OK;
-    // Similarly, D3DFMT_R3G3B2 isn't supported by D3D9 dxvk, however some
-    // applications require it to be supported by ddraw, even if they do not
-    // use it. Simply ignore any D3DFMT_R3G3B2 textures/surfaces for now.
-    } else if (unlikely(m_format9 == d3d9::D3DFMT_R3G3B2)) {
-      static bool s_formatR3G3B2ErrorShown;
-
-      if (!std::exchange(s_formatR3G3B2ErrorShown, true))
-        Logger::warn("DDrawCommonSurface::InitializeD3D9: Unsupported format D3DFMT_R3G3B2");
-
-      return DD_OK;
+    if (unlikely(dwWidth == 0 || dwHeight == 0)) {
+      Logger::err("DDrawCommonSurface::InitializeD3D9: Surface has 0 height or width");
+      return DDERR_UNSUPPORTED;
     }
 
-    d3d9::D3DPOOL pool  = d3d9::D3DPOOL_DEFAULT;
-    DWORD         usage = 0;
+    d3d9::D3DPOOL pool;
+    DWORD         usage = 0u;
 
     // General surface/texture pool placement
-    if (dwCaps & DDSCAPS_LOCALVIDMEM)
+    //
+    // Early DDraw/D3D didn't make the distinction between local and
+    // non-local video memory, so also cater to sole DDSCAPS_VIDEOMEMORY surfaces
+    if (IsInLocalVideoMemory() || (IsInVideoMemory() && !IsInNonLocalVideoMemory())) {
       pool = d3d9::D3DPOOL_DEFAULT;
     // There's no explicit non-local video memory placement
-    // per se, but D3DPOOL_MANAGED is close enough
-    else if ((dwCaps & DDSCAPS_NONLOCALVIDMEM) || (dwCaps2 & DDSCAPS2_TEXTUREMANAGE))
+    // per se in D3D9, but D3DPOOL_MANAGED is close enough
+    } else if (IsManaged() || IsInNonLocalVideoMemory()) {
       pool = d3d9::D3DPOOL_MANAGED;
-    else if (dwCaps & DDSCAPS_SYSTEMMEMORY)
+    } else if (IsInSystemMemory()) {
       // We can't know beforehand if a texture is or isn't going to be
       // used in SetTexture() calls, and textures placed in D3DPOOL_SYSTEMMEM
-      // will not work in that context in dxvk, so revert to D3DPOOL_MANAGED.
+      // will not work in that context, so revert to D3DPOOL_MANAGED
       pool = IsTextureOrCubeMap() ? d3d9::D3DPOOL_MANAGED : d3d9::D3DPOOL_SYSTEMMEM;
+    } else {
+      pool = d3d9::D3DPOOL_DEFAULT;
+    }
 
-    // Place all possible render targets in DEFAULT
+    // Place all possible render targets and depth stencils in DEFAULT,
+    // as per D3D9 requirements. In early D3D these can reside in system
+    // memory as well (for SWVP), but in practice this isn't crucial.
     //
     // Note: This is somewhat problematic for textures and cube maps
     // which will have D3DUSAGE_RENDERTARGET, but also need to have
@@ -215,179 +187,110 @@ namespace dxvk {
       //Logger::debug("DDrawCommonSurface::InitializeD3D9: Usage: D3DUSAGE_RENDERTARGET");
       pool  = d3d9::D3DPOOL_DEFAULT;
       usage |= D3DUSAGE_RENDERTARGET;
-    }
-    // All depth stencils will be created in DEFAULT
-    if (IsDepthStencil()) {
+    } else if (IsDepthStencil()) {
       //Logger::debug("DDrawCommonSurface::InitializeD3D9: Usage: D3DUSAGE_DEPTHSTENCIL");
       pool  = d3d9::D3DPOOL_DEFAULT;
       usage |= D3DUSAGE_DEPTHSTENCIL;
     }
 
-    // General usage flags
+    // General usage flags and mip map count
     if (IsTextureOrCubeMap()) {
+      // Needed to ensure D3DPOOL_DEFAULT textures/cubemaps are lockable
       if (pool == d3d9::D3DPOOL_DEFAULT) {
         //Logger::debug("DDrawCommonSurface::InitializeD3D9: Usage: D3DUSAGE_DYNAMIC");
         usage |= D3DUSAGE_DYNAMIC;
       }
+      // D3DUSAGE_AUTOGENMIPMAP is also invalid in D3DPOOL_SYSTEMMEM, but we fixed that earlier
       if (unlikely(m_commonIntf->GetOptions()->autoGenMipMaps)) {
         //Logger::debug("DDrawCommonSurface::InitializeD3D9: Usage: D3DUSAGE_AUTOGENMIPMAP");
         usage |= D3DUSAGE_AUTOGENMIPMAP;
+      } else {
+        // Determine the mip map count based on the existing surface interface
+        if (m_surf7 != nullptr) {
+          m_mipCount = DetermineMipMapCount<IDirectDrawSurface7, DDSURFACEDESC2>(m_surf7->GetProxied());
+        } else if (m_surf4 != nullptr) {
+          m_mipCount = DetermineMipMapCount<IDirectDrawSurface4, DDSURFACEDESC2>(m_surf4->GetProxied());
+        } else if (m_surf != nullptr) {
+          m_mipCount = DetermineMipMapCount<IDirectDrawSurface, DDSURFACEDESC>(m_surf->GetProxied());
+        }
       }
     }
 
-    const char* poolPlacement = pool == d3d9::D3DPOOL_DEFAULT ? "D3DPOOL_DEFAULT" :
-                                pool == d3d9::D3DPOOL_SYSTEMMEM ? "D3DPOOL_SYSTEMMEM" : "D3DPOOL_MANAGED";
-    Logger::debug(str::format("DDrawCommonSurface::InitializeD3D9: Placing in: ", poolPlacement));
-
     // Use the MSAA type that was determined to be supported during device creation
-    const d3d9::D3DMULTISAMPLE_TYPE multiSampleType = m_commonIntf->GetCommonD3DDevice()->GetMultiSampleType();
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonIntf->GetCommonD3DDevice()->GetD3D9Device();
+    const d3d9::D3DMULTISAMPLE_TYPE multiSampleType = m_commonD3DDevice->GetMultiSampleType();
+    d3d9::IDirect3DDevice9* d3d9Device = m_commonD3DDevice->GetD3D9Device();
 
-    HRESULT hr = DDERR_GENERIC;
+    DetermineD3D9SurfaceType(initRenderTarget);
 
-    // Primary Surface
-    if (IsPrimarySurface()) {
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing primary surface");
-
-      hr = d3d9Device->GetBackBuffer(0, m_backBufferIndex, d3d9::D3DBACKBUFFER_TYPE_MONO, &m_surface9);
-
-      if (unlikely(unlikely(FAILED(hr)))) {
-        Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to retrieve primary surface");
-        return hr;
-      }
-
-      MarkAsD3D9BackBuffer();
-    // Front Buffer
-    } else if (IsFrontBuffer()) {
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing front buffer");
-
-      hr = d3d9Device->GetBackBuffer(0, m_backBufferIndex, d3d9::D3DBACKBUFFER_TYPE_MONO, &m_surface9);
-
-      if (unlikely(unlikely(FAILED(hr)))) {
-        Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to retrieve front buffer");
-        return hr;
-      }
-
-      MarkAsD3D9BackBuffer();
-    // Back Buffer
-    } else if (IsBackBufferOrFlippable()) {
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing back buffer");
-
-      hr = d3d9Device->GetBackBuffer(0, m_backBufferIndex, d3d9::D3DBACKBUFFER_TYPE_MONO, &m_surface9);
-
-      if (unlikely(FAILED(hr))) {
-        Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to retrieve back buffer");
-        return hr;
-      }
-
-      MarkAsD3D9BackBuffer();
-    // Cube maps
-    } else if (IsCubeMap()) {
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing cube map");
-
-      hr = d3d9Device->CreateCubeTexture(
-        dwWidth, m_mipCount, usage,
-        m_format9, pool, &m_cubeMap9, nullptr);
-
-      if (unlikely(FAILED(hr))) {
-        Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to create cube map");
-        return hr;
-      }
-
-      // Always attach the positive X face to this surface
-      m_cubeMap9->GetCubeMapSurface(d3d9::D3DCUBEMAP_FACE_POSITIVE_X, 0, &m_surface9);
-    // Textures
-    } else if (IsTexture()) {
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing texture");
-
-      hr = d3d9Device->CreateTexture(
-        dwWidth, dwHeight, m_mipCount, usage,
-        m_format9, pool, &m_texture9, nullptr);
-
-      if (unlikely(FAILED(hr))) {
-        Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to create texture");
-        return hr;
-      }
-
-      // Attach level 0 to this surface
-      m_texture9->GetSurfaceLevel(0, &m_surface9);
-    // Depth Stencil
-    } else if (IsDepthStencil()) {
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing depth stencil");
-
-      hr = d3d9Device->CreateDepthStencilSurface(
-        dwWidth, dwHeight, m_format9,
-        multiSampleType, 0, FALSE, &m_surface9, nullptr);
-
-      if (unlikely(FAILED(hr))) {
-        Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to create depth stencil");
-        return hr;
-      }
-    // Offscreen Plain Surfaces
-    } else if (IsOffScreenPlainSurface()) {
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing offscreen plain surface");
-
-      if (unlikely(initRenderTarget)) {
-        hr = d3d9Device->GetBackBuffer(0, m_backBufferIndex, d3d9::D3DBACKBUFFER_TYPE_MONO, &m_surface9);
-
+    switch (m_d3d9SurfaceType) {
+      case D3D9SurfaceType::BackBuffer: {
+        HRESULT hr = d3d9Device->GetBackBuffer(0, m_backBufferIndex, d3d9::D3DBACKBUFFER_TYPE_MONO, &m_surface9);
         if (unlikely(unlikely(FAILED(hr)))) {
-          Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to retrieve offscreen plain surface");
+          Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to retrieve D3D9 back buffer");
           return hr;
         }
+        break;
+      }
+      case D3D9SurfaceType::CubeTexture: {
+        // Properly handle cube textures with auto-generated mip maps
+        const UINT mipCount = usage & D3DUSAGE_AUTOGENMIPMAP ? 0 : m_mipCount;
 
-        MarkAsD3D9BackBuffer();
-
-      } else {
-        hr = d3d9Device->CreateOffscreenPlainSurface(
-          dwWidth, dwHeight, m_format9,
-          pool, &m_surface9, nullptr);
-
+        HRESULT hr = d3d9Device->CreateCubeTexture(dwWidth, mipCount, usage,
+                                                   m_format9, pool, &m_cubeMap9, nullptr);
         if (unlikely(FAILED(hr))) {
-          Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to create offscreen plain surface");
+          Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to create D3D9 cube texture");
           return hr;
         }
+        // Always attach the positive X face to this surface
+        m_cubeMap9->GetCubeMapSurface(d3d9::D3DCUBEMAP_FACE_POSITIVE_X, 0, &m_surface9);
+        break;
       }
-    // Overlays
-    } else if (IsOverlay()) {
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing overlay");
+      case D3D9SurfaceType::Texture: {
+        // Properly handle textures with auto-generated mip maps
+        const UINT mipCount = usage & D3DUSAGE_AUTOGENMIPMAP ? 0 : m_mipCount;
 
-      hr = d3d9Device->CreateOffscreenPlainSurface(
-        dwWidth, dwHeight, m_format9,
-        pool, &m_surface9, nullptr);
-
-      if (unlikely(FAILED(hr))) {
-        Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to create offscreen plain surface");
-        return hr;
+        HRESULT hr = d3d9Device->CreateTexture(dwWidth, dwHeight, mipCount, usage,
+                                               m_format9, pool, &m_texture9, nullptr);
+        if (unlikely(FAILED(hr))) {
+          Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to create D3D9 texture");
+          return hr;
+        }
+        // Attach level 0 to this surface
+        m_texture9->GetSurfaceLevel(0, &m_surface9);
+        break;
       }
-    // Generic render target
-    } else if (IsRenderTarget()) {
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing render target");
-
-      // Must be lockable for blitting to work. Note that
-      // D3D9 does not allow the creation of lockable RTs when
-      // using MSAA, but we have a D3D7 exception in place.
-      hr = d3d9Device->CreateRenderTarget(
-        dwWidth, dwHeight, m_format9,
-        multiSampleType, usage, TRUE, &m_surface9, nullptr);
-
-      if (unlikely(FAILED(hr))) {
-        Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to create render target");
-        return hr;
+      case D3D9SurfaceType::DepthStencil: {
+        HRESULT hr = d3d9Device->CreateDepthStencilSurface(dwWidth, dwHeight, m_format9,
+                                                           multiSampleType, 0, FALSE, &m_surface9, nullptr);
+        if (unlikely(FAILED(hr))) {
+          Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to create D3D9 depth stencil");
+          return hr;
+        }
+        break;
       }
-    // We sometimes get generic surfaces, with only dimensions, format and placement info
-    } else if (!IsNotKnown()) {
-      Logger::debug("DDrawCommonSurface::InitializeD3D9: Initializing generic surface");
-
-      hr = d3d9Device->CreateOffscreenPlainSurface(
-          dwWidth, dwHeight, m_format9,
-          pool, &m_surface9, nullptr);
-
-      if (unlikely(FAILED(hr))) {
-        Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to create offscreen plain surface");
-        return hr;
+      case D3D9SurfaceType::OffscreenPlainSurface: {
+        HRESULT hr = d3d9Device->CreateOffscreenPlainSurface(dwWidth, dwHeight, m_format9,
+                                                             pool, &m_surface9, nullptr);
+        if (unlikely(FAILED(hr))) {
+          Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to create D3D9 offscreen plain surface");
+          return hr;
+        }
+        break;
       }
-    } else {
-      Logger::warn("DDrawCommonSurface::InitializeD3D9: Skipping initialization of unknown surface");
+      case D3D9SurfaceType::RenderTarget: {
+        // Must be lockable for blitting to work. Note that D3D9 does not allow the creation of
+        // lockable RTs when using MSAA, but we have a D3D7 exception in place.
+        HRESULT hr = d3d9Device->CreateRenderTarget(dwWidth, dwHeight, m_format9,
+                                                    multiSampleType, usage, TRUE, &m_surface9, nullptr);
+        if (unlikely(FAILED(hr))) {
+          Logger::err("DDrawCommonSurface::InitializeD3D9: Failed to create D3D9 render target");
+          return hr;
+        }
+        break;
+      }
+      default:
+        Logger::err("DDrawCommonSurface::InitializeD3D9: Unknown or undetermined D3D9 surface type");
+        return DDERR_UNSUPPORTED;
     }
 
     return DD_OK;

--- a/src/ddraw/ddraw_common_surface.h
+++ b/src/ddraw/ddraw_common_surface.h
@@ -10,6 +10,16 @@
 
 namespace dxvk {
 
+  enum class D3D9SurfaceType : uint8_t {
+    None,
+    BackBuffer,
+    CubeTexture,
+    Texture,
+    DepthStencil,
+    OffscreenPlainSurface,
+    RenderTarget
+  };
+
   class D3DCommonDevice;
 
   class DDraw7Surface;
@@ -35,9 +45,11 @@ namespace dxvk {
 
     DDrawCommonSurface* GetShadowCommonSurface();
 
-    HRESULT RefreshSurfaceDescripton();
+    HRESULT RefreshSurfaceDescripton(const bool refreshFormat);
 
-    d3d9::IDirect3DDevice9* RefreshD3D9Device();
+    void RefreshD3D9Device();
+
+    d3d9::IDirect3DDevice9* GetRefreshedD3D9Device();
 
     HRESULT InitializeD3D9(const bool initRenderTarget);
 
@@ -83,8 +95,21 @@ namespace dxvk {
       return m_cubeMap9.ptr();
     }
 
+    void ResetD3D9Objects() {
+      m_cubeMap9 = nullptr;
+      m_texture9 = nullptr;
+      m_surface9 = nullptr;
+      // Also reset all D3D9 related tracking flags
+      m_d3d9SurfaceType = D3D9SurfaceType::None;
+      m_dirtyD3D9 = false;
+    }
+
     d3d9::D3DFORMAT GetD3D9Format() const {
       return m_format9;
+    }
+
+    D3D9SurfaceType GetD3D9SurfaceType() const {
+      return m_d3d9SurfaceType;
     }
 
     bool IsDesc2Set() const {
@@ -94,7 +119,7 @@ namespace dxvk {
     void SetDesc2(const DDSURFACEDESC2& desc2) {
       m_desc2 = desc2;
       m_isDesc2Set = true;
-      RefreshStaticDescData();
+      RefreshStaticDescData(true);
     }
 
     const DDSURFACEDESC2* GetDesc2() const {
@@ -108,7 +133,7 @@ namespace dxvk {
     void SetDesc(const DDSURFACEDESC& desc) {
       m_desc = desc;
       m_isDescSet = true;
-      RefreshStaticDescData();
+      RefreshStaticDescData(true);
     }
 
     const DDSURFACEDESC* GetDesc() const {
@@ -116,8 +141,8 @@ namespace dxvk {
     }
 
     uint8_t GetColorBitCount() const {
-      return (m_desc2.dwFlags & DDSD_PIXELFORMAT) ? m_desc2.ddpfPixelFormat.dwRGBBitCount
-                                                  : m_desc.ddpfPixelFormat.dwRGBBitCount;
+      return (m_desc2.dwFlags & DDSD_PIXELFORMAT) ? m_desc2.ddpfPixelFormat.dwRGBBitCount :
+             (m_desc.dwFlags & DDSD_PIXELFORMAT)  ? m_desc.ddpfPixelFormat.dwRGBBitCount : 0u;
     }
 
     bool IsAlphaFormat() const {
@@ -129,19 +154,17 @@ namespace dxvk {
       return (m_desc2.dwFlags & DDSD_CKSRCBLT) || (m_desc.dwFlags & DDSD_CKSRCBLT);
     }
 
-    const DDCOLORKEY* GetColorKey() const {
-      return (m_desc2.dwFlags & DDSD_CKSRCBLT) ? &m_desc2.ddckCKSrcBlt : &m_desc.ddckCKSrcBlt;
-    }
-
     DDCOLORKEY GetColorKeyNormalized() const {
-      const DDPIXELFORMAT* pixelFormat = (m_desc2.dwFlags & DDSD_PIXELFORMAT) ? &m_desc2.ddpfPixelFormat : &m_desc.ddpfPixelFormat;
-      const DDCOLORKEY*    colorKey    = (m_desc2.dwFlags & DDSD_CKSRCBLT) ? &m_desc2.ddckCKSrcBlt : &m_desc.ddckCKSrcBlt;
+      const DDPIXELFORMAT* pixelFormat = (m_desc2.dwFlags & DDSD_PIXELFORMAT) ? &m_desc2.ddpfPixelFormat :
+                                         (m_desc.dwFlags & DDSD_PIXELFORMAT)  ? &m_desc.ddpfPixelFormat : nullptr;
+      const DDCOLORKEY*    colorKey    = (m_desc2.dwFlags & DDSD_CKSRCBLT) ? &m_desc2.ddckCKSrcBlt :
+                                         (m_desc.dwFlags & DDSD_CKSRCBLT)  ? &m_desc.ddckCKSrcBlt : nullptr;
 
       // Empire of the Ants relies on us using the "Low" color space DWORD
-      return ColorKeyToARGB(pixelFormat, colorKey->dwColorSpaceLowValue);
+      return ColorKeyToARGB(pixelFormat, colorKey != nullptr ? colorKey->dwColorSpaceLowValue : 0u);
     }
 
-    bool IsFullSurfaceLock(RECT* lockRect, RECT* fullSurfaceRect) const {
+    bool IsFullSurfaceLock(const RECT* lockRect, const RECT* fullSurfaceRect) const {
       if (lockRect == nullptr) {
         if (fullSurfaceRect == nullptr)
           return true;
@@ -149,14 +172,11 @@ namespace dxvk {
         lockRect = fullSurfaceRect;
       }
 
-      const DWORD width  = (m_desc2.dwFlags & DDSD_WIDTH)  ? m_desc2.dwWidth  : m_desc.dwWidth;
-      const DWORD height = (m_desc2.dwFlags & DDSD_HEIGHT) ? m_desc2.dwHeight : m_desc.dwHeight;
-
-      return width  == static_cast<DWORD>(lockRect->right  - lockRect->left) &&
-             height == static_cast<DWORD>(lockRect->bottom - lockRect->top);
+      return (m_rect.right  == lockRect->right  - lockRect->left) &&
+             (m_rect.bottom == lockRect->bottom - lockRect->top);
     }
 
-    RECT* GetFullSurfaceRect() {
+    const RECT* GetFullSurfaceRect() const {
       return &m_rect;
     }
 
@@ -167,12 +187,7 @@ namespace dxvk {
     }
 
     uint16_t GetMipCount() const {
-      // Properly handle textures with auto-generated mip maps
-      return std::max<uint16_t>(1u, m_mipCount);
-    }
-
-    void SetMipCount(uint16_t mipCount) {
-      m_mipCount = mipCount;
+      return m_mipCount;
     }
 
     uint32_t GetBackBufferIndex() const {
@@ -207,28 +222,12 @@ namespace dxvk {
       m_dirtyD3D9 = false;
     }
 
-    bool IsAttached() const {
-      return m_isAttached;
-    }
-
     void SetIsAttached(bool isAttached) {
       m_isAttached = isAttached;
     }
 
-    void MarkAsD3D9BackBuffer() {
-      m_isD3D9BackBuffer = true;
-    }
-
-    bool IsD3D9BackBuffer() const {
-      return m_isD3D9BackBuffer;
-    }
-
-    void MarkAsD3D9DepthStencil() {
-      m_isD3D9DepthStencil = true;
-    }
-
-    bool IsD3D9DepthStencil() const {
-      return m_isD3D9DepthStencil;
+    bool IsAttached() const {
+      return m_isAttached;
     }
 
     void MarkWithTextureHandle() {
@@ -327,6 +326,11 @@ namespace dxvk {
           || m_desc.ddsCaps.dwCaps  & DDSCAPS_BACKBUFFER;
     }
 
+    bool IsFlippable() const {
+      return m_desc2.ddsCaps.dwCaps & DDSCAPS_FLIP
+          || m_desc.ddsCaps.dwCaps  & DDSCAPS_FLIP;
+    }
+
     bool IsDepthStencil() const {
       return m_desc2.ddsCaps.dwCaps & DDSCAPS_ZBUFFER
           || m_desc.ddsCaps.dwCaps  & DDSCAPS_ZBUFFER;
@@ -343,16 +347,6 @@ namespace dxvk {
           || m_hasTextureHandle;
     }
 
-    bool IsOverlay() const {
-      return m_desc2.ddsCaps.dwCaps & DDSCAPS_OVERLAY
-          || m_desc.ddsCaps.dwCaps  & DDSCAPS_OVERLAY;
-    }
-
-    bool Is3DSurface() const {
-      return m_desc2.ddsCaps.dwCaps & DDSCAPS_3DDEVICE
-          || m_desc.ddsCaps.dwCaps  & DDSCAPS_3DDEVICE;
-    }
-
     bool IsTextureMip() const {
       return m_desc2.ddsCaps.dwCaps  & DDSCAPS_MIPMAP
           || m_desc2.ddsCaps.dwCaps2 & DDSCAPS2_MIPMAPSUBLEVEL
@@ -363,14 +357,21 @@ namespace dxvk {
       return m_desc2.ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP;
     }
 
-    bool IsFlippable() const {
-      return m_desc2.ddsCaps.dwCaps & DDSCAPS_FLIP
-          || m_desc.ddsCaps.dwCaps  & DDSCAPS_FLIP;
+    bool IsTextureOrCubeMap() const {
+      return m_desc2.ddsCaps.dwCaps  & DDSCAPS_TEXTURE
+          || m_desc2.ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP
+          || m_desc.ddsCaps.dwCaps   & DDSCAPS_TEXTURE
+          || m_hasTextureHandle;
     }
 
-    bool IsNotKnown() const {
-      return !(m_desc2.dwFlags & DDSD_CAPS)
-          && !(m_desc.dwFlags  & DDSD_CAPS);
+    bool IsOverlay() const {
+      return m_desc2.ddsCaps.dwCaps & DDSCAPS_OVERLAY
+          || m_desc.ddsCaps.dwCaps  & DDSCAPS_OVERLAY;
+    }
+
+    bool Is3DSurface() const {
+      return m_desc2.ddsCaps.dwCaps & DDSCAPS_3DDEVICE
+          || m_desc.ddsCaps.dwCaps  & DDSCAPS_3DDEVICE;
     }
 
     bool IsManaged() const {
@@ -378,21 +379,24 @@ namespace dxvk {
           || m_desc2.ddsCaps.dwCaps2 & DDSCAPS2_D3DTEXTUREMANAGE;
     }
 
+    bool IsInVideoMemory() const {
+      return m_desc2.ddsCaps.dwCaps & DDSCAPS_VIDEOMEMORY
+          || m_desc.ddsCaps.dwCaps  & DDSCAPS_VIDEOMEMORY;
+    }
+
+    bool IsInLocalVideoMemory() const {
+      return m_desc2.ddsCaps.dwCaps & DDSCAPS_LOCALVIDMEM
+          || m_desc.ddsCaps.dwCaps  & DDSCAPS_LOCALVIDMEM;
+    }
+
+    bool IsInNonLocalVideoMemory() const {
+      return m_desc2.ddsCaps.dwCaps & DDSCAPS_NONLOCALVIDMEM
+          || m_desc.ddsCaps.dwCaps  & DDSCAPS_NONLOCALVIDMEM;
+    }
+
     bool IsInSystemMemory() const {
       return m_desc2.ddsCaps.dwCaps & DDSCAPS_SYSTEMMEMORY
           || m_desc.ddsCaps.dwCaps  & DDSCAPS_SYSTEMMEMORY;
-    }
-
-    bool HasColorKey() const {
-      return m_desc2.dwFlags & DDSD_CKSRCBLT
-          || m_desc.dwFlags  & DDSD_CKSRCBLT;
-    }
-
-    bool IsTextureOrCubeMap() const {
-      return m_desc2.ddsCaps.dwCaps  & DDSCAPS_TEXTURE
-          || m_desc2.ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP
-          || m_desc.ddsCaps.dwCaps   & DDSCAPS_TEXTURE
-          || m_hasTextureHandle;
     }
 
     bool IsRenderTarget() const {
@@ -411,31 +415,26 @@ namespace dxvk {
           || m_format9 == d3d9::D3DFMT_DXT5;
     }
 
-    bool Is8BitFormat() const {
-      return m_format9 == d3d9::D3DFMT_R3G3B2
-          || m_format9 == d3d9::D3DFMT_P8;
-    }
-
     // D3D7 is a bit more sane here, as always, so handle it separately
     HRESULT ValidateRTUsage7(bool isHALOrTNLHALDevice, bool isDeviceCreation) const {
       // Render targets require the DDSCAPS_3DDEVICE flag
       if (unlikely(!Is3DSurface())) {
-        Logger::err("DDrawCommonInterface::ValidateRTUsage: Missing DDSCAPS_3DDEVICE");
+        Logger::err("DDrawCommonSurface::ValidateRTUsage: Missing DDSCAPS_3DDEVICE");
         return DDERR_INVALIDCAPS;
       }
       // Depth stencil surfaces can't be set as render targets
       if (unlikely(IsDepthStencil())) {
-        Logger::err("DDrawCommonInterface::ValidateRTUsage: Invalid DDSCAPS_ZBUFFER");
+        Logger::err("DDrawCommonSurface::ValidateRTUsage: Invalid DDSCAPS_ZBUFFER");
         return isDeviceCreation ? DDERR_INVALIDCAPS : DDERR_INVALIDPIXELFORMAT;
       }
       // DXVK doesn't support P8 render targets, so pretend these are always invalid
       if (unlikely(m_format9 == d3d9::D3DFMT_P8)) {
-        Logger::err("DDrawCommonInterface::ValidateRTUsage: Invalid P8 render target");
+        Logger::err("DDrawCommonSurface::ValidateRTUsage: Invalid P8 render target");
         return isDeviceCreation ? DDERR_NOPALETTEATTACHED : DDERR_INVALIDPARAMS;
       }
       // Render targets can't be created in system memory on HAL/HAL T&L devices
       if (unlikely(IsInSystemMemory() && isHALOrTNLHALDevice)) {
-        Logger::err("DDrawCommonInterface::ValidateRTUsage: Invalid DDSCAPS_SYSTEMMEMORY");
+        Logger::err("DDrawCommonSurface::ValidateRTUsage: Invalid DDSCAPS_SYSTEMMEMORY");
         return isDeviceCreation ? D3DERR_SURFACENOTINVIDMEM : DDERR_INVALIDPARAMS;
       }
 
@@ -446,27 +445,41 @@ namespace dxvk {
     HRESULT ValidateRTUsage(bool isHALDevice, bool isDeviceCreation) const {
       // Render targets require the DDSCAPS_3DDEVICE flag
       if (unlikely(!Is3DSurface())) {
-        Logger::err("DDrawCommonInterface::ValidateRTUsage: Missing DDSCAPS_3DDEVICE");
+        Logger::err("DDrawCommonSurface::ValidateRTUsage: Missing DDSCAPS_3DDEVICE");
         return DDERR_INVALIDCAPS;
       }
       // Depth stencil surfaces can't be set as render targets
       if (unlikely(IsDepthStencil())) {
-        Logger::err("DDrawCommonInterface::ValidateRTUsage: Invalid DDSCAPS_ZBUFFER");
+        Logger::err("DDrawCommonSurface::ValidateRTUsage: Invalid DDSCAPS_ZBUFFER");
         return isDeviceCreation ? DDERR_INVALIDCAPS : DDERR_INVALIDPIXELFORMAT;
       }
       // DXVK doesn't support P8 render targets, so pretend these are always invalid
       if (unlikely(m_format9 == d3d9::D3DFMT_P8)) {
-        Logger::err("DDrawCommonInterface::ValidateRTUsage: Invalid P8 render target");
+        Logger::err("DDrawCommonSurface::ValidateRTUsage: Invalid P8 render target");
         return isDeviceCreation ? DDERR_NOPALETTEATTACHED : DDERR_INVALIDPARAMS;
       }
       // Render targets can't be created in system memory on HAL devices,
       // however system memory surfaces can later be set as render targets... yeah...
       if (unlikely(isDeviceCreation && IsInSystemMemory() && isHALDevice)) {
-        Logger::err("DDrawCommonInterface::ValidateRTUsage: Invalid DDSCAPS_SYSTEMMEMORY");
+        Logger::err("DDrawCommonSurface::ValidateRTUsage: Invalid DDSCAPS_SYSTEMMEMORY");
         return D3DERR_SURFACENOTINVIDMEM;
       }
 
       return DD_OK;
+    }
+
+    bool SkipD3D9Operations() const {
+      // Skip all D3D9 operations on P8 textures/surfaces, since DXVK doesn't support them
+      if (unlikely(m_format9 == d3d9::D3DFMT_P8)) {
+        static bool s_formatP8ErrorShown;
+
+        if (!std::exchange(s_formatP8ErrorShown, true))
+          Logger::warn("DDrawCommonSurface: Unsupported format D3DFMT_P8");
+
+        return true;
+      }
+
+      return false;
     }
 
     void ListSurfaceDetails() const {
@@ -479,49 +492,94 @@ namespace dxvk {
       else if (IsTextureMip())            type = "texture mipmap";
       else if (IsTexture())               type = "texture";
       else if (IsDepthStencil())          type = "depth stencil";
-      else if (IsOffScreenPlainSurface()) type = "offscreen plain surface";
       else if (IsOverlay())               type = "overlay";
+      else if (IsOffScreenPlainSurface()) type = "offscreen plain surface";
       else if (Is3DSurface())             type = "render target";
-      else if (IsNotKnown())              type = "unknown";
 
-      const DWORD width          = (m_desc2.dwFlags & DDSD_WIDTH)  ? m_desc2.dwWidth  : m_desc.dwWidth;
-      const DWORD height         = (m_desc2.dwFlags & DDSD_HEIGHT) ? m_desc2.dwHeight : m_desc.dwHeight;
-      const DWORD mipMapCount    = (m_desc2.dwFlags & DDSD_MIPMAPCOUNT) ? m_desc2.dwMipMapCount : m_desc.dwMipMapCount;
-      const DWORD backBuferCount = (m_desc2.dwFlags & DDSD_BACKBUFFERCOUNT) ? m_desc2.dwBackBufferCount : m_desc.dwBackBufferCount;
+      const DWORD mipMapCount    = (m_desc2.dwFlags & DDSD_MIPMAPCOUNT) ? m_desc2.dwMipMapCount :
+                                   (m_desc.dwFlags & DDSD_MIPMAPCOUNT) ? m_desc.dwMipMapCount : 0u;
+      const DWORD backBuferCount = (m_desc2.dwFlags & DDSD_BACKBUFFERCOUNT) ? m_desc2.dwBackBufferCount :
+                                   (m_desc.dwFlags & DDSD_BACKBUFFERCOUNT) ? m_desc.dwBackBufferCount : 0u;
 
-      Logger::debug(str::format("   Type:        ", type));
-      Logger::debug(str::format("   Dimensions:  ", width, "x", height));
-      Logger::debug(str::format("   Format:      ", GetD3D9Format()));
-      Logger::debug(str::format("   IsComplex:   ", IsComplex() ? "yes" : "no"));
-      Logger::debug(str::format("   HasMipMaps:  ", mipMapCount ? "yes" : "no"));
-      Logger::debug(str::format("   IsAttached:  ", IsAttached() ? "yes" : "no"));
-      Logger::debug(str::format("   ColorKey:    ", HasColorKey() ? "yes" : "no"));
-      if (IsFrontBuffer())
+      Logger::debug(str::format("   Type:        ", type,
+                              "\n   Dimensions:  ", m_rect.right, "x", m_rect.bottom,
+                              "\n   Format:      ", GetD3D9Format(),
+                              "\n   IsComplex:   ", IsComplex() ? "yes" : "no",
+                              "\n   IsAttached:  ", IsAttached() ? "yes" : "no"));
+      if (mipMapCount)
+        Logger::debug(str::format("   MipMaps:     ", mipMapCount));
+      if (backBuferCount)
         Logger::debug(str::format("   BackBuffers: ", backBuferCount));
     }
 
   private:
 
-    inline void RefreshStaticDescData() {
-      m_rect.right  = (m_desc2.dwFlags & DDSD_WIDTH)  ? m_desc2.dwWidth  : m_desc.dwWidth;
-      m_rect.bottom = (m_desc2.dwFlags & DDSD_HEIGHT) ? m_desc2.dwHeight : m_desc.dwHeight;
-      m_format9 = ConvertFormat((m_desc2.dwFlags & DDSD_PIXELFORMAT) ? m_desc2.ddpfPixelFormat : m_desc.ddpfPixelFormat);
+    // Note: The flag check order IS important here, as some flags take
+    // priority over others when considering D3D9 surface type mappings
+    inline void DetermineD3D9SurfaceType(const bool initRenderTarget) {
+      // Primary Surface
+      if (IsPrimarySurface()) {
+        m_d3d9SurfaceType = D3D9SurfaceType::BackBuffer;
+      // Front Buffer
+      } else if (IsFrontBuffer()) {
+        m_d3d9SurfaceType = D3D9SurfaceType::BackBuffer;
+      // Back Buffer
+      } else if (IsBackBufferOrFlippable()) {
+        m_d3d9SurfaceType = D3D9SurfaceType::BackBuffer;
+      // Cube maps
+      } else if (IsCubeMap()) {
+        m_d3d9SurfaceType = D3D9SurfaceType::CubeTexture;
+      // Textures
+      } else if (IsTexture()) {
+        m_d3d9SurfaceType = D3D9SurfaceType::Texture;
+      // Depth Stencil
+      } else if (IsDepthStencil()) {
+        m_d3d9SurfaceType = D3D9SurfaceType::DepthStencil;
+      // Overlays
+      } else if (unlikely(IsOverlay())) {
+        m_d3d9SurfaceType = D3D9SurfaceType::OffscreenPlainSurface;
+      // Offscreen Plain Surfaces
+      } else if (IsOffScreenPlainSurface()) {
+        if (unlikely(initRenderTarget)) {
+          m_d3d9SurfaceType = D3D9SurfaceType::BackBuffer;
+        } else {
+          m_d3d9SurfaceType = D3D9SurfaceType::OffscreenPlainSurface;
+        }
+      // Generic render target
+      } else if (Is3DSurface()) {
+        m_d3d9SurfaceType = D3D9SurfaceType::RenderTarget;
+      // We sometimes get generic surfaces, with only dimensions, format and placement info
+      } else {
+        m_d3d9SurfaceType = D3D9SurfaceType::OffscreenPlainSurface;
+      }
+    }
+
+    inline void RefreshStaticDescData(const bool refreshFormat) {
       // determine and cache various frequently used flag combinations
       m_isRenderTarget          = IsFrontBuffer() || IsBackBuffer() || IsFlippable() || Is3DSurface();
       m_isBackBufferOrFlippable = !IsPrimarySurface() && !IsFrontBuffer() && (IsBackBuffer() || IsFlippable());
+      // refresh static values such as the full surface rect and format
+      m_rect.right  = (m_desc2.dwFlags & DDSD_WIDTH) ? m_desc2.dwWidth :
+                      (m_desc.dwFlags & DDSD_WIDTH) ? m_desc.dwWidth  : 0;
+      m_rect.bottom = (m_desc2.dwFlags & DDSD_HEIGHT) ? m_desc2.dwHeight :
+                      (m_desc.dwFlags & DDSD_HEIGHT) ? m_desc.dwHeight : 0;
+      if (refreshFormat) {
+        const d3d9::D3DFORMAT format9 = ConvertFormat((m_desc2.dwFlags & DDSD_PIXELFORMAT) ? m_desc2.ddpfPixelFormat : m_desc.ddpfPixelFormat);
+        // warn if a format change is detected on an already initialized surface
+        if (unlikely(m_surface9 != nullptr && m_format9 != format9))
+          Logger::warn("DDrawCommonSurface::RefreshStaticDescData: Surface format has changed post initialization");
+        m_format9 = format9;
+      }
     }
 
     bool                             m_dirtyDDraw         = false;
     bool                             m_dirtyD3D9          = false;
 
-    bool                             m_isAttached         = false;
-    bool                             m_isD3D9BackBuffer   = false;
-    bool                             m_isD3D9DepthStencil = false;
-
     bool                             m_isDesc2Set         = false;
     bool                             m_isDescSet          = false;
     bool                             m_hasTextureHandle   = false;
 
+    bool                             m_isAttached         = false;
     bool                             m_isRenderTarget     = false;
     bool                             m_isBackBufferOrFlippable = false;
 
@@ -534,6 +592,7 @@ namespace dxvk {
 
     DDSURFACEDESC                    m_desc               = { };
     DDSURFACEDESC2                   m_desc2              = { };
+    D3D9SurfaceType                  m_d3d9SurfaceType    = D3D9SurfaceType::None;
     RECT                             m_rect               = { };
 
     Com<DDrawClipper>                m_clipper;

--- a/src/ddraw/ddraw_format.h
+++ b/src/ddraw/ddraw_format.h
@@ -38,166 +38,173 @@ namespace dxvk {
     DDSURFACEDESC2       desc2        = { };
   };
 
-  inline bool IsCubeMapFace(DDSURFACEDESC2* desc) {
-    return desc->ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP_POSITIVEX
-        || desc->ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP_NEGATIVEX
-        || desc->ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP_POSITIVEY
-        || desc->ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP_NEGATIVEY
-        || desc->ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP_POSITIVEZ
-        || desc->ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP_NEGATIVEZ;
-  }
-
   inline d3d9::D3DCUBEMAP_FACES GetCubemapFace(DDSURFACEDESC2* desc) {
-    if (desc->ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP_POSITIVEX) return d3d9::D3DCUBEMAP_FACE_POSITIVE_X;
-    if (desc->ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP_NEGATIVEX) return d3d9::D3DCUBEMAP_FACE_NEGATIVE_X;
-    if (desc->ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP_POSITIVEY) return d3d9::D3DCUBEMAP_FACE_POSITIVE_Y;
-    if (desc->ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP_NEGATIVEY) return d3d9::D3DCUBEMAP_FACE_NEGATIVE_Y;
-    if (desc->ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP_POSITIVEZ) return d3d9::D3DCUBEMAP_FACE_POSITIVE_Z;
-    if (desc->ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP_NEGATIVEZ) return d3d9::D3DCUBEMAP_FACE_NEGATIVE_Z;
-    return d3d9::D3DCUBEMAP_FACE_POSITIVE_X;
+    const DWORD cubeFaceMask = desc->ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP_ALLFACES;
+
+    switch (cubeFaceMask) {
+      default:
+      case DDSCAPS2_CUBEMAP_POSITIVEX: return d3d9::D3DCUBEMAP_FACE_POSITIVE_X;
+      case DDSCAPS2_CUBEMAP_NEGATIVEX: return d3d9::D3DCUBEMAP_FACE_NEGATIVE_X;
+      case DDSCAPS2_CUBEMAP_POSITIVEY: return d3d9::D3DCUBEMAP_FACE_POSITIVE_Y;
+      case DDSCAPS2_CUBEMAP_NEGATIVEY: return d3d9::D3DCUBEMAP_FACE_NEGATIVE_Y;
+      case DDSCAPS2_CUBEMAP_POSITIVEZ: return d3d9::D3DCUBEMAP_FACE_POSITIVE_Z;
+      case DDSCAPS2_CUBEMAP_NEGATIVEZ: return d3d9::D3DCUBEMAP_FACE_NEGATIVE_Z;
+    }
   }
 
   inline d3d9::D3DFORMAT ConvertFormat(DDPIXELFORMAT& fmt) {
+    d3d9::D3DFORMAT d3d9Format;
+
+    // Empire of the Ants erroneously marks all DDPF_RGB surfaces
+    // with the DDPF_ZBUFFER flag as well, so prioritize DDPF_RGB
     if (fmt.dwFlags & DDPF_RGB) {
-      Logger::debug(str::format("ConvertFormat: fmt.dwRGBBitCount:     ", fmt.dwRGBBitCount));
-      Logger::debug(str::format("ConvertFormat: fmt.dwRGBAlphaBitMask: ", fmt.dwRGBAlphaBitMask));
-      Logger::debug(str::format("ConvertFormat: fmt.dwRBitMask:        ", fmt.dwRBitMask));
-      Logger::debug(str::format("ConvertFormat: fmt.dwGBitMask:        ", fmt.dwGBitMask));
-      Logger::debug(str::format("ConvertFormat: fmt.dwBBitMask:        ", fmt.dwBBitMask));
+      //Logger::debug(str::format("ConvertFormat: fmt.dwRGBBitCount:     ", fmt.dwRGBBitCount,
+      //                        "\nConvertFormat: fmt.dwRGBAlphaBitMask: ", fmt.dwRGBAlphaBitMask,
+      //                        "\nConvertFormat: fmt.dwRBitMask:        ", fmt.dwRBitMask,
+      //                        "\nConvertFormat: fmt.dwGBitMask:        ", fmt.dwGBitMask,
+      //                        "\nConvertFormat: fmt.dwBBitMask:        ", fmt.dwBBitMask));
 
       switch (fmt.dwRGBBitCount) {
         case 8:
           // R: 1110 0000
-          return (fmt.dwFlags & DDPF_PALETTEINDEXED8) ? d3d9::D3DFMT_P8 : d3d9::D3DFMT_R3G3B2;
-        case 16: {
+          d3d9Format = (fmt.dwFlags & DDPF_PALETTEINDEXED8) ? d3d9::D3DFMT_P8 : d3d9::D3DFMT_R3G3B2;
+          break;
+
+        case 16:
           switch (fmt.dwRBitMask) {
             case (0xF << 8):
               // A: 1111 0000 0000 0000
               // R: 0000 1111 0000 0000
-              return d3d9::D3DFMT_A4R4G4B4;
+              d3d9Format = d3d9::D3DFMT_A4R4G4B4;
+              break;
+
             case (0x1F << 10):
               // A: 1000 0000 0000 0000
               // R: 0111 1100 0000 0000
-              return fmt.dwRGBAlphaBitMask ? d3d9::D3DFMT_A1R5G5B5 : d3d9::D3DFMT_X1R5G5B5;
+              d3d9Format = fmt.dwRGBAlphaBitMask ? d3d9::D3DFMT_A1R5G5B5 : d3d9::D3DFMT_X1R5G5B5;
+              break;
+
             case (0x1F << 11):
               // R: 1111 1000 0000 0000
-              return d3d9::D3DFMT_R5G6B5;
+              d3d9Format = d3d9::D3DFMT_R5G6B5;
+              break;
+
+            default:
+              Logger::warn("ConvertFormat: Unhandled dwRGBBitCount 16 format");
+              d3d9Format = d3d9::D3DFMT_UNKNOWN;
+              break;
           }
-          Logger::warn("ConvertFormat: Unhandled dwRGBBitCount 16 format");
-          return d3d9::D3DFMT_UNKNOWN;
-        }
+          break;
+
         // Drakan: Order of the Flame uses a dwRGBBitCount of 24
         // to request for D3DFMT_X8R8G8B8, based on provided bitmasks
         case 24:
-          return d3d9::D3DFMT_X8R8G8B8;
-        case 32: {
+          d3d9Format = d3d9::D3DFMT_X8R8G8B8;
+          break;
+
+        case 32:
           // A: 1111 1111 0000 0000 0000 0000 0000 0000
           // R: 0000 0000 1111 1111 0000 0000 0000 0000
-          return fmt.dwRGBAlphaBitMask ? d3d9::D3DFMT_A8R8G8B8 : d3d9::D3DFMT_X8R8G8B8;
-        }
-      }
-      Logger::warn("ConvertFormat: Unhandled dwRGBBitCount format");
-      return d3d9::D3DFMT_UNKNOWN;
+          d3d9Format = fmt.dwRGBAlphaBitMask ? d3d9::D3DFMT_A8R8G8B8 : d3d9::D3DFMT_X8R8G8B8;
+          break;
 
+        default:
+          Logger::warn("ConvertFormat: Unhandled dwRGBBitCount format");
+          d3d9Format = d3d9::D3DFMT_UNKNOWN;
+          break;
+      }
     // Depth formats will traditionally store stencil info in the MSB, however
     // some games will apparently try to use the LSB, so handle both cases
     } else if (fmt.dwFlags & DDPF_ZBUFFER) {
-      Logger::debug(str::format("ConvertFormat: fmt.dwZBufferBitDepth: ", fmt.dwZBufferBitDepth));
-      Logger::debug(str::format("ConvertFormat: fmt.dwZBitMask:        ",        fmt.dwZBitMask));
-      Logger::debug(str::format("ConvertFormat: fmt.dwStencilBitMask:  ",  fmt.dwStencilBitMask));
+      //Logger::debug(str::format("ConvertFormat: fmt.dwZBufferBitDepth: ", fmt.dwZBufferBitDepth,
+      //                        "\nConvertFormat: fmt.dwZBitMask:        ",        fmt.dwZBitMask,
+      //                        "\nConvertFormat: fmt.dwStencilBitMask:  ",  fmt.dwStencilBitMask));
 
       switch (fmt.dwZBufferBitDepth) {
-        case 16: {
+        case 16:
           switch (fmt.dwStencilBitMask) {
             case 0:
               // D: 1111 1111 1111 1111
               // S: 0000 0000 0000 0000
-              return d3d9::D3DFMT_D16;
+              d3d9Format = d3d9::D3DFMT_D16;
+              break;
+
             case 0x1:
             case (0x1 << 15):
               // D: 0111 1111 1111 1111
               // S: 1000 0000 0000 0000
-              Logger::warn("ConvertFormat: Unsupported format D3DFMT_D15S1");
-              return d3d9::D3DFMT_D16;
+              d3d9Format = d3d9::D3DFMT_D15S1;
+              break;
+
+            default:
+              Logger::warn("ConvertFormat: Unhandled dwStencilBitMask 16 format");
+              d3d9Format = d3d9::D3DFMT_UNKNOWN;
+              break;
           }
-          Logger::warn("ConvertFormat: Unhandled dwStencilBitMask 16 format");
-          return d3d9::D3DFMT_UNKNOWN;
-        }
+          break;
+
         // We don't support or expose a 24-bit depth stencil per se,
         // but some applications request one anyway. Use 32-bit depth.
         case 24:
-        case 32: {
+        case 32:
           switch (fmt.dwStencilBitMask) {
-            case 0: {
+            case 0:
               switch (fmt.dwZBitMask) {
                 case 0xFFFFFFFF:
                   // D: 1111 1111 1111 1111 1111 1111 1111 1111
                   // S: 0000 0000 0000 0000 0000 0000 0000 0000
-                  Logger::warn("ConvertFormat: Unsupported format D3DFMT_D32");
-                  return d3d9::D3DFMT_D24X8;
+                  d3d9Format = d3d9::D3DFMT_D32;
+                  break;
+
                 case 0xFFFFFF:
-                case (DWORD(0xFFFFFF << 8)):
+                case DWORD(0xFFFFFF << 8):
                   // D: 0000 0000 1111 1111 1111 1111 1111 1111
                   // S: 0000 0000 0000 0000 0000 0000 0000 0000
-                  return d3d9::D3DFMT_D24X8;
+                  d3d9Format = d3d9::D3DFMT_D24X8;
+                  break;
+
+                default:
+                  Logger::warn("ConvertFormat: Unhandled dwZBitMask 24/32 format");
+                  d3d9Format = d3d9::D3DFMT_UNKNOWN;
+                  break;
               }
-              Logger::warn("ConvertFormat: Unhandled dwZBitMask 24/32 format");
-              return d3d9::D3DFMT_UNKNOWN;
-            }
+              break;
+
             case 0xFF:
-            case (DWORD(0xFF << 24)):
+            case DWORD(0xFF << 24):
               // D: 0000 0000 1111 1111 1111 1111 1111 1111
               // S: 1111 1111 0000 0000 0000 0000 0000 0000
-              return d3d9::D3DFMT_D24S8;
+              d3d9Format = d3d9::D3DFMT_D24S8;
+              break;
+
             case 0xF:
-            case (DWORD(0xF << 24)):
+            case DWORD(0xF << 24):
               // D: 0000 0000 1111 1111 1111 1111 1111 1111
               // S: 1111 0000 0000 0000 0000 0000 0000 0000
               Logger::warn("ConvertFormat: Unsupported format D3DFMT_D24X4S4");
-              return d3d9::D3DFMT_D24S8;
+              d3d9Format = d3d9::D3DFMT_D24S8;
+              break;
+
+            default:
+              Logger::warn("ConvertFormat: Unhandled dwStencilBitMask 24/32 format");
+              d3d9Format = d3d9::D3DFMT_UNKNOWN;
+              break;
           }
-          Logger::warn("ConvertFormat: Unhandled dwStencilBitMask 24/32 format");
-          return d3d9::D3DFMT_UNKNOWN;
-        }
+          break;
+
+        default:
+          Logger::warn("ConvertFormat: Unhandled dwZBufferBitDepth format");
+          d3d9Format = d3d9::D3DFMT_UNKNOWN;
+          break;
       }
-      Logger::warn("ConvertFormat: Unhandled dwZBufferBitDepth format");
-      return d3d9::D3DFMT_UNKNOWN;
-
-    } else if (fmt.dwFlags & DDPF_LUMINANCE) {
-      Logger::debug(str::format("ConvertFormat: fmt.dwLuminanceBitCount:     ", fmt.dwLuminanceBitCount));
-      Logger::debug(str::format("ConvertFormat: fmt.dwLuminanceAlphaBitMask: ", fmt.dwLuminanceAlphaBitMask));
-      Logger::debug(str::format("ConvertFormat: fmt.dwLuminanceBitMask:      ", fmt.dwLuminanceBitMask));
-
-      switch (fmt.dwLuminanceBitCount) {
-        case 8: {
-          switch (fmt.dwLuminanceBitMask) {
-            case 0xFF:
-              // L: 1111 1111
-              return d3d9::D3DFMT_L8;
-            case 0xF:
-              // A: 1111 0000
-              // L: 0000 1111
-              return d3d9::D3DFMT_A4L4;
-          }
-          Logger::warn("ConvertFormat: Unhandled dwLuminanceBitCount 8 format");
-          return d3d9::D3DFMT_UNKNOWN;
-        }
-        case 16:
-          // A: 1111 1111 0000 0000
-          // L: 0000 0000 1111 1111
-          return d3d9::D3DFMT_A8L8;
-      }
-      Logger::warn("ConvertFormat: Unhandled dwLuminanceBitCount format");
-      return d3d9::D3DFMT_UNKNOWN;
-
     } else if (fmt.dwFlags & DDPF_BUMPDUDV) {
-      Logger::debug(str::format("ConvertFormat: fmt.dwBumpBitCount:         ", fmt.dwBumpBitCount));
-      Logger::debug(str::format("ConvertFormat: fmt.dwBumpLuminanceBitMask: ", fmt.dwBumpLuminanceBitMask));
-      Logger::debug(str::format("ConvertFormat: fmt.dwBumpDvBitMask:        ", fmt.dwBumpDvBitMask));
-      Logger::debug(str::format("ConvertFormat: fmt.dwBumpDuBitMask:        ", fmt.dwBumpDuBitMask));
+      //Logger::debug(str::format("ConvertFormat: fmt.dwBumpBitCount:         ", fmt.dwBumpBitCount,
+      //                        "\nConvertFormat: fmt.dwBumpLuminanceBitMask: ", fmt.dwBumpLuminanceBitMask,
+      //                        "\nConvertFormat: fmt.dwBumpDvBitMask:        ", fmt.dwBumpDvBitMask,
+      //                        "\nConvertFormat: fmt.dwBumpDuBitMask:        ", fmt.dwBumpDuBitMask));
 
       switch (fmt.dwBumpBitCount) {
-        case 16: {
+        case 16:
           // L: 1111 1100 0000 0000
           // V: 0000 0011 1110 0000
           // U: 0000 0000 0001 1111
@@ -205,43 +212,100 @@ namespace dxvk {
           // L: 0000 0000 0000 0000
           // V: 1111 1111 0000 0000
           // U: 0000 0000 1111 1111
-          return fmt.dwBumpLuminanceBitMask ? d3d9::D3DFMT_L6V5U5 : d3d9::D3DFMT_V8U8;
-        }
-        case 32: {
+          d3d9Format = fmt.dwBumpLuminanceBitMask ? d3d9::D3DFMT_L6V5U5 : d3d9::D3DFMT_V8U8;
+          break;
+
+        case 32:
           // A: 0000 0000 0000 0000 0000 0000 0000 0000
           // L: 0000 0000 1111 1111 0000 0000 0000 0000
           // V: 0000 0000 0000 0000 1111 1111 0000 0000
           // U: 0000 0000 0000 0000 0000 0000 1111 1111
-          return d3d9::D3DFMT_X8L8V8U8;
-        }
-      }
-      Logger::warn("ConvertFormat: Unhandled dwBumpBitCount format");
-      return d3d9::D3DFMT_UNKNOWN;
+          d3d9Format = d3d9::D3DFMT_X8L8V8U8;
+          break;
 
+        default:
+          Logger::warn("ConvertFormat: Unhandled dwBumpBitCount format");
+          d3d9Format = d3d9::D3DFMT_UNKNOWN;
+          break;
+      }
     } else if (fmt.dwFlags & DDPF_FOURCC) {
       switch (fmt.dwFourCC) {
         case MAKEFOURCC('D', 'X', 'T', '1'):
-          return d3d9::D3DFMT_DXT1;
+          d3d9Format = d3d9::D3DFMT_DXT1;
+          break;
+
         case MAKEFOURCC('D', 'X', 'T', '2'):
-          return d3d9::D3DFMT_DXT2;
+          d3d9Format = d3d9::D3DFMT_DXT2;
+          break;
+
         case MAKEFOURCC('D', 'X', 'T', '3'):
-          return d3d9::D3DFMT_DXT3;
+          d3d9Format = d3d9::D3DFMT_DXT3;
+          break;
+
         case MAKEFOURCC('D', 'X', 'T', '4'):
-          return d3d9::D3DFMT_DXT4;
+          d3d9Format = d3d9::D3DFMT_DXT4;
+          break;
+
         case MAKEFOURCC('D', 'X', 'T', '5'):
-          return d3d9::D3DFMT_DXT5;
+          d3d9Format = d3d9::D3DFMT_DXT5;
+          break;
+
         case MAKEFOURCC('Y', 'U', 'Y', '2'):
-          return d3d9::D3DFMT_YUY2;
+          d3d9Format = d3d9::D3DFMT_YUY2;
+          break;
+
+        default:
+          Logger::warn("ConvertFormat: Unhandled FOURCC payload");
+          d3d9Format = d3d9::D3DFMT_UNKNOWN;
+          break;
       }
-      Logger::warn("ConvertFormat: Unhandled FOURCC payload");
-      return d3d9::D3DFMT_UNKNOWN;
+    // Luminance/alpha-luminance formats appear to be unused in practice in early D3D
+    } else if (unlikely(fmt.dwFlags & DDPF_LUMINANCE)) {
+      //Logger::debug(str::format("ConvertFormat: fmt.dwLuminanceBitCount:     ", fmt.dwLuminanceBitCount,
+      //                        "\nConvertFormat: fmt.dwLuminanceAlphaBitMask: ", fmt.dwLuminanceAlphaBitMask,
+      //                        "\nConvertFormat: fmt.dwLuminanceBitMask:      ", fmt.dwLuminanceBitMask));
+
+      switch (fmt.dwLuminanceBitCount) {
+        case 8:
+          switch (fmt.dwLuminanceBitMask) {
+            case 0xFF:
+              // L: 1111 1111
+              d3d9Format = d3d9::D3DFMT_L8;
+              break;
+
+            case 0xF:
+              // A: 1111 0000
+              // L: 0000 1111
+              d3d9Format = d3d9::D3DFMT_A4L4;
+              break;
+
+            default:
+              Logger::warn("ConvertFormat: Unhandled dwLuminanceBitCount 8 format");
+              d3d9Format = d3d9::D3DFMT_UNKNOWN;
+              break;
+          }
+          break;
+
+        case 16:
+          // A: 1111 1111 0000 0000
+          // L: 0000 0000 1111 1111
+          d3d9Format = d3d9::D3DFMT_A8L8;
+          break;
+
+        default:
+          Logger::warn("ConvertFormat: Unhandled dwLuminanceBitCount format");
+          d3d9Format = d3d9::D3DFMT_UNKNOWN;
+          break;
+      }
+    } else {
+      Logger::warn("ConvertFormat: Unhandled bit payload");
+      d3d9Format = d3d9::D3DFMT_UNKNOWN;
     }
 
-    Logger::warn("ConvertFormat: Unhandled bit payload");
-    return d3d9::D3DFMT_UNKNOWN;
+    return d3d9Format;
   }
 
-  inline DDPIXELFORMAT GetTextureFormat (d3d9::D3DFORMAT format) {
+  inline DDPIXELFORMAT GetTextureFormat(d3d9::D3DFORMAT format) {
     DDPIXELFORMAT tformat = { };
     tformat.dwSize = sizeof(DDPIXELFORMAT);
 
@@ -383,6 +447,11 @@ namespace dxvk {
         tformat.dwFourCC = MAKEFOURCC('D', 'X', 'T', '5');
         break;
 
+      case d3d9::D3DFMT_YUY2:
+        tformat.dwFlags = DDPF_FOURCC;
+        tformat.dwFourCC = MAKEFOURCC('Y', 'U', 'Y', '2');
+        break;
+
       default:
       case d3d9::D3DFMT_UNKNOWN:
         Logger::err("GetTextureFormat: Unhandled format");
@@ -392,7 +461,7 @@ namespace dxvk {
     return tformat;
   }
 
-  inline DDPIXELFORMAT GetZBufferFormat (d3d9::D3DFORMAT format) {
+  inline DDPIXELFORMAT GetZBufferFormat(d3d9::D3DFORMAT format) {
     DDPIXELFORMAT zformat = { };
     zformat.dwSize = sizeof(DDPIXELFORMAT);
 
@@ -456,24 +525,6 @@ namespace dxvk {
     return zformat;
   }
 
-  inline d3d9::D3DMULTISAMPLE_TYPE GetSupportedMultiSampleType(d3d9::IDirect3D9* d3d9Intf, d3d9::D3DFORMAT backBufferFormat) {
-    HRESULT hr4S = d3d9Intf->CheckDeviceMultiSampleType(0, d3d9::D3DDEVTYPE_HAL, backBufferFormat,
-                                                        TRUE, d3d9::D3DMULTISAMPLE_4_SAMPLES, NULL);
-    if (likely(SUCCEEDED(hr4S))) {
-      Logger::info("GetSupportedMultiSampleType: Using 4x MSAA for FSAA emulation");
-      return d3d9::D3DMULTISAMPLE_4_SAMPLES;
-    } else {
-      HRESULT hr2S = d3d9Intf->CheckDeviceMultiSampleType(0, d3d9::D3DDEVTYPE_HAL, backBufferFormat,
-                                                          TRUE, d3d9::D3DMULTISAMPLE_2_SAMPLES, NULL);
-      if (likely(SUCCEEDED(hr2S))) {
-        Logger::info("GetSupportedMultiSampleType: Using 2x MSAA for FSAA emulation");
-        return d3d9::D3DMULTISAMPLE_2_SAMPLES;
-      }
-    }
-
-    return d3d9::D3DMULTISAMPLE_NONE;
-  }
-
   template <typename DescType>
   inline HRESULT ValidateSurfaceFlags(DescType* desc) {
     const bool isOffScreenPlainSurface = desc->ddsCaps.dwCaps & DDSCAPS_OFFSCREENPLAIN;
@@ -491,6 +542,22 @@ namespace dxvk {
     }
 
     return DD_OK;
+  }
+
+  inline HRESULT STDMETHODCALLTYPE EnumDisplayModesCallback(DDSURFACEDESC* desc, void* ctx) {
+    auto& displayModes = *static_cast<std::vector<DDSURFACEDESC>*>(ctx);
+
+    displayModes.push_back(*desc);
+
+    return DDENUMRET_OK;
+  }
+
+  inline HRESULT STDMETHODCALLTYPE EnumDisplayModesCallback2(DDSURFACEDESC2* desc, void* ctx) {
+    auto& displayModes = *static_cast<std::vector<DDSURFACEDESC2>*>(ctx);
+
+    displayModes.push_back(*desc);
+
+    return DDENUMRET_OK;
   }
 
   inline HRESULT STDMETHODCALLTYPE ListBackBufferSurfacesCallback(IDirectDrawSurface* subsurf, DDSURFACEDESC* desc, void* ctx) {
@@ -591,31 +658,117 @@ namespace dxvk {
   inline HRESULT STDMETHODCALLTYPE EnumAndAttachCubeMapFacesCallback(IDirectDrawSurface7* subsurf, DDSURFACEDESC2* desc, void* ctx) {
     CubeMapAttachedSurfaces* cubeMapAttachedSurfaces = static_cast<CubeMapAttachedSurfaces*>(ctx);
 
-    // Skip any surface which isn't a cube map face
-    if (unlikely(!IsCubeMapFace(desc)))
-      return DDENUMRET_OK;
+    const DWORD cubeFaceMask = desc->ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP_ALLFACES;
 
-    if (desc->ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP_POSITIVEX) {
-      cubeMapAttachedSurfaces->positiveX = subsurf;
-      return DDENUMRET_OK;
-    } else if (desc->ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP_NEGATIVEX) {
-      cubeMapAttachedSurfaces->negativeX = subsurf;
-      return DDENUMRET_OK;
-    } else if (desc->ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP_POSITIVEY) {
-      cubeMapAttachedSurfaces->positiveY = subsurf;
-      return DDENUMRET_OK;
-    } else if (desc->ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP_NEGATIVEY) {
-      cubeMapAttachedSurfaces->negativeY = subsurf;
-      return DDENUMRET_OK;
-    } else if (desc->ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP_POSITIVEZ) {
-      cubeMapAttachedSurfaces->positiveZ = subsurf;
-      return DDENUMRET_OK;
-    } else if (desc->ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP_NEGATIVEZ) {
-      cubeMapAttachedSurfaces->negativeZ = subsurf;
-      return DDENUMRET_OK;
+    switch (cubeFaceMask) {
+      case DDSCAPS2_CUBEMAP_POSITIVEX:
+        cubeMapAttachedSurfaces->positiveX = subsurf;
+        break;
+      case DDSCAPS2_CUBEMAP_NEGATIVEX:
+        cubeMapAttachedSurfaces->negativeX = subsurf;
+        break;
+      case DDSCAPS2_CUBEMAP_POSITIVEY:
+        cubeMapAttachedSurfaces->positiveY = subsurf;
+        break;
+      case DDSCAPS2_CUBEMAP_NEGATIVEY:
+        cubeMapAttachedSurfaces->negativeY = subsurf;
+        break;
+      case DDSCAPS2_CUBEMAP_POSITIVEZ:
+        cubeMapAttachedSurfaces->positiveZ = subsurf;
+        break;
+      case DDSCAPS2_CUBEMAP_NEGATIVEZ:
+        cubeMapAttachedSurfaces->negativeZ = subsurf;
+        break;
+      default:
+        break;
     }
 
     return DDENUMRET_OK;
+  }
+
+  // We need to count the number of actual mips on surface initialization by going through
+  // the mip chain, since the dwMipMapCount number may or may not be accurate. I am
+  // guessing it was intended more as a hint, not necessarily a set number.
+  template <typename SurfaceType, typename DescType>
+  inline uint16_t DetermineMipMapCount(SurfaceType* surface) {
+    SurfaceType* mipMap = surface;
+    DescType mipDesc;
+    uint16_t mipCount = 1;
+
+    while (mipMap != nullptr) {
+      SurfaceType* parentSurface = mipMap;
+      mipMap = nullptr;
+
+      if constexpr (std::is_same<SurfaceType, IDirectDrawSurface7>::value) {
+        parentSurface->EnumAttachedSurfaces(&mipMap, ListMipChainSurfaces7Callback);
+      } else if constexpr (std::is_same<SurfaceType, IDirectDrawSurface4>::value) {
+        parentSurface->EnumAttachedSurfaces(&mipMap, ListMipChainSurfaces4Callback);
+      } else if constexpr (std::is_same<SurfaceType, IDirectDrawSurface>::value) {
+        parentSurface->EnumAttachedSurfaces(&mipMap, ListMipChainSurfacesCallback);
+      } else {
+        Logger::err("DetermineMipMapCount: Unsupported surface type");
+        break;
+      }
+
+      if (mipMap != nullptr) {
+        mipCount++;
+
+        mipDesc = { };
+        mipDesc.dwSize = sizeof(DescType);
+        mipMap->GetSurfaceDesc(&mipDesc);
+        // Ignore multiple 1x1 mips, which apparently can get generated if the
+        // application gets the dwMipMapCount wrong vs surface dimensions.
+        if (unlikely(mipDesc.dwWidth == 1 && mipDesc.dwHeight == 1))
+          break;
+      }
+    }
+
+    // Don't worry about maximum supported mip map levels validation,
+    // because D3D9 will handle this for us and cap them appropriately
+    if (mipCount > 1) {
+      //Logger::debug(str::format("DetermineMipMapCount: Found ", mipCount, " mip levels"));
+
+      DescType desc;
+      desc.dwSize = sizeof(DescType);
+      surface->GetSurfaceDesc(&desc);
+
+      if (unlikely(mipCount != desc.dwMipMapCount))
+        Logger::debug(str::format("DetermineMipMapCount: Mismatch with declared ", desc.dwMipMapCount, " mip levels"));
+    }
+
+    return mipCount;
+  }
+
+  template <typename SurfaceType>
+  inline DWORD DetermineBackBufferCount(SurfaceType* renderTarget) {
+    DWORD backBufferCount = 0;
+
+    SurfaceType* backBuffer = renderTarget;
+
+    while (backBuffer != nullptr) {
+      SurfaceType* parentSurface = backBuffer;
+      backBuffer = nullptr;
+
+      if constexpr (std::is_same<SurfaceType, IDirectDrawSurface7>::value) {
+        parentSurface->EnumAttachedSurfaces(&backBuffer, ListBackBufferSurfaces7Callback);
+      } else if constexpr (std::is_same<SurfaceType, IDirectDrawSurface4>::value) {
+        parentSurface->EnumAttachedSurfaces(&backBuffer, ListBackBufferSurfaces4Callback);
+      } else if constexpr (std::is_same<SurfaceType, IDirectDrawSurface>::value) {
+        parentSurface->EnumAttachedSurfaces(&backBuffer, ListBackBufferSurfacesCallback);
+      } else {
+        Logger::err("DetermineBackBufferCount: Unsupported surface type");
+        break;
+      }
+
+      // The swapchain will eventually return to its origin
+      if (backBuffer == renderTarget)
+        break;
+
+      if (likely(backBuffer != nullptr))
+        backBufferCount++;
+    }
+
+    return std::max<DWORD>(1u, backBufferCount);
   }
 
   inline void BlitToD3D9CubeMap(
@@ -628,14 +781,9 @@ namespace dxvk {
     surface->GetSurfaceDesc(&desc);
     const d3d9::D3DCUBEMAP_FACES face = GetCubemapFace(&desc);
     IDirectDrawSurface7* mipMap = surface;
+    IDirectDrawSurface7* parentSurface;
 
     for (uint16_t i = 0; i < mipLevels; i++) {
-      // Should never occur normally, but acts as a last ditch safety check
-      if (unlikely(mipMap == nullptr)) {
-        Logger::warn(str::format("BlitToD3D9CubeMap: Last found source mip ", i - 1));
-        break;
-      }
-
       d3d9::D3DLOCKED_RECT rect9mip;
       // D3DLOCK_DISCARD will get ignored for MANAGED/SYSTEMMEM, but will work on DEFAULT
       HRESULT hr9 = cubeTex9->LockRect(face, i, &rect9mip, NULL, D3DLOCK_DISCARD);
@@ -656,9 +804,11 @@ namespace dxvk {
             uint8_t* data7 = reinterpret_cast<uint8_t*>(descMip.lpSurface);
 
             const size_t copyPitch = std::min<size_t>(descMip.lPitch, rect9mip.Pitch);
-            for (uint32_t h = 0; h < descMip.dwHeight; h++)
-              memcpy(&data9[h * rect9mip.Pitch], &data7[h * descMip.lPitch], copyPitch);
-
+            for (uint32_t h = 0; h < descMip.dwHeight; h++) {
+              memcpy(data9, data7, copyPitch);
+              data9 += rect9mip.Pitch;
+              data7 += descMip.lPitch;
+            }
             //Logger::debug(str::format("BlitToD3D9CubeMap: Done blitting mip ", i, " row by row"));
           } else {
             const size_t size = static_cast<size_t>(descMip.dwHeight * descMip.lPitch);
@@ -670,13 +820,14 @@ namespace dxvk {
           Logger::warn(str::format("BlitToD3D9CubeMap: Failed to lock mip ", i));
         }
         cubeTex9->UnlockRect(face, i);
-
-        IDirectDrawSurface7* parentSurface = mipMap;
-        mipMap = nullptr;
-
-        parentSurface->EnumAttachedSurfaces(&mipMap, ListMipChainSurfaces7Callback);
       } else {
         Logger::warn(str::format("BlitToD3D9CubeMap: Failed to lock D3D9 mip ", i));
+      }
+
+      // Skip the enumeration if we've reached the final mip
+      if (likely(i < mipLevels - 1)) {
+        parentSurface = mipMap;
+        parentSurface->EnumAttachedSurfaces(&mipMap, ListMipChainSurfaces7Callback);
       }
     }
   }
@@ -688,14 +839,9 @@ namespace dxvk {
         const uint16_t mipLevels,
         const bool isDXTFormat) {
     SurfaceType* mipMap = surface;
+    SurfaceType* parentSurface;
 
     for (uint16_t i = 0; i < mipLevels; i++) {
-      // Should never occur normally, but acts as a last ditch safety check
-      if (unlikely(mipMap == nullptr)) {
-        Logger::warn(str::format("BlitToD3D9Texture: Last found source mip ", i - 1));
-        break;
-      }
-
       d3d9::D3DLOCKED_RECT rect9mip;
       // D3DLOCK_DISCARD will get ignored for MANAGED/SYSTEMMEM, but will work on DEFAULT
       HRESULT hr9 = texture9->LockRect(i, &rect9mip, NULL, D3DLOCK_DISCARD);
@@ -716,9 +862,11 @@ namespace dxvk {
             uint8_t* data7 = reinterpret_cast<uint8_t*>(descMip.lpSurface);
 
             const size_t copyPitch = std::min<size_t>(descMip.lPitch, rect9mip.Pitch);
-            for (uint32_t h = 0; h < descMip.dwHeight; h++)
-              memcpy(&data9[h * rect9mip.Pitch], &data7[h * descMip.lPitch], copyPitch);
-
+            for (uint32_t h = 0; h < descMip.dwHeight; h++) {
+              memcpy(data9, data7, copyPitch);
+              data9 += rect9mip.Pitch;
+              data7 += descMip.lPitch;
+            }
             //Logger::debug(str::format("BlitToD3D9Texture: Done blitting mip ", i, " row by row"));
           } else {
             const size_t size = static_cast<size_t>(descMip.dwHeight * descMip.lPitch);
@@ -730,10 +878,13 @@ namespace dxvk {
           Logger::warn(str::format("BlitToD3D9Texture: Failed to lock mip ", i));
         }
         texture9->UnlockRect(i);
+      } else {
+        Logger::warn(str::format("BlitToD3D9Texture: Failed to lock D3D9 mip ", i));
+      }
 
-        SurfaceType* parentSurface = mipMap;
-        mipMap = nullptr;
-
+      // Skip the enumeration if we've reached the final mip
+      if (likely(i < mipLevels - 1)) {
+        parentSurface = mipMap;
         if constexpr (std::is_same<SurfaceType, IDirectDrawSurface7>::value) {
           parentSurface->EnumAttachedSurfaces(&mipMap, ListMipChainSurfaces7Callback);
         } else if constexpr (std::is_same<SurfaceType, IDirectDrawSurface4>::value) {
@@ -742,9 +893,8 @@ namespace dxvk {
           parentSurface->EnumAttachedSurfaces(&mipMap, ListMipChainSurfacesCallback);
         } else {
           Logger::err("BlitToD3D9Texture: Unsupported surface type");
+          break;
         }
-      } else {
-        Logger::warn(str::format("BlitToD3D9Texture: Failed to lock D3D9 mip ", i));
       }
     }
   }
@@ -774,9 +924,11 @@ namespace dxvk {
           uint8_t* data7 = reinterpret_cast<uint8_t*>(desc.lpSurface);
 
           const size_t copyPitch = std::min<size_t>(desc.lPitch, rect9.Pitch);
-          for (uint32_t h = 0; h < desc.dwHeight; h++)
-            memcpy(&data9[h * rect9.Pitch], &data7[h * desc.lPitch], copyPitch);
-
+          for (uint32_t h = 0; h < desc.dwHeight; h++) {
+            memcpy(data9, data7, copyPitch);
+            data9 += rect9.Pitch;
+            data7 += desc.lPitch;
+          }
           //Logger::debug("BlitToD3D9Surface: Done blitting surface row by row");
         } else {
           const size_t size = static_cast<size_t>(desc.dwHeight * desc.lPitch);
@@ -817,9 +969,11 @@ namespace dxvk {
           uint8_t* data9 = reinterpret_cast<uint8_t*>(rect9.pBits);
 
           const size_t copyPitch = std::min<size_t>(desc.lPitch, rect9.Pitch);
-          for (uint32_t h = 0; h < desc.dwHeight; h++)
-            memcpy(&data7[h * desc.lPitch], &data9[h * rect9.Pitch], copyPitch);
-
+          for (uint32_t h = 0; h < desc.dwHeight; h++) {
+            memcpy(data7, data9, copyPitch);
+            data7 += desc.lPitch;
+            data9 += rect9.Pitch;
+          }
           //Logger::debug("BlitToDDrawSurface: Done blitting surface row by row");
         } else {
           const size_t size = static_cast<size_t>(desc.dwHeight * desc.lPitch);
@@ -866,7 +1020,7 @@ namespace dxvk {
   inline DDCOLORKEY ColorKeyToARGB(const DDPIXELFORMAT* fmt, DWORD colorKey) {
     DDCOLORKEY rgbColorKey = { };
 
-    if (unlikely(!(fmt->dwFlags & DDPF_RGB)))
+    if (unlikely(fmt == nullptr || !(fmt->dwFlags & DDPF_RGB)))
       return rgbColorKey;
 
     DDCOLORKEY b = GetColorChannel(colorKey, fmt->dwBBitMask);

--- a/src/ddraw/ddraw_gamma.cpp
+++ b/src/ddraw/ddraw_gamma.cpp
@@ -10,11 +10,9 @@ namespace dxvk {
         IUnknown* pParent)
     : DDrawWrappedObject<IUnknown, IDirectDrawGammaControl>(pParent, std::move(proxyGamma))
     , m_commonSurf ( commonSurf ) {
-    Logger::debug("DDrawGammaControl: Created a new gamma control interface");
   }
 
   DDrawGammaControl::~DDrawGammaControl() {
-    Logger::debug("DDrawGammaControl: A gamma control interface bites the dust");
   }
 
   HRESULT STDMETHODCALLTYPE DDrawGammaControl::QueryInterface(REFIID riid, void** ppvObject) {

--- a/src/ddraw/ddraw_include.h
+++ b/src/ddraw/ddraw_include.h
@@ -161,6 +161,11 @@ __CRT_UUID_DECL(d3d9::IDirect3DDevice9Ex,          0xB18B10CE, 0x2649, 0x405A, 0
   #define DLLEXPORT
 #endif
 
+// Don't use any SSE2 specific paths when compiling for ARM(64)
+#if !defined(_ARM_) && !defined(_M_ARM)
+  #define DXVK_SWVP_SSE2 TRUE
+#endif
+
 
 #include "../util/com/com_guid.h"
 #include "../util/com/com_object.h"

--- a/src/ddraw/ddraw_main.cpp
+++ b/src/ddraw/ddraw_main.cpp
@@ -68,6 +68,13 @@ namespace dxvk {
       }
     }
 
+#ifdef DXVK_SWVP_SSE2
+    static bool s_sse2InfoShown;
+
+    if (!std::exchange(s_sse2InfoShown, true))
+      Logger::info("D7VK: Using SSE2 optimizations for SWVP");
+#endif
+
     return hDDraw;
   }
 

--- a/src/ddraw/ddraw_options.cpp
+++ b/src/ddraw/ddraw_options.cpp
@@ -16,7 +16,6 @@ namespace dxvk {
     this->viewportZCorrection    = config.getOption<bool>   ("ddraw.viewportZCorrection",    false);
     this->forceLegacyDiscard     = config.getOption<bool>   ("ddraw.forceLegacyDiscard",     false);
     this->cpuProcessVertices     = config.getOption<bool>   ("ddraw.cpuProcessVertices",      true);
-    this->vertexOffset           = config.getOption<float>  ("ddraw.vertexOffset",            0.0f);
     this->backBufferResize       = config.getOption<bool>   ("ddraw.backBufferResize",        true);
     this->forceLegacyPresent     = config.getOption<bool>   ("ddraw.forceLegacyPresent",     false);
     this->forceRTFlip            = config.getOption<bool>   ("ddraw.forceRTFlip",            false);
@@ -31,8 +30,14 @@ namespace dxvk {
     this->robustTextureLifeCycle = config.getOption<bool>   ("ddraw.robustTextureLifeCycle", false);
     this->apitraceMode           = config.getOption<bool>   ("ddraw.apitraceMode",           false);
 
-    // Clamp the vertex offset in the (sensible) -1.0f/1.0f range
-    this->vertexOffset = dxvk::fclamp(this->vertexOffset, -1.0f, 1.0f);
+    std::string alternatePixelCenterStr = Config::toLower(config.getOption<std::string>("ddraw.alternatePixelCenter", "false"));
+    if (alternatePixelCenterStr == "true") {
+      this->alternatePixelCenter = AlternatePixelCenter::Disabled; // Unsupported in DXVK-Sarek
+    } else if (alternatePixelCenterStr == "legacy") {
+      this->alternatePixelCenter = AlternatePixelCenter::Legacy;
+    } else {
+      this->alternatePixelCenter = AlternatePixelCenter::Disabled;
+    }
 
     std::string legacyPresentGuardStr = Config::toLower(config.getOption<std::string>("ddraw.legacyPresentGuard", "auto"));
     if (legacyPresentGuardStr == "strict") {
@@ -44,7 +49,9 @@ namespace dxvk {
     }
 
     std::string emulateFSAAStr = Config::toLower(config.getOption<std::string>("ddraw.emulateFSAA", "false"));
-    if (emulateFSAAStr == "forced") {
+    if (emulateFSAAStr == "true") {
+      this->emulateFSAA = FSAAEmulation::Disabled; // Unsupported in DXVK-Sarek
+    } else if (emulateFSAAStr == "forced") {
       this->emulateFSAA = FSAAEmulation::Forced;
     } else {
       this->emulateFSAA = FSAAEmulation::Disabled;

--- a/src/ddraw/ddraw_options.h
+++ b/src/ddraw/ddraw_options.h
@@ -7,15 +7,22 @@
 
 namespace dxvk {
 
-  enum class FSAAEmulation {
+  enum class AlternatePixelCenter {
     Disabled,
-    Forced
+    Enabled,
+    Legacy
   };
 
   enum class D3DLegacyPresentGuard {
     Auto,
     Disabled,
     Strict
+  };
+
+  enum class FSAAEmulation {
+    Disabled,
+    Enabled,
+    Forced
   };
 
   struct D3DOptions {
@@ -60,9 +67,6 @@ namespace dxvk {
     /// Process vertices on the CPU, instead of relaying to D3D9
     bool cpuProcessVertices;
 
-    /// Correction offset for X/Y vertex position
-    float vertexOffset;
-
     /// Resize the back buffer size to screen size when needed
     bool backBufferResize;
 
@@ -101,6 +105,9 @@ namespace dxvk {
 
     /// Extends features and relaxes validations to enable apitrace debugging
     bool apitraceMode;
+
+    /// Half-texel correction offset for X/Y vertex position
+    AlternatePixelCenter alternatePixelCenter;
 
     /// By default guards against legacy presents while inside of a scene
     D3DLegacyPresentGuard legacyPresentGuard;

--- a/src/ddraw/ddraw_palette.cpp
+++ b/src/ddraw/ddraw_palette.cpp
@@ -4,18 +4,12 @@
 
 namespace dxvk {
 
-  std::atomic<uint32_t> DDrawPalette::s_paletteCount = 0;
-
   DDrawPalette::DDrawPalette(
         Com<IDirectDrawPalette>&& paletteProxy,
         IUnknown* pParent)
     : DDrawWrappedObject<IUnknown, IDirectDrawPalette>(pParent, std::move(paletteProxy)) {
     if (m_parent != nullptr)
       m_parent->AddRef();
-
-    m_paletteCount = ++s_paletteCount;
-
-    Logger::debug(str::format("DDrawPalette: Created a new palette nr. [[1-", m_paletteCount, "]]"));
   }
 
   DDrawPalette::~DDrawPalette() {
@@ -24,8 +18,6 @@ namespace dxvk {
 
     if (m_parent != nullptr)
       m_parent->Release();
-
-    Logger::debug(str::format("DDrawPalette: Palette nr. [[1-", m_paletteCount, "]] bites the dust"));
   }
 
   HRESULT STDMETHODCALLTYPE DDrawPalette::QueryInterface(REFIID riid, void** ppvObject) {

--- a/src/ddraw/ddraw_palette.h
+++ b/src/ddraw/ddraw_palette.h
@@ -35,9 +35,6 @@ namespace dxvk {
 
     DDrawCommonSurface* m_commonSurf   = nullptr;
 
-    uint32_t            m_paletteCount = 0;
-    static std::atomic<uint32_t> s_paletteCount;
-
   };
 
 }

--- a/src/ddraw/ddraw_util.h
+++ b/src/ddraw/ddraw_util.h
@@ -12,8 +12,8 @@
 namespace dxvk {
 
   struct PackedVertexBuffer {
-    std::vector<uint8_t> vertexData;
     UINT stride;
+    std::vector<uint8_t> vertexData;
   };
 
   struct VertexStreamInfo {
@@ -340,7 +340,7 @@ namespace dxvk {
 
   inline DWORD DecodeD3D7TexFilterValues(const D3DTEXTURESTAGESTATETYPE StageType, const DWORD FilterType7) {
     switch (StageType) {
-      case D3DTSS_MAGFILTER: {
+      case D3DTSS_MAGFILTER:
         switch (FilterType7) {
           default:
           case D3DTFG_POINT:          return d3d9::D3DTEXF_POINT;
@@ -349,8 +349,7 @@ namespace dxvk {
           case D3DTFG_ANISOTROPIC:    return d3d9::D3DTEXF_ANISOTROPIC;
         }
         break;
-      }
-      case D3DTSS_MINFILTER: {
+      case D3DTSS_MINFILTER:
         switch (FilterType7) {
           default:
           case D3DTFN_POINT:          return d3d9::D3DTEXF_POINT;
@@ -358,8 +357,7 @@ namespace dxvk {
           case D3DTFN_ANISOTROPIC:    return d3d9::D3DTEXF_ANISOTROPIC;
         }
         break;
-      }
-      case D3DTSS_MIPFILTER: {
+      case D3DTSS_MIPFILTER:
         switch (FilterType7) {
           // All values in D3DTEXTUREMIPFILTER are offset by +1
           // vs D3DTEXTUREFILTERTYPE...
@@ -369,14 +367,13 @@ namespace dxvk {
           case D3DTFP_LINEAR:         return d3d9::D3DTEXF_LINEAR;
         }
         break;
-      }
       default: return 0;
     }
   }
 
   inline DWORD DecodeD3D9TexFilterValues(const D3DTEXTURESTAGESTATETYPE StageType, const DWORD FilterType9) {
     switch (StageType) {
-      case D3DTSS_MAGFILTER: {
+      case D3DTSS_MAGFILTER:
         switch (FilterType9) {
           default:
           case d3d9::D3DTEXF_POINT:       return D3DTFG_POINT;
@@ -385,8 +382,7 @@ namespace dxvk {
           case d3d9::D3DTEXF_ANISOTROPIC: return D3DTFG_ANISOTROPIC;
         }
         break;
-      }
-      case D3DTSS_MINFILTER: {
+      case D3DTSS_MINFILTER:
         switch (FilterType9) {
           default:
           case d3d9::D3DTEXF_POINT:       return D3DTFN_POINT;
@@ -394,8 +390,7 @@ namespace dxvk {
           case d3d9::D3DTEXF_ANISOTROPIC: return D3DTFN_ANISOTROPIC;
         }
         break;
-      }
-      case D3DTSS_MIPFILTER: {
+      case D3DTSS_MIPFILTER:
         switch (FilterType9) {
           // All values in D3DTEXTUREMIPFILTER are offset by +1
           // vs D3DTEXTUREFILTERTYPE...
@@ -405,28 +400,30 @@ namespace dxvk {
           case d3d9::D3DTEXF_LINEAR:      return D3DTFP_LINEAR;
         }
         break;
-      }
       default: return 0;
     }
   }
 
   inline DWORD DecodeTextureMinValues(DWORD minFilter, DWORD mipFilter) {
-    if (minFilter == d3d9::D3DTEXF_POINT) {
-      switch(mipFilter) {
-        default:
-        case d3d9::D3DTEXF_NONE:   return D3DFILTER_NEAREST;
-        case d3d9::D3DTEXF_POINT:  return D3DFILTER_MIPNEAREST;
-        case d3d9::D3DTEXF_LINEAR: return D3DFILTER_LINEARMIPNEAREST;
-      }
-    } else if (minFilter == d3d9::D3DTEXF_LINEAR) {
-      switch(mipFilter) {
-        default:
-        case d3d9::D3DTEXF_NONE:   return D3DFILTER_LINEAR;
-        case d3d9::D3DTEXF_POINT:  return D3DFILTER_MIPLINEAR;
-        case d3d9::D3DTEXF_LINEAR: return D3DFILTER_LINEARMIPLINEAR;
-      }
+    switch (minFilter) {
+      case d3d9::D3DTEXF_POINT:
+        switch (mipFilter) {
+          default:
+          case d3d9::D3DTEXF_NONE:   return D3DFILTER_NEAREST;
+          case d3d9::D3DTEXF_POINT:  return D3DFILTER_MIPNEAREST;
+          case d3d9::D3DTEXF_LINEAR: return D3DFILTER_LINEARMIPNEAREST;
+        }
+        break;
+      case d3d9::D3DTEXF_LINEAR:
+        switch (mipFilter) {
+          default:
+          case d3d9::D3DTEXF_NONE:   return D3DFILTER_LINEAR;
+          case d3d9::D3DTEXF_POINT:  return D3DFILTER_MIPLINEAR;
+          case d3d9::D3DTEXF_LINEAR: return D3DFILTER_LINEARMIPLINEAR;
+        }
+        break;
+      default: return 0;
     }
-    return 0;
   }
 
   inline HRESULT ValidateViewportRT(
@@ -450,7 +447,7 @@ namespace dxvk {
     return D3D_OK;
   }
 
-  inline D3DDEVICEDESC3 GetD3D3Caps(const IID rclsid, const D3DOptions* options) {
+  inline D3DDEVICEDESC3 GetD3D3BaseCaps(const D3DOptions* options) {
     D3DDEVICEDESC3 desc;
 
     desc.dwSize    = sizeof(D3DDEVICEDESC3);
@@ -479,14 +476,6 @@ namespace dxvk {
                    | D3DDEVCAPS_TEXTUREVIDEOMEMORY
                    | D3DDEVCAPS_TLVERTEXSYSTEMMEMORY
                    | D3DDEVCAPS_TLVERTEXVIDEOMEMORY;
-
-    // Also advertised in D3D3
-    if (rclsid == IID_IDirect3DHALDevice) {
-      desc.dwDevCaps |= D3DDEVCAPS_HWRASTERIZATION
-                      | D3DDEVCAPS_HWTRANSFORMANDLIGHT
-                      | D3DDEVCAPS_DRAWPRIMITIVES2
-                      | D3DDEVCAPS_DRAWPRIMITIVES2EX;
-    }
 
     D3DTRANSFORMCAPS transformCaps;
     transformCaps.dwSize = sizeof(D3DTRANSFORMCAPS);
@@ -620,7 +609,21 @@ namespace dxvk {
     return desc;
   }
 
-  inline D3DDEVICEDESC2 GetD3D5Caps(const IID rclsid, const D3DOptions* options) {
+  inline void ApplyD3D3DeviceCaps(D3DDEVICEDESC3* desc, const IID rclsid) {
+    if (rclsid == IID_IDirect3DHALDevice) {
+      desc->dwDevCaps |= D3DDEVCAPS_HWRASTERIZATION
+                       | D3DDEVCAPS_HWTRANSFORMANDLIGHT
+                       | D3DDEVCAPS_DRAWPRIMITIVES2
+                       | D3DDEVCAPS_DRAWPRIMITIVES2EX;
+    } else {
+      desc->dwDevCaps &= ~D3DDEVCAPS_HWRASTERIZATION
+                       & ~D3DDEVCAPS_HWTRANSFORMANDLIGHT
+                       & ~D3DDEVCAPS_DRAWPRIMITIVES2
+                       & ~D3DDEVCAPS_DRAWPRIMITIVES2EX;
+    }
+  }
+
+  inline D3DDEVICEDESC2 GetD3D5BaseCaps(const D3DOptions* options) {
     D3DDEVICEDESC2 desc;
 
     desc.dwSize    = sizeof(D3DDEVICEDESC2);
@@ -657,14 +660,6 @@ namespace dxvk {
     // Powerslide uses a broken rendering path if non-local video memory is advertized
     if (likely(options->nonLocalVideoMemory)) {
       desc.dwDevCaps |= D3DDEVCAPS_TEXTURENONLOCALVIDMEM;
-    }
-
-    // Also advertised in D3D5
-    if (rclsid == IID_IDirect3DHALDevice) {
-      desc.dwDevCaps |= D3DDEVCAPS_HWRASTERIZATION
-                      | D3DDEVCAPS_HWTRANSFORMANDLIGHT
-                      | D3DDEVCAPS_DRAWPRIMITIVES2
-                      | D3DDEVCAPS_DRAWPRIMITIVES2EX;
     }
 
     D3DTRANSFORMCAPS transformCaps;
@@ -825,7 +820,21 @@ namespace dxvk {
     return desc;
   }
 
-  inline D3DDEVICEDESC GetD3D6Caps(const IID rclsid, const D3DOptions* options) {
+  inline void ApplyD3D5DeviceCaps(D3DDEVICEDESC2* desc, const IID rclsid) {
+    if (rclsid == IID_IDirect3DHALDevice) {
+      desc->dwDevCaps |= D3DDEVCAPS_HWRASTERIZATION
+                       | D3DDEVCAPS_HWTRANSFORMANDLIGHT
+                       | D3DDEVCAPS_DRAWPRIMITIVES2
+                       | D3DDEVCAPS_DRAWPRIMITIVES2EX;
+    } else {
+      desc->dwDevCaps &= ~D3DDEVCAPS_HWRASTERIZATION
+                       & ~D3DDEVCAPS_HWTRANSFORMANDLIGHT
+                       & ~D3DDEVCAPS_DRAWPRIMITIVES2
+                       & ~D3DDEVCAPS_DRAWPRIMITIVES2EX;
+    }
+  }
+
+  inline D3DDEVICEDESC GetD3D6BaseCaps(const D3DOptions* options) {
     D3DDEVICEDESC desc;
 
     desc.dwSize    = sizeof(D3DDEVICEDESC);
@@ -862,14 +871,6 @@ namespace dxvk {
     // Powerslide uses a broken rendering path if non-local video memory is advertized
     if (likely(options->nonLocalVideoMemory)) {
       desc.dwDevCaps |= D3DDEVCAPS_TEXTURENONLOCALVIDMEM;
-    }
-
-    // Also advertised in D3D6
-    if (rclsid == IID_IDirect3DHALDevice) {
-      desc.dwDevCaps |= D3DDEVCAPS_HWRASTERIZATION
-                      | D3DDEVCAPS_HWTRANSFORMANDLIGHT
-                      | D3DDEVCAPS_DRAWPRIMITIVES2
-                      | D3DDEVCAPS_DRAWPRIMITIVES2EX;
     }
 
     D3DTRANSFORMCAPS transformCaps;
@@ -1090,7 +1091,21 @@ namespace dxvk {
     return desc;
   }
 
-  inline D3DDEVICEDESC7 GetD3D7Caps(const IID rclsid, const D3DOptions* options) {
+  inline void ApplyD3D6DeviceCaps(D3DDEVICEDESC* desc, const IID rclsid) {
+    if (rclsid == IID_IDirect3DHALDevice) {
+      desc->dwDevCaps |= D3DDEVCAPS_HWRASTERIZATION
+                       | D3DDEVCAPS_HWTRANSFORMANDLIGHT
+                       | D3DDEVCAPS_DRAWPRIMITIVES2
+                       | D3DDEVCAPS_DRAWPRIMITIVES2EX;
+    } else {
+      desc->dwDevCaps &= ~D3DDEVCAPS_HWRASTERIZATION
+                       & ~D3DDEVCAPS_HWTRANSFORMANDLIGHT
+                       & ~D3DDEVCAPS_DRAWPRIMITIVES2
+                       & ~D3DDEVCAPS_DRAWPRIMITIVES2EX;
+    }
+  }
+
+  inline D3DDEVICEDESC7 GetD3D7BaseCaps(const D3DOptions* options) {
     D3DDEVICEDESC7 desc7;
 
     desc7.dwDevCaps = D3DDEVCAPS_CANBLTSYSTONONLOCAL
@@ -1107,7 +1122,6 @@ namespace dxvk {
                  // | D3DDEVCAPS_SORTDECREASINGZ
                  // | D3DDEVCAPS_SORTEXACT
                  // | D3DDEVCAPS_SORTINCREASINGZ
-                 // | D3DDEVCAPS_STRIDEDVERTICES // Mentioned in the docs, but apparently is a ghost
                  // | D3DDEVCAPS_TEXTURENONLOCALVIDMEM // Exposed through a config option
                  // | D3DDEVCAPS_TEXTURESYSTEMMEMORY
                     | D3DDEVCAPS_TEXTUREVIDEOMEMORY
@@ -1117,18 +1131,6 @@ namespace dxvk {
     // Powerslide uses a broken rendering path if non-local video memory is advertized
     if (likely(options->nonLocalVideoMemory)) {
       desc7.dwDevCaps |= D3DDEVCAPS_TEXTURENONLOCALVIDMEM;
-    }
-
-    if (rclsid == IID_IDirect3DTnLHalDevice) {
-      desc7.dwDevCaps |= D3DDEVCAPS_HWRASTERIZATION
-                       | D3DDEVCAPS_HWTRANSFORMANDLIGHT
-                       | D3DDEVCAPS_DRAWPRIMITIVES2
-                       | D3DDEVCAPS_DRAWPRIMITIVES2EX;
-    }
-    else if (rclsid == IID_IDirect3DHALDevice) {
-      desc7.dwDevCaps |= D3DDEVCAPS_HWRASTERIZATION
-                       | D3DDEVCAPS_DRAWPRIMITIVES2
-                       | D3DDEVCAPS_DRAWPRIMITIVES2EX;
     }
 
     D3DPRIMCAPS prim;
@@ -1328,7 +1330,7 @@ namespace dxvk {
     desc7.dwMaxActiveLights        = ddrawCaps::MaxEnabledLights;
     desc7.dvMaxVertexW             = 1e10f;
 
-    desc7.deviceGUID               = rclsid;
+    desc7.deviceGUID               = GUID_NULL;
 
     desc7.wMaxUserClipPlanes       = ddrawCaps::MaxClipPlanes;
     desc7.wMaxVertexBlendMatrices  = 4;
@@ -1348,333 +1350,24 @@ namespace dxvk {
     return desc7;
   }
 
-  inline bool IsValidD3D3RenderStateType(D3DRENDERSTATETYPE rs) {
-    return rs == D3DRENDERSTATE_TEXTUREHANDLE
-        || rs == D3DRENDERSTATE_ANTIALIAS
-        || rs == D3DRENDERSTATE_TEXTUREADDRESS
-        || rs == D3DRENDERSTATE_TEXTUREPERSPECTIVE
-        || rs == D3DRENDERSTATE_WRAPU
-        || rs == D3DRENDERSTATE_WRAPV
-        || rs == D3DRENDERSTATE_ZENABLE
-        || rs == D3DRENDERSTATE_FILLMODE
-        || rs == D3DRENDERSTATE_SHADEMODE
-        || rs == D3DRENDERSTATE_LINEPATTERN
-        || rs == D3DRENDERSTATE_MONOENABLE
-        || rs == D3DRENDERSTATE_ROP2
-        || rs == D3DRENDERSTATE_PLANEMASK
-        || rs == D3DRENDERSTATE_ZWRITEENABLE
-        || rs == D3DRENDERSTATE_ALPHATESTENABLE
-        || rs == D3DRENDERSTATE_LASTPIXEL
-        || rs == D3DRENDERSTATE_TEXTUREMAG
-        || rs == D3DRENDERSTATE_TEXTUREMIN
-        || rs == D3DRENDERSTATE_SRCBLEND
-        || rs == D3DRENDERSTATE_DESTBLEND
-        || rs == D3DRENDERSTATE_TEXTUREMAPBLEND
-        || rs == D3DRENDERSTATE_CULLMODE
-        || rs == D3DRENDERSTATE_ZFUNC
-        || rs == D3DRENDERSTATE_ALPHAREF
-        || rs == D3DRENDERSTATE_ALPHAFUNC
-        || rs == D3DRENDERSTATE_DITHERENABLE
-        || rs == D3DRENDERSTATE_BLENDENABLE // The actual D3DRENDERSTATE_ALPHABLENDENABLE
-        || rs == D3DRENDERSTATE_FOGENABLE
-        || rs == D3DRENDERSTATE_SPECULARENABLE
-        || rs == D3DRENDERSTATE_ZVISIBLE
-        || rs == D3DRENDERSTATE_SUBPIXEL
-        || rs == D3DRENDERSTATE_SUBPIXELX
-        || rs == D3DRENDERSTATE_STIPPLEDALPHA
-        || rs == D3DRENDERSTATE_FOGCOLOR
-        || rs == D3DRENDERSTATE_FOGTABLEMODE
-        || rs == D3DRENDERSTATE_FOGTABLESTART
-        || rs == D3DRENDERSTATE_FOGTABLEEND
-        || rs == D3DRENDERSTATE_FOGTABLEDENSITY
-        || rs == D3DRENDERSTATE_STIPPLEENABLE
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN00
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN01
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN02
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN03
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN04
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN05
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN06
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN07
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN08
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN09
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN10
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN11
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN12
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN13
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN14
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN15
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN16
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN17
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN18
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN19
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN20
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN21
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN22
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN23
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN24
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN25
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN26
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN27
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN28
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN29
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN30
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN31;
-  }
+  inline void ApplyD3D7DeviceCaps(D3DDEVICEDESC7* desc7, const IID rclsid) {
+    desc7->deviceGUID = rclsid;
 
-  inline bool IsValidD3D5RenderStateType(D3DRENDERSTATETYPE rs) {
-    return rs == D3DRENDERSTATE_TEXTUREHANDLE
-        || rs == D3DRENDERSTATE_ANTIALIAS
-        || rs == D3DRENDERSTATE_TEXTUREADDRESS
-        || rs == D3DRENDERSTATE_TEXTUREPERSPECTIVE
-        || rs == D3DRENDERSTATE_WRAPU
-        || rs == D3DRENDERSTATE_WRAPV
-        || rs == D3DRENDERSTATE_ZENABLE
-        || rs == D3DRENDERSTATE_FILLMODE
-        || rs == D3DRENDERSTATE_SHADEMODE
-        || rs == D3DRENDERSTATE_LINEPATTERN
-        || rs == D3DRENDERSTATE_MONOENABLE
-        || rs == D3DRENDERSTATE_ROP2
-        || rs == D3DRENDERSTATE_PLANEMASK
-        || rs == D3DRENDERSTATE_ZWRITEENABLE
-        || rs == D3DRENDERSTATE_ALPHATESTENABLE
-        || rs == D3DRENDERSTATE_LASTPIXEL
-        || rs == D3DRENDERSTATE_TEXTUREMAG
-        || rs == D3DRENDERSTATE_TEXTUREMIN
-        || rs == D3DRENDERSTATE_SRCBLEND
-        || rs == D3DRENDERSTATE_DESTBLEND
-        || rs == D3DRENDERSTATE_TEXTUREMAPBLEND
-        || rs == D3DRENDERSTATE_CULLMODE
-        || rs == D3DRENDERSTATE_ZFUNC
-        || rs == D3DRENDERSTATE_ALPHAREF
-        || rs == D3DRENDERSTATE_ALPHAFUNC
-        || rs == D3DRENDERSTATE_DITHERENABLE
-        || rs == D3DRENDERSTATE_BLENDENABLE // The actual D3DRENDERSTATE_ALPHABLENDENABLE
-        || rs == D3DRENDERSTATE_FOGENABLE
-        || rs == D3DRENDERSTATE_SPECULARENABLE
-        || rs == D3DRENDERSTATE_ZVISIBLE
-        || rs == D3DRENDERSTATE_SUBPIXEL
-        || rs == D3DRENDERSTATE_SUBPIXELX
-        || rs == D3DRENDERSTATE_STIPPLEDALPHA
-        || rs == D3DRENDERSTATE_FOGCOLOR
-        || rs == D3DRENDERSTATE_FOGTABLEMODE
-        || rs == D3DRENDERSTATE_FOGTABLESTART
-        || rs == D3DRENDERSTATE_FOGTABLEEND
-        || rs == D3DRENDERSTATE_FOGTABLEDENSITY
-        || rs == D3DRENDERSTATE_STIPPLEENABLE
-        || rs == D3DRENDERSTATE_EDGEANTIALIAS
-        || rs == D3DRENDERSTATE_COLORKEYENABLE
-        || rs == D3DRENDERSTATE_ALPHABLENDENABLE_OLD // Deprecated in D3D6
-        || rs == D3DRENDERSTATE_BORDERCOLOR
-        || rs == D3DRENDERSTATE_TEXTUREADDRESSU
-        || rs == D3DRENDERSTATE_TEXTUREADDRESSV
-        || rs == D3DRENDERSTATE_MIPMAPLODBIAS
-        || rs == D3DRENDERSTATE_ZBIAS
-        || rs == D3DRENDERSTATE_RANGEFOGENABLE
-        || rs == D3DRENDERSTATE_ANISOTROPY
-        || rs == D3DRENDERSTATE_FLUSHBATCH // Not in the docs, but valid in D3D5
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN00
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN01
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN02
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN03
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN04
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN05
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN06
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN07
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN08
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN09
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN10
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN11
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN12
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN13
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN14
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN15
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN16
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN17
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN18
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN19
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN20
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN21
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN22
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN23
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN24
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN25
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN26
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN27
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN28
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN29
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN30
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN31;
-  }
-
-  inline bool IsValidD3D6RenderStateType(D3DRENDERSTATETYPE rs) {
-    return rs == D3DRENDERSTATE_TEXTUREHANDLE
-        || rs == D3DRENDERSTATE_ANTIALIAS
-        || rs == D3DRENDERSTATE_TEXTUREADDRESS
-        || rs == D3DRENDERSTATE_TEXTUREPERSPECTIVE
-        || rs == D3DRENDERSTATE_WRAPU
-        || rs == D3DRENDERSTATE_WRAPV
-        || rs == D3DRENDERSTATE_ZENABLE
-        || rs == D3DRENDERSTATE_FILLMODE
-        || rs == D3DRENDERSTATE_SHADEMODE
-        || rs == D3DRENDERSTATE_LINEPATTERN
-        || rs == D3DRENDERSTATE_MONOENABLE
-        || rs == D3DRENDERSTATE_ROP2
-        || rs == D3DRENDERSTATE_PLANEMASK
-        || rs == D3DRENDERSTATE_ZWRITEENABLE
-        || rs == D3DRENDERSTATE_ALPHATESTENABLE
-        || rs == D3DRENDERSTATE_LASTPIXEL
-        || rs == D3DRENDERSTATE_TEXTUREMAG
-        || rs == D3DRENDERSTATE_TEXTUREMIN
-        || rs == D3DRENDERSTATE_SRCBLEND
-        || rs == D3DRENDERSTATE_DESTBLEND
-        || rs == D3DRENDERSTATE_TEXTUREMAPBLEND
-        || rs == D3DRENDERSTATE_CULLMODE
-        || rs == D3DRENDERSTATE_ZFUNC
-        || rs == D3DRENDERSTATE_ALPHAREF
-        || rs == D3DRENDERSTATE_ALPHAFUNC
-        || rs == D3DRENDERSTATE_DITHERENABLE
-        || rs == D3DRENDERSTATE_ALPHABLENDENABLE
-        || rs == D3DRENDERSTATE_FOGENABLE
-        || rs == D3DRENDERSTATE_SPECULARENABLE
-        || rs == D3DRENDERSTATE_ZVISIBLE
-        || rs == D3DRENDERSTATE_SUBPIXEL
-        || rs == D3DRENDERSTATE_SUBPIXELX
-        || rs == D3DRENDERSTATE_STIPPLEDALPHA
-        || rs == D3DRENDERSTATE_FOGCOLOR
-        || rs == D3DRENDERSTATE_FOGTABLEMODE
-        || rs == D3DRENDERSTATE_FOGTABLESTART
-        || rs == D3DRENDERSTATE_FOGTABLEEND
-        || rs == D3DRENDERSTATE_FOGTABLEDENSITY
-        || rs == D3DRENDERSTATE_STIPPLEENABLE
-        || rs == D3DRENDERSTATE_EDGEANTIALIAS
-        || rs == D3DRENDERSTATE_COLORKEYENABLE
-        || rs == D3DRENDERSTATE_BORDERCOLOR
-        || rs == D3DRENDERSTATE_TEXTUREADDRESSU
-        || rs == D3DRENDERSTATE_TEXTUREADDRESSV
-        || rs == D3DRENDERSTATE_MIPMAPLODBIAS
-        || rs == D3DRENDERSTATE_ZBIAS
-        || rs == D3DRENDERSTATE_RANGEFOGENABLE
-        || rs == D3DRENDERSTATE_ANISOTROPY
-        || rs == D3DRENDERSTATE_FLUSHBATCH
-        || rs == D3DRENDERSTATE_TRANSLUCENTSORTINDEPENDENT
-        || rs == D3DRENDERSTATE_STENCILENABLE
-        || rs == D3DRENDERSTATE_STENCILFAIL
-        || rs == D3DRENDERSTATE_STENCILZFAIL
-        || rs == D3DRENDERSTATE_STENCILPASS
-        || rs == D3DRENDERSTATE_STENCILFUNC
-        || rs == D3DRENDERSTATE_STENCILREF
-        || rs == D3DRENDERSTATE_STENCILMASK
-        || rs == D3DRENDERSTATE_STENCILWRITEMASK
-        || rs == D3DRENDERSTATE_TEXTUREFACTOR
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN00
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN01
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN02
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN03
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN04
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN05
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN06
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN07
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN08
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN09
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN10
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN11
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN12
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN13
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN14
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN15
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN16
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN17
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN18
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN19
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN20
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN21
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN22
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN23
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN24
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN25
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN26
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN27
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN28
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN29
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN30
-        || rs == D3DRENDERSTATE_STIPPLEPATTERN31
-        || rs == D3DRENDERSTATE_WRAP0
-        || rs == D3DRENDERSTATE_WRAP1
-        || rs == D3DRENDERSTATE_WRAP2
-        || rs == D3DRENDERSTATE_WRAP3
-        || rs == D3DRENDERSTATE_WRAP4
-        || rs == D3DRENDERSTATE_WRAP5
-        || rs == D3DRENDERSTATE_WRAP6
-        || rs == D3DRENDERSTATE_WRAP7;
-  }
-
-  inline bool IsValidD3D7RenderStateType(D3DRENDERSTATETYPE rs) {
-    return rs == D3DRENDERSTATE_ANTIALIAS
-        || rs == D3DRENDERSTATE_TEXTUREPERSPECTIVE
-        || rs == D3DRENDERSTATE_ZENABLE
-        || rs == D3DRENDERSTATE_FILLMODE
-        || rs == D3DRENDERSTATE_SHADEMODE
-        || rs == D3DRENDERSTATE_LINEPATTERN
-        || rs == D3DRENDERSTATE_ZWRITEENABLE
-        || rs == D3DRENDERSTATE_ALPHATESTENABLE
-        || rs == D3DRENDERSTATE_LASTPIXEL
-        || rs == D3DRENDERSTATE_SRCBLEND
-        || rs == D3DRENDERSTATE_DESTBLEND
-        || rs == D3DRENDERSTATE_CULLMODE
-        || rs == D3DRENDERSTATE_ZFUNC
-        || rs == D3DRENDERSTATE_ALPHAREF
-        || rs == D3DRENDERSTATE_ALPHAFUNC
-        || rs == D3DRENDERSTATE_DITHERENABLE
-        || rs == D3DRENDERSTATE_ALPHABLENDENABLE
-        || rs == D3DRENDERSTATE_FOGENABLE
-        || rs == D3DRENDERSTATE_SPECULARENABLE
-        || rs == D3DRENDERSTATE_ZVISIBLE
-        || rs == D3DRENDERSTATE_STIPPLEDALPHA
-        || rs == D3DRENDERSTATE_FOGCOLOR
-        || rs == D3DRENDERSTATE_FOGTABLEMODE
-        || rs == D3DRENDERSTATE_FOGTABLESTART
-        || rs == D3DRENDERSTATE_FOGTABLEEND
-        || rs == D3DRENDERSTATE_FOGTABLEDENSITY
-        || rs == D3DRENDERSTATE_FOGSTART
-        || rs == D3DRENDERSTATE_FOGEND
-        || rs == D3DRENDERSTATE_FOGDENSITY
-        || rs == D3DRENDERSTATE_EDGEANTIALIAS
-        || rs == D3DRENDERSTATE_COLORKEYENABLE
-        || rs == D3DRENDERSTATE_ZBIAS
-        || rs == D3DRENDERSTATE_RANGEFOGENABLE
-        || rs == D3DRENDERSTATE_STENCILENABLE
-        || rs == D3DRENDERSTATE_STENCILFAIL
-        || rs == D3DRENDERSTATE_STENCILZFAIL
-        || rs == D3DRENDERSTATE_STENCILPASS
-        || rs == D3DRENDERSTATE_STENCILFUNC
-        || rs == D3DRENDERSTATE_STENCILREF
-        || rs == D3DRENDERSTATE_STENCILMASK
-        || rs == D3DRENDERSTATE_STENCILWRITEMASK
-        || rs == D3DRENDERSTATE_TEXTUREFACTOR
-        || rs == D3DRENDERSTATE_WRAP0
-        || rs == D3DRENDERSTATE_WRAP1
-        || rs == D3DRENDERSTATE_WRAP2
-        || rs == D3DRENDERSTATE_WRAP3
-        || rs == D3DRENDERSTATE_WRAP4
-        || rs == D3DRENDERSTATE_WRAP5
-        || rs == D3DRENDERSTATE_WRAP6
-        || rs == D3DRENDERSTATE_WRAP7
-        || rs == D3DRENDERSTATE_CLIPPING
-        || rs == D3DRENDERSTATE_LIGHTING
-        || rs == D3DRENDERSTATE_EXTENTS
-        || rs == D3DRENDERSTATE_AMBIENT
-        || rs == D3DRENDERSTATE_FOGVERTEXMODE
-        || rs == D3DRENDERSTATE_COLORVERTEX
-        || rs == D3DRENDERSTATE_LOCALVIEWER
-        || rs == D3DRENDERSTATE_NORMALIZENORMALS
-        || rs == D3DRENDERSTATE_COLORKEYBLENDENABLE
-        || rs == D3DRENDERSTATE_DIFFUSEMATERIALSOURCE
-        || rs == D3DRENDERSTATE_SPECULARMATERIALSOURCE
-        || rs == D3DRENDERSTATE_AMBIENTMATERIALSOURCE
-        || rs == D3DRENDERSTATE_EMISSIVEMATERIALSOURCE
-        || rs == D3DRENDERSTATE_VERTEXBLEND
-        || rs == D3DRENDERSTATE_CLIPPLANEENABLE;
+    if (rclsid == IID_IDirect3DTnLHalDevice) {
+      desc7->dwDevCaps |= D3DDEVCAPS_HWRASTERIZATION
+                        | D3DDEVCAPS_HWTRANSFORMANDLIGHT
+                        | D3DDEVCAPS_DRAWPRIMITIVES2
+                        | D3DDEVCAPS_DRAWPRIMITIVES2EX;
+    } else if (rclsid == IID_IDirect3DHALDevice) {
+      desc7->dwDevCaps |= D3DDEVCAPS_HWRASTERIZATION
+                        | D3DDEVCAPS_DRAWPRIMITIVES2
+                        | D3DDEVCAPS_DRAWPRIMITIVES2EX;
+    } else {
+      desc7->dwDevCaps &= ~D3DDEVCAPS_HWRASTERIZATION
+                        & ~D3DDEVCAPS_HWTRANSFORMANDLIGHT
+                        & ~D3DDEVCAPS_DRAWPRIMITIVES2
+                        & ~D3DDEVCAPS_DRAWPRIMITIVES2EX;
+    }
   }
 
   inline Matrix4 MatrixD3DTo4(const D3DMATRIX* m) {

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1389,6 +1389,7 @@ namespace dxvk {
     { R"(\\arx\.exe$)", {{
       { "ddraw.forceLegacyPresent",         "True" },
       { "ddraw.legacyPresentGuard",       "Strict" },
+      { "ddraw.emulateFSAA",                "True" },
     }} },
     /* Sacrifice - Prevents hitching on asset     *
      * loading and fixes broken AI above 60 FPS.  *
@@ -1396,6 +1397,7 @@ namespace dxvk {
     { R"(\\Sacrifice\.exe$)", {{
       { "d3d9.cachedWriteOnlyBuffers",      "True" },
       { "d3d9.maxFrameRate",                 "-60" },
+      { "ddraw.emulateFSAA",                "True" },
       { "ddraw.useD24X8forD32",             "True" },
     }} },
     /* Battle Isle: The Andosia War - Performance *
@@ -1451,20 +1453,17 @@ namespace dxvk {
     /* Empire Earth / Art of Conquest             *
      * Works around in-game flickering            */
     { R"(\\(Empire Earth|EE-AOC)\.exe$)", {{
+      { "d3d9.cachedWriteOnlyBuffers",      "True" },
       { "ddraw.forceLegacyPresent",         "True" },
       { "ddraw.legacyPresentGuard",       "Strict" },
     }} },
-    /* Etherlords                                 *
-     * Needs R3G3B2 support for text rendering    */
+    /* Etherlords                                 */
     { R"(\\Etherlords\.exe$)", {{
       { "ddraw.forceLegacyPresent",         "True" },
-      { "ddraw.supportR3G3B2",              "True" },
     }} },
-    /* Etherlords 2                               *
-     * Needs R3G3B2 support for text rendering    */
+    /* Etherlords 2                               */
     { R"(\\Etherlords2\.exe$)", {{
       { "ddraw.forceLegacyPresent",         "True" },
-      { "ddraw.supportR3G3B2",              "True" },
     }} },
     /* Evil Islands                               */
     { R"(\\Evil Islands\\game\.exe$)", {{
@@ -1482,6 +1481,7 @@ namespace dxvk {
      * Crashes without multithreading protection  */
     { R"(\\SCP - Containment Breach\.exe$)", {{
       { "ddraw.forceLegacyPresent",         "True" },
+      { "ddraw.emulateFSAA",                "True" },
       { "ddraw.forceMultiThreaded",         "True" },
       { "ddraw.managedVertexBuffers",       "True" },
     }} },
@@ -1489,6 +1489,7 @@ namespace dxvk {
      * Same engine as Containment Breach          */
     { R"(\\SCP Nine-Tailed Fox\.exe$)", {{
       { "ddraw.forceLegacyPresent",         "True" },
+      { "ddraw.emulateFSAA",                "True" },
       { "ddraw.forceMultiThreaded",         "True" },
       { "ddraw.managedVertexBuffers",       "True" },
     }} },
@@ -1552,6 +1553,7 @@ namespace dxvk {
      * and broken cutscene playback / physics     */
     { R"(\\MessiahD3D\.exe$)", {{
       { "d3d9.maxFrameRate",                 "-60" },
+      { "ddraw.emulateFSAA",                "True" },
       { "ddraw.autoGenMipMaps",             "True" },
     }} },
     /* Might and Magic IX / No One Lives Forever  */
@@ -1574,6 +1576,7 @@ namespace dxvk {
      * loading screens / menu transitions         */
     { R"(\\hitman\.exe$)", {{
       { "d3d9.maxFrameRate",                 "-60" },
+      { "ddraw.emulateFSAA",                "True" },
     }} },
     /* Screamer 4x4 - Broken menu animation speed */
     { R"(\\Screamer4x4_d3d\.exe$)", {{
@@ -1584,6 +1587,7 @@ namespace dxvk {
     { R"(\\Sum\.exe$)", {{
       { "d3d9.maxFrameRate",                 "-60" },
       { "ddraw.viewportZCorrection",        "True" },
+      { "ddraw.emulateFSAA",                "True" },
     }} },
     /* Wizardry 8 - Fixes broken input handling   */
     { R"(\\Wiz8\.exe$)", {{
@@ -1615,6 +1619,10 @@ namespace dxvk {
      * Fixes missing mip map uploads              */
     { R"(\\DS9\.exe$)", {{
       { "ddraw.autoGenMipMaps",             "True" },
+    }} },
+    /* Sacred                                     */
+    { R"(\\Sacred\.exe$)", {{
+      { "ddraw.emulateFSAA",                "True" },
     }} },
     /* StarLancer                                 */
     { R"(\\Lancer\.exe$)", {{
@@ -1662,6 +1670,10 @@ namespace dxvk {
     { R"(\\Tribes2\.exe$)", {{
       { "ddraw.forceLegacyPresent",         "True" },
       { "ddraw.forceSWVP",                  "True" },
+    }} },
+    /* Will Rock                                  */
+    { R"(\\WillRock\.exe$)", {{
+      { "ddraw.emulateFSAA",                "True" },
     }} },
     /* FIFA 2001                                  */
     { R"(\\fifa2001\.exe$)", {{
@@ -1711,6 +1723,19 @@ namespace dxvk {
     /* TrickStyle - fixes Z-fighting              */
     { R"(\\TS_D3D\.exe$)", {{
       { "ddraw.supportD16",                "False" },
+    }} },
+    /* Project I.G.I.: I'm Going In - Performance */
+    { R"(\\IGI\.exe$)", {{
+      { "ddraw.managedVertexBuffers",       "True" },
+    }} },
+    /* Sonic World DX - Performance               */
+    { R"(\\Sonic World DX\.exe$)", {{
+      { "ddraw.managedVertexBuffers",       "True" },
+    }} },
+    /* Discord Times                              */
+    { R"(\\DiscordTimes\.exe$)", {{
+      { "ddraw.forceLegacyPresent",         "True" },
+      { "ddraw.emulateFrontBuffer",         "True" },
     }} },
 
     /**********************************************/
@@ -1779,7 +1804,12 @@ namespace dxvk {
     }} },
     /* Expendable                                 */
     { R"(\\Expendable\\go(_start)?\.exe$)", {{
+      { "ddraw.emulateFSAA",                "True" },
       { "ddraw.support32BitDepth",         "False" },
+    }} },
+    /* Total Annihilation: Kingdoms               */
+    { R"(\\KINGDOMS\.icd$)", {{
+      { "ddraw.emulateFSAA",                "True" },
     }} },
     /* Gorky 17                                   */
     { R"(\\gorky17\.exe$)", {{
@@ -1791,6 +1821,14 @@ namespace dxvk {
     { R"(\\Revenant\.exe$)", {{
       { "ddraw.forceLegacyPresent",         "True" },
       { "ddraw.ignoreGammaRamp",            "True" },
+    }} },
+    /* Re-Volt                                    */
+    { R"(\\revolt\.exe$)", {{
+      { "ddraw.emulateFSAA",                "True" },
+    }} },
+    /* Sea Dogs                                   */
+    { R"(\\Sea Dogs\\ENGINE\.exe$)", {{
+      { "ddraw.emulateFSAA",                "True" },
     }} },
     /* Slave Zero - will not start in 32-bit      *
      * color mode without D32 support             */
@@ -1895,6 +1933,21 @@ namespace dxvk {
       { "d3d9.maxFrameRate",                  "30" },
       { "ddraw.managedVertexBuffers",       "True" },
     }} },
+    /* Catechumen - Fixes runaway physics         */
+    { R"(\\Catechumen\.exe$)", {{
+      { "d3d9.maxFrameRate",                  "30" },
+    }} },
+    /* MechWarrior 3 - Fixes missing main menu    *
+     * backgrounds on exit and other transitions  */
+    { R"(\\Mech3\.exe$)", {{
+      { "ddraw.forceLegacyPresent",         "True" },
+      { "ddraw.emulateFrontBuffer",         "True" },
+    }} },
+    /* Crimson Skies - Fixes occasional missing   *
+     * loading screens and main menu flickering   */
+    { R"(\\CRIMSON\.(EXE|ICD)$)", {{
+      { "ddraw.forceLegacyPresent",         "True" },
+    }} },
 
     /**********************************************/
     /* D3D5 GAMES                                 */
@@ -1942,14 +1995,20 @@ namespace dxvk {
     /* FIFA '99                                   */
     { R"(\\fifa99\.exe$)", {{
       { "ddraw.forceLegacyPresent",         "True" },
+      { "ddraw.emulateFSAA",                "True" },
     }} },
     /* The Longest Journey                        */
     { R"(\\The Longest Journey\\game\.exe$)", {{
       { "ddraw.forceLegacyPresent",         "True" },
     }} },
+    /* Virtua Fighter 2                           */
+    { R"(\\VF2\.exe$)", {{
+      { "ddraw.emulateFSAA",                "True" },
+    }} },
     /* Warhammer: Dark Omen                       *
      * Fixes missing pause screen background      */
     { R"(\\DarkOmen\.exe$)", {{
+      { "ddraw.emulateFSAA",                "True" },
       { "ddraw.forceLegacyPresent",         "True" },
       { "ddraw.emulateFrontBuffer",         "True" },
     }} },
@@ -1976,9 +2035,11 @@ namespace dxvk {
     { R"(\\OVERSEER\.exe$)", {{
       { "ddraw.forceLegacyPresent",         "True" },
     }} },
-    /* Resident Evil 2                            */
+    /* Resident Evil 2                            *
+     * Fixes black lines in the background image  */
     { R"(\\(ClaireU|LeonU)\.exe$)", {{
       { "ddraw.forceLegacyPresent",         "True" },
+      { "ddraw.alternatePixelCenter",       "True" },
     }} },
 
     /**********************************************/
@@ -1988,7 +2049,7 @@ namespace dxvk {
     /* Resident Evil                              *
      * Fixes black lines in the background image  */
     { R"(\\ResidentEvil\.exe$)", {{
-      { "ddraw.vertexOffset",               "-0.5" },
+      { "ddraw.alternatePixelCenter",     "Legacy" },
     }} },
     /* Star Trek: Starfleet Academy               */
     { R"(\\sfad3d\.exe$)", {{


### PR DESCRIPTION
This is quite a chungus PR, because it includes:
- a backport of D7VK v2.1
- the upstream rework of the D3D9 bridge along with the compatibility mode handling
- an upstream backport of the latest D3D8 code (also affected by the D3D9 bridge changes)

I've tested it with a couple of games on each API, since this has the potential to affect everything between D3D3 and D3D9Ex, but it all looks good to me. Hopefully I haven't missed anything... but if I did, it's probably not important (famous last words).

P.S.: You can finally compile for ARM now, if you so wish :P.