### PR TITLE
[d3d9] colorkeying support

### DIFF
--- a/src/d3d9/d3d9_bridge.cpp
+++ b/src/d3d9/d3d9_bridge.cpp
@@ -105,13 +105,12 @@ namespace dxvk {
   }
 
   HRESULT DxvkLegacyD3DDeviceBridge::SetColorKeyState(bool colorKeyState) {
-    //return m_device->SetColorKeyState(colorKeyState);
-    return D3D_OK;
+    return m_device->SetColorKeyState(colorKeyState);
   }
 
   HRESULT DxvkLegacyD3DDeviceBridge::SetColorKey(DWORD colorKeyLow, DWORD colorKeyHigh) {
-    //return m_device->SetColorKey(colorKeyLow, colorKeyHigh);
-    return D3D_OK;
+    // D7VK currently only sets color key for stage 0 due to spec consts size constraints in modern DXVK.
+    return m_device->SetColorKey(0, colorKeyLow, colorKeyHigh);
   }
 
   HRESULT DxvkLegacyD3DDeviceBridge::SetLegacyLightsState(bool legacyLightsState) {

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4071,6 +4071,10 @@ namespace dxvk {
     if (state[StateSampler][Type] == Value)
       return D3D_OK;
 
+    if (unlikely(Type == D3DSAMP_ADDRESSU || Type == D3DSAMP_ADDRESSV)) {
+      m_flags.set(D3D9DeviceFlag::DirtyFFPixelShader);
+    }
+
     state[StateSampler][Type] = Value;
 
     if (Type == D3DSAMP_ADDRESSU
@@ -7261,6 +7265,11 @@ namespace dxvk {
         stage.ProjectedCount = (ttff & D3DTTFF_PROJECTED) ? count  : 0;
 
         stage.SampleDref = (m_depthTextures & (1 << idx)) != 0;
+
+        stage.ColorKeyLow  = m_colorKeyLow[idx];
+        stage.ColorKeyHigh = m_colorKeyHigh[idx];
+        stage.AddressU     = m_state.samplerStates[idx][D3DSAMP_ADDRESSU];
+        stage.AddressV     = m_state.samplerStates[idx][D3DSAMP_ADDRESSV];
       }
 
       auto& stage0 = key.Stages[0].Contents;
@@ -7272,6 +7281,7 @@ namespace dxvk {
         stage0.AlphaArg1 = D3DTA_DIFFUSE;
       }
 
+      stage0.GlobalColorKeyEnable = m_useColorKey;
       stage0.GlobalSpecularEnable = m_state.renderStates[D3DRS_SPECULARENABLE];
       stage0.GlobalFlatShade      = m_state.renderStates[D3DRS_SHADEMODE] == D3DSHADE_FLAT;
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -927,6 +927,23 @@ namespace dxvk {
 
     HRESULT ResetState(D3DPRESENT_PARAMETERS* pPresentationParameters);
 
+    HRESULT SetColorKeyState(bool colorKeyState) {
+      if (unlikely(m_useColorKey != colorKeyState)) {
+        m_useColorKey = colorKeyState;
+        m_flags.set(D3D9DeviceFlag::DirtyFFPixelShader);
+      }
+      return D3D_OK;
+    }
+
+    HRESULT SetColorKey(DWORD stage, DWORD colorKeyLow, DWORD colorKeyHigh) {
+      if (unlikely(m_colorKeyLow[stage] != colorKeyLow || m_colorKeyHigh[stage] != colorKeyHigh)) {
+        m_colorKeyLow[stage] = colorKeyLow;
+        m_colorKeyHigh[stage] = colorKeyHigh;
+        m_flags.set(D3D9DeviceFlag::DirtyFFPixelShader);
+      }
+      return D3D_OK;
+    }
+
     HRESULT SetLegacyLightsState(bool legacyLightState) {
       m_useLegacyLights = legacyLightState;
       return D3D_OK;
@@ -1278,6 +1295,13 @@ namespace dxvk {
     D3D9ShaderMasks                 m_psShaderMasks = FixedFunctionMask;
 
     bool                            m_isSWVP;
+
+    // D3D7 and earlier texture colorkeying
+    bool                            m_useColorKey = false;
+    std::array<DWORD,
+      caps::MaxSimultaneousTextures> m_colorKeyLow = { };
+    std::array<DWORD,
+      caps::MaxSimultaneousTextures> m_colorKeyHigh = { };
 
     // D3D6 and earlier legacy light model state
     bool                            m_useLegacyLights = false;

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -540,6 +540,7 @@ namespace dxvk {
 
     struct {
       uint32_t texcoordCnt;
+      uint32_t origTypeId;
       uint32_t typeId;
       uint32_t varId;
       uint32_t bound;
@@ -627,9 +628,14 @@ namespace dxvk {
     DxsoIsgn              m_osgn;
 
     uint32_t              m_floatType       = 0u;
+    uint32_t              m_int32Type       = 0u;
     uint32_t              m_uint32Type      = 0u;
+    uint32_t              m_bvec4Type       = 0u;
+    uint32_t              m_ivec4Type       = 0u;
     uint32_t              m_vec4Type        = 0u;
+    uint32_t              m_bvec3Type       = 0u;
     uint32_t              m_vec3Type        = 0u;
+    uint32_t              m_ivec2Type       = 0u;
     uint32_t              m_vec2Type        = 0u;
     uint32_t              m_mat3Type        = 0u;
     uint32_t              m_mat4Type        = 0u;
@@ -668,14 +674,19 @@ namespace dxvk {
 
 
   Rc<DxvkShader> D3D9FFShaderCompiler::compile() {
+    m_boolType   = m_module.defBoolType();
     m_floatType  = m_module.defFloatType(32);
+    m_int32Type = m_module.defIntType(32, 1);
     m_uint32Type = m_module.defIntType(32, 0);
+    m_bvec4Type = m_module.defVectorType(m_boolType, 4);
+    m_ivec4Type   = m_module.defVectorType(m_int32Type, 4);
     m_vec4Type   = m_module.defVectorType(m_floatType, 4);
+    m_bvec3Type = m_module.defVectorType(m_boolType, 3);
     m_vec3Type   = m_module.defVectorType(m_floatType, 3);
+    m_ivec2Type   = m_module.defVectorType(m_int32Type, 2);
     m_vec2Type   = m_module.defVectorType(m_floatType, 2);
     m_mat3Type   = m_module.defMatrixType(m_vec3Type, 3);
     m_mat4Type   = m_module.defMatrixType(m_vec4Type, 4);
-    m_boolType   = m_module.defBoolType();
 
     m_entryPointId = m_module.allocateId();
 
@@ -886,12 +897,10 @@ namespace dxvk {
 
       // Some games rely on normals not being normal.
       if (m_vsKey.Data.Contents.NormalizeNormals) {
-        uint32_t bool3_t = m_module.defVectorType(m_boolType, 3);
-
-        uint32_t isZeroNormal = m_module.opAll(m_boolType, m_module.opFOrdEqual(bool3_t, normal, m_module.constvec3f32(0.0f, 0.0f, 0.0f)));
+        uint32_t isZeroNormal = m_module.opAll(m_boolType, m_module.opFOrdEqual(m_bvec3Type, normal, m_module.constvec3f32(0.0f, 0.0f, 0.0f)));
 
         std::array<uint32_t, 3> members = { isZeroNormal, isZeroNormal, isZeroNormal };
-        uint32_t isZeroNormal3 = m_module.opCompositeConstruct(bool3_t, members.size(), members.data());
+        uint32_t isZeroNormal3 = m_module.opCompositeConstruct(m_bvec3Type, members.size(), members.data());
 
         normal = m_module.opNormalize(m_vec3Type, normal);
         normal = m_module.opSelect(m_vec3Type, isZeroNormal3, m_module.constvec3f32(0.0f, 0.0f, 0.0f), normal);
@@ -1076,14 +1085,12 @@ namespace dxvk {
         uint32_t theta     = LoadLightItem(m_floatType, 11);
         uint32_t phi       = LoadLightItem(m_floatType, 12);
 
-        uint32_t bool3_t = m_module.defVectorType(m_boolType, 3);
-
         uint32_t isSpot        = m_module.opIEqual(m_boolType, type, m_module.constu32(D3DLIGHT_SPOT));
         uint32_t isDirectional = m_module.opIEqual(m_boolType, type, m_module.constu32(D3DLIGHT_DIRECTIONAL));
 
         std::array<uint32_t, 3> members = { isDirectional, isDirectional, isDirectional };
 
-        uint32_t isDirectional3 = m_module.opCompositeConstruct(bool3_t, members.size(), members.data());
+        uint32_t isDirectional3 = m_module.opCompositeConstruct(m_bvec3Type, members.size(), members.data());
 
         uint32_t vtx3      = m_module.opVectorShuffle(m_vec3Type, vtx, vtx, 3, indices.data());
                  position  = m_module.opVectorShuffle(m_vec3Type, position, position, 3, indices.data());
@@ -1632,6 +1639,23 @@ namespace dxvk {
         return m_module.opCompositeConstruct(m_vec4Type, replicant.size(), replicant.data());
       };
 
+      auto DecodeColorKey = [&](uint32_t key) {
+        uint32_t ckey = m_module.constu32(key);
+        uint32_t a = m_module.opBitwiseAnd(m_uint32Type, ckey, m_module.constu32(0xFF000000));
+        a = m_module.opShiftRightLogical(m_uint32Type, a, m_module.constu32(24));
+
+        uint32_t r = m_module.opBitwiseAnd(m_uint32Type, ckey, m_module.constu32(0xFF0000));
+        r = m_module.opShiftRightLogical(m_uint32Type, r, m_module.constu32(16));
+
+        uint32_t g = m_module.opBitwiseAnd(m_uint32Type, ckey, m_module.constu32(0xFF00));
+        g = m_module.opShiftRightLogical(m_uint32Type, g, m_module.constu32(8));
+
+        uint32_t b = m_module.opBitwiseAnd(m_uint32Type, ckey, m_module.constu32(0xFF));
+
+        std::array<uint32_t, 4> v = { r, g, b, a };
+        return m_module.opCompositeConstruct(m_ivec4Type, v.size(), v.data());
+      };
+
       auto GetTexture = [&]() {
         if (!processedTexture) {
           SpirvImageOperands imageOperands;
@@ -1691,6 +1715,72 @@ namespace dxvk {
             texture = m_module.opImageSampleProjImplicitLod(m_vec4Type, imageVarId, texcoord, imageOperands);
           } else {
             texture = m_module.opImageSampleImplicitLod(m_vec4Type, imageVarId, texcoord, imageOperands);
+          }
+
+          if (m_fsKey.Stages[0].Contents.GlobalColorKeyEnable) {
+            uint32_t image = m_module.opImage(m_ps.samplers[i].origTypeId, imageVarId);
+            uint32_t texSize = m_module.opImageQuerySize(m_ivec2Type, image);
+            uint32_t texelPos = m_module.opFMul(m_vec2Type, texcoord, m_module.opConvertStoF(m_vec2Type, texSize));
+            uint32_t pixelCoord = m_module.opConvertFtoS(m_ivec2Type, texelPos);
+
+            uint32_t xIndex = 0;
+            uint32_t yIndex = 1;
+            uint32_t texSizeX = m_module.opCompositeExtract(m_int32Type, texSize, 1, &xIndex);
+            uint32_t texSizeY = m_module.opCompositeExtract(m_int32Type, texSize, 1, &yIndex);
+            uint32_t pixelCoordX = m_module.opCompositeExtract(m_int32Type, pixelCoord, 1, &xIndex);
+            uint32_t pixelCoordY = m_module.opCompositeExtract(m_int32Type, pixelCoord, 1, &yIndex);
+
+            if (stage.AddressU == D3DTADDRESS_CLAMP) {
+              uint32_t limit = m_module.opISub(m_int32Type, texSizeX, m_module.consti32(1));
+              pixelCoordX = m_module.opSClamp(m_int32Type, pixelCoordX, m_module.consti32(0), limit);
+            } else if (stage.AddressU == D3DTADDRESS_MIRROR) {
+              uint32_t period = m_module.opIMul(m_int32Type, texSizeX, m_module.consti32(2));
+              uint32_t mod = m_module.opSRem(m_int32Type, pixelCoordX, period);
+              uint32_t wrapped = m_module.opSRem(m_int32Type, m_module.opIAdd(m_int32Type, mod, period), period);
+              uint32_t limit = m_module.opISub(m_int32Type, period, wrapped);
+              limit = m_module.opISub(m_int32Type, limit, m_module.consti32(1));
+              pixelCoordX = m_module.opSMin(m_int32Type, wrapped, limit);
+            } else {
+              uint32_t mod = m_module.opSRem(m_int32Type, pixelCoordX, texSizeX);
+              pixelCoordX = m_module.opSRem(m_int32Type, m_module.opIAdd(m_int32Type, mod, texSizeX), texSizeX);
+            }
+
+            if (stage.AddressV == D3DTADDRESS_CLAMP) {
+              uint32_t limit = m_module.opISub(m_int32Type, texSizeY, m_module.consti32(1));
+              pixelCoordY = m_module.opSClamp(m_int32Type, pixelCoordY, m_module.consti32(0), limit);
+            } else if (stage.AddressV == D3DTADDRESS_MIRROR) {
+              uint32_t period = m_module.opIMul(m_int32Type, texSizeY, m_module.consti32(2));
+              uint32_t mod = m_module.opSRem(m_int32Type, pixelCoordY, period);
+              uint32_t wrapped = m_module.opSRem(m_int32Type, m_module.opIAdd(m_int32Type, mod, period), period);
+              uint32_t limit = m_module.opISub(m_int32Type, period, wrapped);
+              limit = m_module.opISub(m_int32Type, limit, m_module.consti32(1));
+              pixelCoordY = m_module.opSMin(m_int32Type, wrapped, limit);
+            } else {
+              uint32_t mod = m_module.opSRem(m_int32Type, pixelCoordY, texSizeY);
+              pixelCoordY = m_module.opSRem(m_int32Type, m_module.opIAdd(m_int32Type, mod, texSizeY), texSizeY);
+            }
+
+            std::array<uint32_t, 2> v = { pixelCoordX, pixelCoordY };
+            pixelCoord = m_module.opCompositeConstruct(m_ivec2Type, v.size(), v.data());
+
+            uint32_t texVal = m_module.opImageFetch(m_vec4Type, image, pixelCoord, imageOperands);
+            uint32_t texValInt = m_module.opConvertFtoS(m_ivec2Type, m_module.opFMul(m_vec2Type, texVal, m_module.constf32(255.0)));
+
+            uint32_t keyLow = DecodeColorKey(stage.ColorKeyLow);
+            uint32_t keyHigh = DecodeColorKey(stage.ColorKeyHigh);
+
+            uint32_t ckl = m_module.opAll(m_boolType, m_module.opSGreaterThanEqual(m_bvec4Type, texValInt, keyLow));
+            uint32_t ckh = m_module.opAll(m_boolType, m_module.opSLessThanEqual(m_bvec4Type, texValInt, keyHigh));
+
+            uint32_t discard = m_module.opLogicalAnd(m_boolType, ckl, ckh);
+
+            uint32_t colorkeyDiscardLabel = m_module.allocateId();
+            uint32_t colorkeyKeepLabel = m_module.allocateId();
+            m_module.opSelectionMerge(colorkeyKeepLabel, spv::SelectionControlMaskNone);
+            m_module.opBranchConditional(discard, colorkeyDiscardLabel, colorkeyKeepLabel);
+            m_module.opLabel(colorkeyDiscardLabel);
+            m_module.opKill();
+            m_module.opLabel(colorkeyKeepLabel);
           }
 
           if (i != 0 && m_fsKey.Stages[i - 1].Contents.ColorOp == D3DTOP_BUMPENVMAPLUMINANCE) {
@@ -2131,12 +2221,12 @@ namespace dxvk {
           break;
       }
 
-      sampler.typeId = m_module.defImageType(
+      sampler.origTypeId = m_module.defImageType(
         m_module.defFloatType(32),
         dimensionality, 0, 0, 0, 1,
         spv::ImageFormatUnknown);
 
-      sampler.typeId = m_module.defSampledImageType(sampler.typeId);
+      sampler.typeId = m_module.defSampledImageType(sampler.origTypeId);
 
       sampler.varId = m_module.newVar(
         m_module.defPointerType(

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -165,6 +165,12 @@ namespace dxvk {
         // Affects all stages.
         uint32_t     GlobalSpecularEnable : 1;
         uint32_t     GlobalFlatShade      : 1;
+        uint32_t     GlobalColorKeyEnable : 1;
+
+        uint32_t     AddressU        : 3;
+        uint32_t     AddressV        : 3;
+        uint32_t     ColorKeyLow     : 32;
+        uint32_t     ColorKeyHigh    : 32;
       } Contents;
 
       uint32_t Primitive[2];

--- a/src/spirv/spirv_module.cpp
+++ b/src/spirv/spirv_module.cpp
@@ -2284,6 +2284,25 @@ namespace dxvk {
   }
 
 
+  uint32_t SpirvModule::opSClamp(
+          uint32_t                resultType,
+          uint32_t                x,
+          uint32_t                minVal,
+          uint32_t                maxVal) {
+    uint32_t resultId = this->allocateId();
+
+    m_code.putIns (spv::OpExtInst, 8);
+    m_code.putWord(resultType);
+    m_code.putWord(resultId);
+    m_code.putWord(m_instExtGlsl450);
+    m_code.putWord(GLSLstd450SClamp);
+    m_code.putWord(x);
+    m_code.putWord(minVal);
+    m_code.putWord(maxVal);
+    return resultId;
+  }
+
+
   uint32_t SpirvModule::opIEqual(
           uint32_t                resultType,
           uint32_t                vector1,

--- a/src/spirv/spirv_module.h
+++ b/src/spirv/spirv_module.h
@@ -810,6 +810,12 @@ namespace dxvk {
             uint32_t                minVal,
             uint32_t                maxVal);
 
+    uint32_t opSClamp(
+            uint32_t                resultType,
+            uint32_t                x,
+            uint32_t                minVal,
+            uint32_t                maxVal);
+
     uint32_t opIEqual(
             uint32_t                resultType,
             uint32_t                vector1,


### PR DESCRIPTION
Backport of colorkeying support to old fixed-function shader compiler.

Note: As was mentioned in comment in DxvkLegacyD3DDeviceBridge::SetColorKey D7VK currently only sets color key for stage 0 due to spec consts size constraints in modern DXVK. Old shader compiler doesn't have such constraint and could support colorkeying on all texture stages. But adding stage argument to aformentioned bridge call and adjusting d7vk code wasn't done as that would lead to additional changes in d7vk backports in the future. Otherwise d3d9 backend in sarek is ready for colorkeying on all texture stages.