### PR TITLE
[d3d7] Backport fixed function alternate pixel center

### DIFF
--- a/src/d3d9/d3d9_bridge.cpp
+++ b/src/d3d9/d3d9_bridge.cpp
@@ -119,8 +119,7 @@ namespace dxvk {
   }
 
   HRESULT DxvkLegacyD3DDeviceBridge::SetAlternatePixelCenter(bool alternatePixelCenter) {
-    //return m_device->SetAlternatePixelCenter(alternatePixelCenter);
-    return D3D_OK;
+    return m_device->SetAlternatePixelCenter(alternatePixelCenter);
   }
 
   DxvkLegacyD3DInterfaceBridge::DxvkLegacyD3DInterfaceBridge(D3D9InterfaceEx* pObject)

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -7053,6 +7053,7 @@ namespace dxvk {
       key.Data.Contents.SpecularEnabled  = m_state.renderStates[D3DRS_SPECULARENABLE];
 
       key.Data.Contents.UseLegacyLights  = m_useLegacyLights;
+      key.Data.Contents.AlternatePixelCenter = m_alternatePixelCenter;
 
       uint32_t lightCount = 0;
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -932,6 +932,11 @@ namespace dxvk {
       return D3D_OK;
     }
 
+    HRESULT SetAlternatePixelCenter(bool alternatePixelCenter) {
+      m_alternatePixelCenter = alternatePixelCenter;
+      return D3D_OK;
+    }
+
     HRESULT ResetSwapChain(D3DPRESENT_PARAMETERS* pPresentationParameters, D3DDISPLAYMODEEX* pFullscreenDisplayMode);
 
     HRESULT InitialReset(D3DPRESENT_PARAMETERS* pPresentationParameters, D3DDISPLAYMODEEX* pFullscreenDisplayMode);
@@ -1281,6 +1286,8 @@ namespace dxvk {
 
     // D3D6 and earlier legacy light model state
     bool                            m_useLegacyLights = false;
+    // Fixed function VS alternate pixel center hack
+    bool                            m_alternatePixelCenter = false;
 
     bool                            m_amdATOC         = false;
     bool                            m_nvATOC          = false;

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -807,6 +807,8 @@ namespace dxvk {
       normal = m_module.opFMix(m_vec3Type, normal, normal1, m_vs.constants.tweenFactor);
     }
 
+    const uint32_t xIndex = 0;
+    const uint32_t yIndex = 1;
     const uint32_t wIndex = 3;
 
     if (!m_vsKey.Data.Contents.HasPositionT) {
@@ -899,6 +901,15 @@ namespace dxvk {
 
       gl_Position = emitVectorTimesMatrix(4, 4, vtx, m_vs.constants.proj);
     } else {
+      if (m_vsKey.Data.Contents.AlternatePixelCenter) {
+        uint32_t x = m_module.opCompositeExtract(m_floatType, gl_Position, 1, &xIndex);
+        uint32_t y = m_module.opCompositeExtract(m_floatType, gl_Position, 1, &yIndex);
+        x = m_module.opFSub(m_floatType, x, m_module.constf32(0.5f));
+        y = m_module.opFSub(m_floatType, y, m_module.constf32(0.5f));
+        gl_Position = m_module.opCompositeInsert(m_vec4Type, x, gl_Position, 1, &xIndex);
+        gl_Position = m_module.opCompositeInsert(m_vec4Type, y, gl_Position, 1, &yIndex);
+      }
+
       gl_Position = m_module.opFMul(m_vec4Type, gl_Position, m_vs.constants.invExtent);
       gl_Position = m_module.opFAdd(m_vec4Type, gl_Position, m_vs.constants.invOffset);
 

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -115,6 +115,7 @@ namespace dxvk {
         uint32_t SpecularEnabled : 1;
 
         uint32_t UseLegacyLights : 1;
+        uint32_t AlternatePixelCenter : 1;
 
         uint32_t TexcoordDeclMask : 24;
         uint32_t HasFog : 1;

--- a/src/ddraw/ddraw_options.cpp
+++ b/src/ddraw/ddraw_options.cpp
@@ -32,7 +32,7 @@ namespace dxvk {
 
     std::string alternatePixelCenterStr = Config::toLower(config.getOption<std::string>("ddraw.alternatePixelCenter", "false"));
     if (alternatePixelCenterStr == "true") {
-      this->alternatePixelCenter = AlternatePixelCenter::Disabled; // Unsupported in DXVK-Sarek
+      this->alternatePixelCenter = AlternatePixelCenter::Enabled;
     } else if (alternatePixelCenterStr == "legacy") {
       this->alternatePixelCenter = AlternatePixelCenter::Legacy;
     } else {


### PR DESCRIPTION
Backports the fixed function pixel alignment hack required for Resident Evil 2 and potentially other (silly) early D3D titles. The DDraw side is already in place, so this mostly targets the legacy fixed function vertex shader compiler.