### PR TITLE
replace chunk allocator with page and pool allocators

### DIFF
--- a/src/dxvk/dxvk_allocator.cpp
+++ b/src/dxvk/dxvk_allocator.cpp
@@ -1,0 +1,633 @@
+#include <algorithm>
+#include <utility>
+
+#include "dxvk_allocator.h"
+
+#include "../util/util_bit.h"
+#include "../util/util_likely.h"
+
+namespace dxvk {
+
+  DxvkPageAllocator::DxvkPageAllocator() {
+
+  }
+
+
+  DxvkPageAllocator::~DxvkPageAllocator() {
+
+  }
+
+
+  int64_t DxvkPageAllocator::alloc(uint64_t size, uint64_t alignment) {
+    uint32_t pageCount = (size + PageSize - 1u) / PageSize;
+    uint32_t pageAlign = (alignment + PageSize - 1u) / PageSize;
+
+    return std::max<int64_t>(-1, int64_t(allocPages(pageCount, pageAlign)) * int64_t(PageSize));
+  }
+
+
+  int32_t DxvkPageAllocator::allocPages(uint32_t count, uint32_t alignment) {
+    int32_t index = searchFreeList(count);
+
+    while (index--) {
+      PageRange entry = m_freeList[index];
+
+      // The chunk index is the same regardless of alignment.
+      // Skip chunk if it does not accept new allocations.
+      uint32_t chunkIndex = entry.index >> ChunkPageBits;
+
+      if (unlikely(m_chunks[chunkIndex].disabled))
+        continue;
+
+      if (likely(!(entry.index & (alignment - 1u)))) {
+        // If the current free range is sufficiently aligned, we can use
+        // it as-is and simply modify the remaining free list entry.
+        uint32_t pageIndex = entry.index;
+
+        entry.index += count;
+        entry.count -= count;
+
+        insertFreeRange(entry, index);
+
+        m_chunks[chunkIndex].pagesUsed += count;
+        return pageIndex;
+      } else {
+        // Apply alignment and skip if the free range is too small.
+        uint32_t pageIndex = align(entry.index, alignment);
+
+        if (pageIndex + count > entry.index + entry.count)
+          continue;
+
+        // Insert free range before the first allocated page,
+        // guaranteed to be non-empty at this point.
+        PageRange prevRange = { };
+        prevRange.index = entry.index;
+        prevRange.count = pageIndex - entry.index;
+
+        insertFreeRange(prevRange, index);
+
+        // Insert free range after the last allocated page.
+        PageRange nextRange = { };
+        nextRange.index = pageIndex + count;
+        nextRange.count = entry.index + entry.count - nextRange.index;
+
+        if (nextRange.count)
+          insertFreeRange(nextRange, -1);
+
+        m_chunks[chunkIndex].pagesUsed += count;
+
+        return pageIndex;
+      }
+    }
+
+    return -1;
+  }
+
+
+  bool DxvkPageAllocator::free(uint64_t address, uint64_t size) {
+    uint32_t pageIndex = address / PageSize;
+    uint32_t pageCount = (size + PageSize - 1u) / PageSize;
+
+    return freePages(pageIndex, pageCount);
+  }
+
+
+  bool DxvkPageAllocator::freePages(uint32_t index, uint32_t count) {
+    // Use the lookup table to quickly determine which
+    // free ranges we can actually merge with
+    int32_t prevRange = -1;
+    int32_t nextRange = -1;
+
+    if (index & ChunkPageMask)
+      prevRange = m_freeListLutByPage[index - 1];
+
+    if ((index + count) & ChunkPageMask)
+      nextRange = m_freeListLutByPage[index + count];
+
+    if (prevRange < 0) {
+      if (nextRange < 0) {
+        // No adjacent range, need to insert a new one
+        PageRange range = { };
+        range.index = index;
+        range.count = count;
+
+        insertFreeRange(range, -1);
+      } else {
+        // One adjacent range after the current one
+        PageRange range = m_freeList[nextRange];
+        range.index = index;
+        range.count += count;
+
+        insertFreeRange(range, nextRange);
+      }
+    } else if (nextRange < 0) {
+        // One adjacent range before the current one
+      PageRange range = m_freeList[prevRange];
+      range.count += count;
+
+      insertFreeRange(range, prevRange);
+    } else {
+      // Two adjacent ranges, need to merge with both
+      // and replace one while removing the other.
+      PageRange prev = m_freeList[prevRange];
+      PageRange next = m_freeList[nextRange];
+
+      PageRange mergedRange = { };
+      mergedRange.index = prev.index;
+      mergedRange.count = next.index + next.count - prev.index;
+
+      PageRange emptyRange = { };
+
+      // Remove the range at the higher index, then replace the one at the
+      // lower index with the merged range. The order is important here since
+      // having overlapping entries in the free list would cause issues for
+      // the look-up table, and using the correct indices is important since
+      // the index for the second operation could otherwise be invalidated.
+      insertFreeRange(emptyRange, std::max(prevRange, nextRange));
+      insertFreeRange(mergedRange, std::min(prevRange, nextRange));
+    }
+
+    uint32_t chunkIndex = index >> ChunkPageBits;
+    return !(m_chunks[chunkIndex].pagesUsed -= count);
+  }
+
+
+  uint32_t DxvkPageAllocator::addChunk(uint64_t size) {
+    int32_t chunkIndex = m_freeChunk;
+
+    if (chunkIndex < 0) {
+      chunkIndex = m_chunks.size();
+
+      m_freeListLutByPage.resize((chunkIndex + 1u) << ChunkPageBits, -1);
+      m_chunks.emplace_back();
+    }
+
+    auto& chunk = m_chunks[chunkIndex];
+    m_freeChunk = chunk.nextChunk;
+
+    chunk.pageCount = size / PageSize;
+    chunk.pagesUsed = 0u;
+    chunk.nextChunk = -1;
+    chunk.disabled = false;
+
+    PageRange pageRange = { };
+    pageRange.index = uint32_t(chunkIndex) << ChunkPageBits;
+    pageRange.count = chunk.pageCount;
+
+    insertFreeRange(pageRange, -1);
+
+    return uint32_t(chunkIndex);
+  }
+
+
+  void DxvkPageAllocator::removeChunk(uint32_t chunkIndex) {
+    auto& chunk = m_chunks[chunkIndex];
+    chunk.pageCount = 0u;
+    chunk.pagesUsed = 0u;
+    chunk.nextChunk = std::exchange(m_freeChunk, int32_t(chunkIndex));
+    chunk.disabled = true;
+
+    uint32_t pageIndex = chunkIndex << ChunkPageBits;
+
+    PageRange pageRange = { };
+    pageRange.index = pageIndex;
+    pageRange.count = 0;
+
+    insertFreeRange(pageRange, m_freeListLutByPage[pageIndex]);
+  }
+
+
+  void DxvkPageAllocator::killChunk(uint32_t chunkIndex) {
+    m_chunks[chunkIndex].disabled = true;
+  }
+
+
+  void DxvkPageAllocator::reviveChunk(uint32_t chunkIndex) {
+    m_chunks[chunkIndex].disabled = false;
+  }
+
+
+  uint32_t DxvkPageAllocator::reviveChunks() {
+    uint32_t count = 0u;
+
+    for (uint32_t i = 0; i < m_chunks.size(); i++) {
+      if (m_chunks[i].pageCount && m_chunks[i].disabled) {
+        m_chunks[i].disabled = false;
+        count += 1u;
+      }
+    }
+
+    return count;
+  }
+
+
+  void DxvkPageAllocator::getPageAllocationMask(uint32_t chunkIndex, uint32_t* pageMask) const {
+    // Initialize bit mask with all ones
+    const auto& chunk = m_chunks[chunkIndex];
+
+    uint32_t fullCount = chunk.pageCount / 32u;
+    uint32_t lastCount = chunk.pageCount % 32u;
+
+    for (uint32_t i = 0; i < fullCount; i++)
+      pageMask[i] = ~0u;
+
+    if (lastCount)
+      pageMask[fullCount] = (1u << lastCount) - 1u;
+
+    // Iterate over free list and set all pages included
+    // in the current chunk to 0.
+    for (PageRange range : m_freeList) {
+      if ((range.index >> ChunkPageBits) != chunkIndex)
+        continue;
+
+      range.index &= ChunkPageMask;
+
+      uint32_t index = range.index / 32u;
+      uint32_t shift = range.index % 32u;
+
+      if (shift + range.count < 32u) {
+        // Entire free range fits in one single mask
+        pageMask[index] ^= ((1u << range.count) - 1u) << shift;
+      } else {
+        if (shift) {
+          pageMask[index++] ^= ~0u << shift;
+          range.count -= 32u - shift;
+        }
+
+        while (range.count >= 32u) {
+          pageMask[index++] = 0u;
+          range.count -= 32u;
+        }
+
+        if (range.count)
+          pageMask[index++] &= ~0u << range.count;
+      }
+    }
+  }
+
+
+  int32_t DxvkPageAllocator::searchFreeList(uint32_t count) {
+    // Find the insertion index of a free list entry with the given page count.
+    // All entries with an index lower than but not equal to the return value
+    // will have a page count greater than or equal to count.
+    if (unlikely(m_freeList.empty()))
+      return 0u;
+
+    // Do a binary search, but optimize for the common
+    // case where we request a small page count
+    uint32_t lo = 0u;
+    uint32_t hi = m_freeList.size();
+
+    if (count <= m_freeList.back().count)
+      return int32_t(hi);
+
+    while (lo < hi) {
+      uint32_t mid = (lo + hi) / 2u;
+
+      if (count <= m_freeList[mid].count)
+        lo = mid + 1;
+      else
+        hi = mid;
+    }
+
+    return int32_t(lo);
+  }
+
+
+  void DxvkPageAllocator::addLutEntry(const PageRange& range, int32_t index) {
+    m_freeListLutByPage[range.index] = index;
+    m_freeListLutByPage[range.index + range.count - 1u] = index;
+  }
+
+
+  void DxvkPageAllocator::removeLutEntry(const PageRange& range) {
+    m_freeListLutByPage[range.index] = -1;
+    m_freeListLutByPage[range.index + range.count - 1u] = -1;
+  }
+
+
+  void DxvkPageAllocator::insertFreeRange(PageRange newRange, int32_t currentIndex) {
+    size_t count = m_freeList.size();
+    size_t index = size_t(currentIndex);
+
+    if (unlikely(currentIndex < 0)) {
+      m_freeList.emplace_back();
+      index = count++;
+    }
+
+    // Remove old range from the LUT since it gets replaced
+    PageRange oldRange = m_freeList[index];
+
+    if (likely(oldRange.count))
+      removeLutEntry(oldRange);
+
+    // Move range within the free list until the proper ordering
+    // is restored again and update LUT entries for all ranges we
+    // move in the process.
+    if (newRange.count < oldRange.count) {
+      while (index + 1u < count) {
+        PageRange next = m_freeList[index + 1u];
+
+        if (newRange.count >= next.count)
+          break;
+
+        addLutEntry(next, index);
+        m_freeList[index++] = next;
+      }
+    } else if (newRange.count > oldRange.count) {
+      while (index) {
+        PageRange prev = m_freeList[index - 1u];
+
+        if (newRange.count <= prev.count)
+          break;
+
+        addLutEntry(prev, index);
+        m_freeList[index--] = prev;
+      }
+    }
+
+    if (newRange.count) {
+      m_freeList[index] = newRange;
+      addLutEntry(newRange, index);
+    } else {
+      m_freeList.pop_back();
+    }
+  }
+
+
+
+  DxvkPoolAllocator::DxvkPoolAllocator(DxvkPageAllocator& pageAllocator)
+  : m_pageAllocator(&pageAllocator) {
+
+  }
+
+
+  DxvkPoolAllocator::~DxvkPoolAllocator() {
+
+  }
+
+
+  int64_t DxvkPoolAllocator::alloc(uint64_t size) {
+    uint32_t listIndex = computeListIndex(size);
+    uint32_t poolCapacity = computePoolCapacity(listIndex);
+
+    // Obtain a page for the size category
+    int32_t pageIndex = m_pageLists[listIndex].head;
+
+    if (likely(pageIndex >= 0)) {
+      uint32_t chunkIndex = uint32_t(pageIndex) >> DxvkPageAllocator::ChunkPageBits;
+
+      // If the selected page is from a dead chunk, do not allocate
+      // into it anymore so that the chunk can actually be freed.
+      if (unlikely(!m_pageAllocator->chunkIsAvailable(chunkIndex))) {
+        int32_t nextIndex = pageIndex;
+
+        do {
+          // This works because we add pages to the end
+          removePageFromList(nextIndex, listIndex);
+          addPageToList(nextIndex, listIndex);
+
+          nextIndex = m_pageLists[listIndex].head;
+          chunkIndex = uint32_t(nextIndex) >> DxvkPageAllocator::ChunkPageBits;
+        } while (nextIndex != pageIndex && !m_pageAllocator->chunkIsAvailable(chunkIndex));
+
+        // Allocate a new page if the entire list is dead
+        pageIndex = nextIndex != pageIndex ? nextIndex : -1;
+      }
+    }
+
+    if (unlikely(pageIndex < 0)) {
+      if ((pageIndex = allocPage(listIndex)) < 0)
+        return -1;
+
+      // Initialize suballocator for the page
+      PageInfo& page = m_pageInfos[pageIndex];
+
+      if (likely(poolCapacity <= MaskBits)) {
+        // Initialize free mask with the first item marked as used
+        page.pool = (MaskType(2) << (poolCapacity - 1u)) - 2u;
+      } else {
+        // This is also going to have its first item used already
+        page.pool = allocPagePool(poolCapacity);
+      }
+
+      return computeByteAddress(pageIndex, 0, listIndex);
+    }
+
+    if (likely(poolCapacity <= MaskBits)) {
+      // Fast path that uses the pool index as an allocator.
+      // Frequent allocations should ideally hit this path.
+      PageInfo& page = m_pageInfos[pageIndex];
+
+      uint32_t itemIndex = bit::tzcnt(page.pool);
+      page.pool &= page.pool - 1u;
+
+      if (unlikely(!page.pool))
+        removePageFromList(pageIndex, listIndex);
+
+      return computeByteAddress(pageIndex, itemIndex, listIndex);
+    } else {
+      PageInfo& page = m_pageInfos[pageIndex];
+      PagePool& pool = m_pagePools[page.pool];
+
+      // Check top-level masks to find which low-level mask to use
+      uint32_t maskIndex = bit::tzcnt(uint32_t(pool.freeMask));
+      MaskType maskBit = MaskType(1) << maskIndex;
+
+      pool.usedMask |= maskBit;
+
+      // Allocate item from the selected low-level mask
+      MaskType& mask = pool.subPools[maskIndex];
+      uint32_t itemIndex = bit::tzcnt(mask) + maskIndex * MaskBits;
+
+      if (!(mask &= mask - 1u)) {
+        pool.freeMask &= ~maskBit;
+
+        if (unlikely(!pool.freeMask))
+          removePageFromList(pageIndex, listIndex);
+      }
+
+      return computeByteAddress(pageIndex, itemIndex, listIndex);
+    }
+  }
+
+
+  bool DxvkPoolAllocator::free(uint64_t address, uint64_t size) {
+    uint32_t listIndex = computeListIndex(size);
+
+    uint32_t pageIndex = computePageIndexFromByteAddress(address);
+    uint32_t itemIndex = computeItemIndexFromByteAddress(address, listIndex);
+
+    uint32_t poolCapacity = computePoolCapacity(listIndex);
+
+    // Return the allocation to the given pool and add the page back
+    // to the free list if it was previously full. If the page is now
+    // unused, return it to the allocator.
+    if (likely(poolCapacity <= MaskBits)) {
+      PageInfo& page = m_pageInfos[pageIndex];
+
+      if (unlikely(!page.pool))
+        addPageToList(pageIndex, listIndex);
+
+      page.pool |= MaskType(1) << itemIndex;
+
+      if (unlikely(bit::tzcnt(page.pool + 1u) >= poolCapacity))
+        return freePage(pageIndex, listIndex);
+
+      return false;
+    } else {
+      PageInfo& page = m_pageInfos[pageIndex];
+      PagePool& pool = m_pagePools[page.pool];
+
+      if (unlikely(!pool.freeMask))
+        addPageToList(pageIndex, listIndex);
+
+      uint32_t maskIndex = itemIndex / MaskBits;
+      MaskType maskBit = MaskType(1) << maskIndex;
+
+      MaskType& mask = pool.subPools[maskIndex];
+      mask |= MaskType(1) << (itemIndex % MaskBits);
+
+      pool.freeMask |= maskBit;
+
+      if (!(mask + 1u)) {
+        pool.usedMask &= ~maskBit;
+
+        if (unlikely(!pool.usedMask)) {
+          freePagePool(page.pool);
+          return freePage(pageIndex, listIndex);
+        }
+      }
+
+      return false;
+    }
+  }
+
+
+  int32_t DxvkPoolAllocator::allocPage(uint32_t listIndex) {
+    int32_t pageIndex = m_pageAllocator->allocPages(1u, 1u);
+
+    if (unlikely(pageIndex < 0))
+      return -1;
+
+    if (unlikely(uint32_t(pageIndex) >= m_pageInfos.size())) {
+      uint32_t chunkCount = (pageIndex >> DxvkPageAllocator::ChunkPageBits) + 1u;
+      m_pageInfos.resize(chunkCount << DxvkPageAllocator::ChunkPageBits);
+    }
+
+    addPageToList(pageIndex, listIndex);
+    return pageIndex;
+  }
+
+
+  bool DxvkPoolAllocator::freePage(uint32_t pageIndex, uint32_t listIndex) {
+    removePageFromList(pageIndex, listIndex);
+
+    return m_pageAllocator->freePages(pageIndex, 1u);
+  }
+
+
+  void DxvkPoolAllocator::addPageToList(uint32_t pageIndex, uint32_t listIndex) {
+    // Add page to the end of the list. Allocations within a single page
+    // often have similar lifetimes, so not reusing the page immediately
+    // increases the chances of it getting freed.
+    PageInfo& page = m_pageInfos[pageIndex];
+    page.prev = m_pageLists[listIndex].tail;
+
+    if (page.prev >= 0)
+      m_pageInfos[page.prev].next = pageIndex;
+    else
+      m_pageLists[listIndex].head = pageIndex;
+
+    m_pageLists[listIndex].tail = pageIndex;
+  }
+
+
+  void DxvkPoolAllocator::removePageFromList(uint32_t pageIndex, uint32_t listIndex) {
+    // The list of non-full pages is organized in a double-linked list so
+    // that entries can get removed in constant time whenever a page gets
+    // filled or removed.
+    PageInfo& page = m_pageInfos[pageIndex];
+
+    if (page.prev >= 0)
+      m_pageInfos[page.prev].next = page.next;
+    else
+      m_pageLists[listIndex].head = page.next;
+
+    if (page.next >= 0)
+      m_pageInfos[page.next].prev = page.prev;
+    else
+      m_pageLists[listIndex].tail = page.prev;
+
+    page.prev = -1;
+    page.next = -1;
+  }
+
+
+  uint32_t DxvkPoolAllocator::allocPagePool(uint32_t capacity) {
+    PagePool* pool;
+    uint32_t poolIndex;
+
+    if (unlikely(m_freePool < 0)) {
+      // Allocate new pool as necessary
+      pool = &m_pagePools.emplace_back();
+      pool->subPools.fill(MaskType(-1));
+
+      poolIndex = uint32_t(m_pagePools.size() - 1u);
+    } else {
+      // Otherwise, just use the free list
+      pool = &m_pagePools[m_freePool];
+      poolIndex = std::exchange(m_freePool, pool->nextPool);
+    }
+
+    // Initialize free mask to the correct capacity. Everything
+    // else is assumed to be in its default initialized state.
+    uint32_t maskCount = capacity / MaskBits;
+    pool->freeMask = (1u << maskCount) - 1u;
+    pool->usedMask = 1u;
+    pool->subPools[0] = MaskType(-2);
+    return poolIndex;
+  }
+
+
+  void DxvkPoolAllocator::freePagePool(uint32_t poolIndex) {
+    PagePool* pool = &m_pagePools[poolIndex];
+    pool->nextPool = m_freePool;
+
+    m_freePool = poolIndex;
+  }
+
+
+  uint32_t DxvkPoolAllocator::computeListIndex(uint64_t size) {
+    size = std::max(size, MinSize);
+
+    // Use leading zero count to determine the size category and
+    // basically round up to the next power of two. Pools are
+    // ordered by allocation size in descending order.
+    return bit::lzcnt(uint32_t(size) - 1u) - (33u - DxvkPageAllocator::PageBits);
+  }
+
+
+  uint32_t DxvkPoolAllocator::computePoolCapacity(uint32_t index) {
+    // Number of objects we can allocate in the pool
+    return 2u << index;
+  }
+
+
+  uint64_t DxvkPoolAllocator::computeByteAddress(uint32_t page, uint32_t index, uint32_t list) {
+    uint32_t shift = DxvkPageAllocator::PageBits - 1u - list;
+    return DxvkPageAllocator::PageSize * uint64_t(page) + (index << shift);
+  }
+
+
+  uint32_t DxvkPoolAllocator::computePageIndexFromByteAddress(uint64_t address) {
+    return address / DxvkPageAllocator::PageSize;
+  }
+
+
+  uint32_t DxvkPoolAllocator::computeItemIndexFromByteAddress(uint64_t address, uint32_t list) {
+    uint32_t shift = DxvkPageAllocator::PageBits - 1u - list;
+    return (address & (DxvkPageAllocator::PageSize - 1u)) >> shift;
+  }
+
+}

--- a/src/dxvk/dxvk_allocator.h
+++ b/src/dxvk/dxvk_allocator.h
@@ -1,0 +1,313 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+#include <vector>
+
+#include "../util/util_env.h"
+
+namespace dxvk {
+
+  /**
+   * \brief Page allocator
+   *
+   * Implements a best-fit allocation strategy for coarse allocations
+   * using an ordered free list. While allocating and freeing memory
+   * are both linear in the worst case, minimum-size allocations can
+   * generally be performed in constant time, with larger allocations
+   * getting gradually slower.
+   */
+  class DxvkPageAllocator {
+
+  public:
+
+    /// Page size. While the allocator interface is fully designed around
+    /// pages, defining a page size is useful for classes built on top of it.
+    constexpr static uint32_t PageBits = 16;
+    constexpr static uint64_t PageSize = 1u << PageBits;
+
+    /// Maximum number of pages per chunk. Chunks represent contiguous memory
+    /// allocations whose free regions can be merged.
+    constexpr static uint32_t ChunkPageBits = 12u;
+    constexpr static uint32_t ChunkPageMask = (1u << ChunkPageBits) - 1u;
+
+    /// Chunk address bits. Can be used to quickly compute the chunk index
+    /// and allocation offset within the chunk from a raw byte address.
+    constexpr static uint32_t ChunkAddressBits = ChunkPageBits + PageBits;
+    constexpr static uint64_t ChunkAddressMask = (1u << ChunkAddressBits) - 1u;
+
+    constexpr static uint64_t MaxChunkSize = 1u << ChunkAddressBits;
+
+
+    DxvkPageAllocator();
+
+    ~DxvkPageAllocator();
+
+    /**
+     * \brief Queries total number of chunks
+     *
+     * This number may include chuks that have already been removed.
+     * \returns Total chunk count
+     */
+    uint32_t chunkCount() const {
+      return uint32_t(m_chunks.size());
+    }
+
+    /**
+     * \brief Queries number of available pages in a chunk
+     *
+     * \param [in] chunkIndex Chunk index
+     * \returns Capacity of the given chunk
+     */
+    uint32_t pageCount(uint32_t chunkIndex) const {
+      return m_chunks.at(chunkIndex).pageCount;
+    }
+
+    /**
+     * \brief Queries number of allocated pages in a chunk
+     *
+     * \param [in] chunkIndex Chunk index
+     * \returns Used page count in the given chunk
+     */
+    uint32_t pagesUsed(uint32_t chunkIndex) const {
+      return m_chunks.at(chunkIndex).pagesUsed;
+    }
+
+    /**
+     * \brief Checks whether a chunk is alive
+     *
+     * \param [in] chunkIndex Chunk index
+     * \returns \c true if chunk can be used
+     */
+    bool chunkIsAvailable(uint32_t chunkIndex) const {
+      return !m_chunks.at(chunkIndex).disabled;
+    }
+
+    /**
+     * \brief Allocates given number of bytes from the pool
+     *
+     * \param [in] size Allocation size, in bytes
+     * \param [in] alignment Required aligment, in bytes
+     * \returns Allocated byte address
+     */
+    int64_t alloc(uint64_t size, uint64_t alignment);
+
+    /**
+     * \brief Allocates pages
+     *
+     * \param [in] count Number of pages to allocate.
+     *    Must be multiple of \c alignment.
+     * \param [in] alignment Required alignment, in pages
+     * \returns Page index, or -1 if not enough memory
+     *    is available in the chunk.
+     */
+    int32_t allocPages(uint32_t count, uint32_t alignment);
+
+    /**
+     * \brief Frees allocated memory region
+     *
+     * \param [in] address Allocated address, in bytes
+     * \param [in] size Allocation size, in bytes
+     * \returns \c true if a chunk was freed
+     */
+    bool free(uint64_t address, uint64_t size);
+
+    /**
+     * \brief Frees pages
+     *
+     * \param [in] index Index of first page to free
+     * \param [in] count Number of pages to free
+     * \returns \c true if a chunk was freed
+     */
+    bool freePages(uint32_t index, uint32_t count);
+
+    /**
+     * \brief Adds a chunk to the allocator
+     *
+     * Adds the given region to the free list, so
+     * that subsequent allocations can succeed.
+     * \param [in] size Total chunk size, in bytes
+     * \returns Chunk index
+     */
+    uint32_t addChunk(uint64_t size);
+
+    /**
+     * \brief Removes chunk from the allocator
+     *
+     * Must only be used if the entire chunk is unused.
+     * \param [in] chunkIndex Chunk index
+     */
+    void removeChunk(uint32_t chunkIndex);
+
+    /**
+     * \brief Disables a chunk
+     *
+     * Makes an entire chunk unavailable for subsequent allocations.
+     * This can be useful when moving allocations out of that chunk
+     * in an attempt to free some memory.
+     * \param [in] chunkIndex Chunk index
+     */
+    void killChunk(uint32_t chunkIndex);
+
+    /**
+     * \brief Re-enables a chunk
+     *
+     * Makes all disabled chunks available for allocations again.
+     * Should be used before allocating new chunk memory.
+     * \param [in] chunkIndex Chunk index
+     */
+    void reviveChunk(uint32_t chunkIndex);
+
+    /**
+     * \brief Re-enables all disabled chunks
+     * \returns Number of chunks re-enabled
+     */
+    uint32_t reviveChunks();
+
+    /**
+     * \brief Queries page allocation mask
+     *
+     * Should be used for informational purposes only. Retrieves
+     * a bit mask where each set bit represents an allocated page,
+     * with the page index corresponding to the page index. The
+     * output array must be sized appropriately.
+     * \param [out] chunkIndex Chunk index
+     * \param [out] pageMask Page mask
+     */
+    void getPageAllocationMask(uint32_t chunkIndex, uint32_t* pageMask) const;
+
+  private:
+
+    struct ChunkInfo {
+      uint32_t  pageCount = 0u;
+      uint32_t  pagesUsed = 0u;
+      int32_t   nextChunk = -1;
+      bool      disabled  = false;
+    };
+
+    struct PageRange {
+      uint32_t  index = 0u;
+      uint32_t  count = 0u;
+    };
+
+    std::vector<PageRange>  m_freeList;
+    std::vector<int32_t>    m_freeListLutByPage;
+
+    std::vector<ChunkInfo>  m_chunks;
+    int32_t                 m_freeChunk = -1;
+
+    int32_t searchFreeList(uint32_t count);
+
+    void addLutEntry(const PageRange& range, int32_t index);
+
+    void removeLutEntry(const PageRange& range);
+
+    void insertFreeRange(PageRange newRange, int32_t currentIndex);
+
+  };
+
+
+  /**
+   * \brief Pool allocator
+   *
+   * Implements an fast allocator for objects less than the size of one
+   * page. Uses a regular page allocator to allocate backing storage for
+   * each object pool.
+   */
+  class DxvkPoolAllocator {
+    // Use the machine's native word size for bit masks to enable fast paths
+    using MaskType = std::conditional_t<env::is32BitHostPlatform(), uint32_t, uint64_t>;
+
+    constexpr static uint32_t MaskBits = sizeof(MaskType) * 8u;
+
+    constexpr static uint32_t MaxCapacityBits = 8u;
+    constexpr static uint32_t MaxCapacity = 1u << MaxCapacityBits;
+
+    constexpr static uint32_t MasksPerPage = MaxCapacity / MaskBits;
+  public:
+
+    /// Allocation granularity. Smaller allocations are rounded up to
+    /// be at least of this size.
+    constexpr static uint64_t MinSize = DxvkPageAllocator::PageSize >> MaxCapacityBits;
+
+    /// Minimum supported allocation size. Always set to half a page
+    /// so that any pools we manage can at least hold two allocations.
+    constexpr static uint64_t MaxSize = DxvkPageAllocator::PageSize >> 1u;
+
+    DxvkPoolAllocator(DxvkPageAllocator& pageAllocator);
+
+    ~DxvkPoolAllocator();
+
+    /**
+     * \brief Allocates given number of bytes from the pool
+     *
+     * \param [in] size Allocation size, in bytes
+     * \returns Allocated address, in bytes
+     */
+    int64_t alloc(uint64_t size);
+
+    /**
+     * \brief Frees allocated memory region
+     *
+     * \param [in] address Memory address, in bytes
+     * \param [in] size Allocation size, in bytes
+     * \returns \c true if a chunk was freed
+     */
+    bool free(uint64_t address, uint64_t size);
+
+  private:
+
+    struct PageList {
+      int32_t   head = -1;
+      int32_t   tail = -1;
+    };
+
+    struct PageInfo {
+      MaskType  pool = 0u;
+      int32_t   prev = -1;
+      int32_t   next = -1;
+    };
+
+    struct PagePool {
+      int32_t   nextPool  = -1;
+      uint16_t  freeMask  = 0u;
+      uint16_t  usedMask  = 0u;
+
+      std::array<MaskType, MasksPerPage> subPools = { };
+    };
+
+    DxvkPageAllocator*      m_pageAllocator = nullptr;
+
+    std::vector<PageInfo>   m_pageInfos;
+    std::vector<PagePool>   m_pagePools;
+    int32_t                 m_freePool = -1;
+
+    std::array<PageList, MaxCapacityBits> m_pageLists = { };
+
+    int32_t allocPage(uint32_t listIndex);
+
+    bool freePage(uint32_t pageIndex, uint32_t listIndex);
+
+    void addPageToList(uint32_t pageIndex, uint32_t listIndex);
+
+    void removePageFromList(uint32_t pageIndex, uint32_t listIndex);
+
+    uint32_t allocPagePool(uint32_t capacity);
+
+    void freePagePool(uint32_t poolIndex);
+
+    static uint32_t computeListIndex(uint64_t size);
+
+    static uint32_t computePoolCapacity(uint32_t index);
+
+    static uint64_t computeByteAddress(uint32_t page, uint32_t index, uint32_t list);
+
+    static uint32_t computePageIndexFromByteAddress(uint64_t address);
+
+    static uint32_t computeItemIndexFromByteAddress(uint64_t address, uint32_t list);
+
+  };
+
+}

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -9,40 +9,40 @@ namespace dxvk {
   DxvkMemory::DxvkMemory() { }
   DxvkMemory::DxvkMemory(
           DxvkMemoryAllocator*  alloc,
-          DxvkMemoryChunk*      chunk,
           DxvkMemoryType*       type,
           VkDeviceMemory        memory,
+          VkDeviceSize          address,
           VkDeviceSize          offset,
           VkDeviceSize          length,
           void*                 mapPtr)
   : m_alloc   (alloc),
-    m_chunk   (chunk),
     m_type    (type),
     m_memory  (memory),
+    m_address (address),
     m_offset  (offset),
     m_length  (length),
     m_mapPtr  (mapPtr) { }
 
 
   DxvkMemory::DxvkMemory(DxvkMemory&& other)
-  : m_alloc   (std::exchange(other.m_alloc,  nullptr)),
-    m_chunk   (std::exchange(other.m_chunk,  nullptr)),
-    m_type    (std::exchange(other.m_type,   nullptr)),
-    m_memory  (std::exchange(other.m_memory, VkDeviceMemory(VK_NULL_HANDLE))),
-    m_offset  (std::exchange(other.m_offset, 0)),
-    m_length  (std::exchange(other.m_length, 0)),
-    m_mapPtr  (std::exchange(other.m_mapPtr, nullptr)) { }
+  : m_alloc   (std::exchange(other.m_alloc,   nullptr)),
+    m_type    (std::exchange(other.m_type,    nullptr)),
+    m_memory  (std::exchange(other.m_memory,  VkDeviceMemory(VK_NULL_HANDLE))),
+    m_address (std::exchange(other.m_address, 0)),
+    m_offset  (std::exchange(other.m_offset,  0)),
+    m_length  (std::exchange(other.m_length,  0)),
+    m_mapPtr  (std::exchange(other.m_mapPtr,  nullptr)) { }
 
 
   DxvkMemory& DxvkMemory::operator = (DxvkMemory&& other) {
     this->free();
-    m_alloc   = std::exchange(other.m_alloc,  nullptr);
-    m_chunk   = std::exchange(other.m_chunk,  nullptr);
-    m_type    = std::exchange(other.m_type,   nullptr);
-    m_memory  = std::exchange(other.m_memory, VkDeviceMemory(VK_NULL_HANDLE));
-    m_offset  = std::exchange(other.m_offset, 0);
-    m_length  = std::exchange(other.m_length, 0);
-    m_mapPtr  = std::exchange(other.m_mapPtr, nullptr);
+    m_alloc   = std::exchange(other.m_alloc,   nullptr);
+    m_type    = std::exchange(other.m_type,    nullptr);
+    m_memory  = std::exchange(other.m_memory,  VkDeviceMemory(VK_NULL_HANDLE));
+    m_address = std::exchange(other.m_address, 0);
+    m_offset  = std::exchange(other.m_offset,  0);
+    m_length  = std::exchange(other.m_length,  0);
+    m_mapPtr  = std::exchange(other.m_mapPtr,  nullptr);
     return *this;
   }
 
@@ -58,206 +58,65 @@ namespace dxvk {
   }
 
 
-  DxvkMemoryChunk::DxvkMemoryChunk(
-          DxvkMemoryAllocator*  alloc,
-          DxvkMemoryType*       type,
-          DxvkDeviceMemory      memory,
-          DxvkMemoryFlags       hints)
-  : m_alloc(alloc), m_type(type), m_memory(memory), m_hints(hints) {
-    // Mark the entire chunk as free
-    m_freeList.push_back(FreeSlice { 0, memory.memSize });
-  }
-
-
-  DxvkMemoryChunk::~DxvkMemoryChunk() {
-    // This call is technically not thread-safe, but it
-    // doesn't need to be since we don't free chunks
-    m_alloc->freeDeviceMemory(m_type, m_memory);
-  }
-
-
-  DxvkMemory DxvkMemoryChunk::alloc(
-          VkMemoryPropertyFlags flags,
-          VkDeviceSize          size,
-          VkDeviceSize          align,
-          DxvkMemoryFlags       hints) {
-    // Property flags must be compatible. This could
-    // be refined a bit in the future if necessary.
-    if (m_memory.memFlags != flags || !checkHints(hints))
-      return DxvkMemory();
-
-    // If the chunk is full, return
-    if (m_freeList.size() == 0)
-      return DxvkMemory();
-
-    // Select the slice to allocate from in a worst-fit
-    // manner. This may help keep fragmentation low.
-    auto bestSlice = m_freeList.begin();
-
-    for (auto slice = m_freeList.begin(); slice != m_freeList.end(); slice++) {
-      if (slice->length == size) {
-        bestSlice = slice;
-        break;
-      } else if (slice->length > bestSlice->length) {
-        bestSlice = slice;
-      }
-    }
-
-    // We need to align the allocation to the requested alignment
-    const VkDeviceSize sliceStart = bestSlice->offset;
-    const VkDeviceSize sliceEnd   = bestSlice->offset + bestSlice->length;
-
-    const VkDeviceSize allocStart = dxvk::align(sliceStart,        align);
-    const VkDeviceSize allocEnd   = dxvk::align(allocStart + size, align);
-
-    if (allocEnd > sliceEnd)
-      return DxvkMemory();
-
-    // We can use this slice, but we'll have to add
-    // the unused parts of it back to the free list.
-    m_freeList.erase(bestSlice);
-
-    if (allocStart != sliceStart)
-      m_freeList.push_back({ sliceStart, allocStart - sliceStart });
-
-    if (allocEnd != sliceEnd)
-      m_freeList.push_back({ allocEnd, sliceEnd - allocEnd });
-
-    // Create the memory object with the aligned slice
-    void* mapPtr = m_memory.memPointer
-      ? reinterpret_cast<char*>(m_memory.memPointer) + allocStart
-      : nullptr;
-
-    // Some games assume freshly mapped buffers are zero-initialized and
-    // break on stale data. Clear the slice on hand-out if requested, which
-    // also covers reused slices from recycled chunks.
-    if (unlikely(mapPtr && m_alloc->zeroMappedMemory()))
-      std::memset(mapPtr, 0, allocEnd - allocStart);
-
-    return DxvkMemory(m_alloc, this, m_type,
-      m_memory.memHandle, allocStart, allocEnd - allocStart, mapPtr);
-  }
-
-
-  void DxvkMemoryChunk::free(
-          VkDeviceSize  offset,
-          VkDeviceSize  length) {
-    // Remove adjacent entries from the free list and then add
-    // a new slice that covers all those entries. Without doing
-    // so, the slice could not be reused for larger allocations.
-    auto curr = m_freeList.begin();
-
-    while (curr != m_freeList.end()) {
-      if (curr->offset == offset + length) {
-        length += curr->length;
-        curr = m_freeList.erase(curr);
-      } else if (curr->offset + curr->length == offset) {
-        offset -= curr->length;
-        length += curr->length;
-        curr = m_freeList.erase(curr);
-      } else {
-        curr++;
-      }
-    }
-
-    m_freeList.push_back({ offset, length });
-  }
-
-
-  bool DxvkMemoryChunk::isEmpty() const {
-    return m_freeList.size() == 1
-        && m_freeList[0].length == m_memory.memSize;
-  }
-
-
-  bool DxvkMemoryChunk::isCompatible(const Rc<DxvkMemoryChunk>& other) const {
-    return other->m_memory.memFlags == m_memory.memFlags && other->m_hints == m_hints;
-  }
-
-
-  bool DxvkMemoryChunk::checkHints(DxvkMemoryFlags hints) const {
-    DxvkMemoryFlags mask(
-      DxvkMemoryFlag::Small,
-      DxvkMemoryFlag::GpuReadable,
-      DxvkMemoryFlag::GpuWritable,
-      DxvkMemoryFlag::Transient);
-
-    if (hints.test(DxvkMemoryFlag::IgnoreConstraints))
-      mask = DxvkMemoryFlags();
-
-    return (m_hints & mask) == (hints & mask);
-  }
-
-
   DxvkMemoryAllocator::DxvkMemoryAllocator(const DxvkDevice* device)
   : m_vkd             (device->vkd()),
     m_device          (device),
     m_devProps        (device->adapter()->deviceProperties()),
     m_memProps        (device->adapter()->memoryProperties()) {
-    VkDeviceSize maxBudget = m_device->config().maxMemoryBudget;
+    m_memTypeCount = m_memProps.memoryTypeCount;
+    m_memHeapCount = m_memProps.memoryHeapCount;
 
-    for (uint32_t i = 0; i < m_memProps.memoryHeapCount; i++) {
-      m_memHeaps[i].properties = m_memProps.memoryHeaps[i];
-      m_memHeaps[i].stats      = DxvkMemoryStats { 0, 0 };
-      m_memHeaps[i].budget     = 0;
+    for (uint32_t i = 0; i < m_memHeapCount; i++) {
+      auto& heap = m_memHeaps[i];
 
-      /* Match upstream: only enforce a soft heap budget on discrete GPUs,
-       * where VRAM is a hard ceiling. On UMA, the OS manages memory pressure
-       * across CPU and GPU usage, and a fixed percentage cap causes spurious
-       * allocation failures in games with large working sets (e.g. Cris Tales
-       * on Intel HD Graphics). The driver reports real pressure via
-       * VK_EXT_memory_budget when it matters. */
-      if ((m_memProps.memoryHeaps[i].flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT)
-       && !m_device->isUnifiedMemoryArchitecture()
-       && m_device->properties().core.properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU)
-        m_memHeaps[i].budget = (8 * m_memProps.memoryHeaps[i].size) / 10;
+      heap.index        = i;
+      heap.properties   = m_memProps.memoryHeaps[i];
+      heap.memoryBudget = m_memProps.memoryHeaps[i].size;
 
-      if (maxBudget && (!m_memHeaps[i].budget || m_memHeaps[i].budget > maxBudget))
-        m_memHeaps[i].budget = maxBudget;
+      /* Only enforce a hard heap budget on discrete GPUs, where VRAM is a
+       * hard ceiling. On UMA, the OS manages memory pressure across CPU and
+       * GPU usage, and a fixed cap causes spurious allocation failures in
+       * games with large working sets (e.g. Cris Tales on Intel HD Graphics).
+       * The driver reports real pressure via VK_EXT_memory_budget instead,
+       * which feeds updateMemoryHeapBudgets below. */
+      heap.enforceBudget = (m_memProps.memoryHeaps[i].flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT)
+        && !m_device->isUnifiedMemoryArchitecture()
+        && m_device->properties().core.properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
     }
 
-    for (uint32_t i = 0; i < m_memProps.memoryTypeCount; i++) {
-      m_memTypes[i].heap       = &m_memHeaps[m_memProps.memoryTypes[i].heapIndex];
-      m_memTypes[i].heapId     = m_memProps.memoryTypes[i].heapIndex;
-      m_memTypes[i].memType    = m_memProps.memoryTypes[i];
-      m_memTypes[i].memTypeId  = i;
-      m_memTypes[i].chunkSize  = MinChunkSize;
+    for (uint32_t i = 0; i < m_memTypeCount; i++) {
+      auto& type = m_memTypes[i];
+
+      type.index    = i;
+      type.memType  = m_memProps.memoryTypes[i];
+      type.heap     = &m_memHeaps[m_memProps.memoryTypes[i].heapIndex];
+
+      type.heap->memoryTypes |= 1u << i;
+
+      type.devicePool.maxChunkSize = determineMaxChunkSize(type, false);
+      type.mappedPool.maxChunkSize = determineMaxChunkSize(type, true);
+
+      // Uncached system memory is going to be used for large temporary
+      // allocations during resource creation. Account for that by always
+      // using full-sized chunks.
+      if ((type.memType.propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
+       && !(type.memType.propertyFlags & (VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT)))
+        type.mappedPool.nextChunkSize = type.mappedPool.maxChunkSize;
     }
 
-    /* Check what kind of heap the HVV memory type is on, if any. If the
-     * HVV memory type is on the largest device-local heap, we either have
-     * an UMA system or an RBAR-enabled system. Otherwise, there will likely
-     * be a separate, smaller heap for it. */
-    VkDeviceSize largestDeviceLocalHeap = 0;
+    determineMemoryTypesWithPropertyFlags();
 
-    for (uint32_t i = 0; i < m_memProps.memoryTypeCount; i++) {
-      if (m_memTypes[i].memType.propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)
-        largestDeviceLocalHeap = std::max(largestDeviceLocalHeap, m_memTypes[i].heap->properties.size);
-    }
-
-    /* Work around an issue on Nvidia drivers where using the entire
-     * device_local | host_visible heap can cause crashes or slowdowns */
-    if (m_device->properties().core.properties.vendorID == uint16_t(DxvkGpuVendor::Nvidia)) {
-      bool shrinkNvidiaHvvHeap = device->adapter()->matchesDriver(DxvkGpuVendor::Nvidia,
-        VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR, 0, VK_MAKE_VERSION(465, 0, 0));
-
-      applyTristate(shrinkNvidiaHvvHeap, device->config().shrinkNvidiaHvvHeap);
-
-      if (shrinkNvidiaHvvHeap) {
-        for (uint32_t i = 0; i < m_memProps.memoryTypeCount; i++) {
-          VkMemoryPropertyFlags hvvFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
-
-          if ((m_memTypes[i].memType.propertyFlags & hvvFlags) == hvvFlags
-           && (m_memTypes[i].heap->properties.size < largestDeviceLocalHeap))
-            m_memTypes[i].heap->budget = 32 << 20;
-        }
-      }
-    }
+    updateMemoryHeapBudgets();
   }
 
 
   DxvkMemoryAllocator::~DxvkMemoryAllocator() {
+    for (uint32_t i = 0; i < m_memTypeCount; i++) {
+      auto& type = m_memTypes[i];
 
+      freeAllChunksInPool(type, type.devicePool);
+      freeAllChunksInPool(type, type.mappedPool);
+    }
   }
 
 
@@ -274,240 +133,198 @@ namespace dxvk {
           DxvkMemoryFlags                   hints) {
     std::lock_guard<dxvk::mutex> lock(m_mutex);
 
-    // Keep small allocations together to avoid fragmenting
-    // chunks for larger resources with lots of small gaps,
-    // as well as resources with potentially weird lifetimes
-    if (req->size <= SmallAllocationThreshold) {
-      hints.set(DxvkMemoryFlag::Small);
-      hints.clr(DxvkMemoryFlag::GpuWritable, DxvkMemoryFlag::GpuReadable);
-    }
+    // If a dedicated allocation is required or preferred, try that first.
+    // Shared resources always end up here because the caller sets both
+    // bits, and the export or import info chained onto dedAllocInfo has
+    // to reach vkAllocateMemory intact.
+    if (dedAllocReq.prefersDedicatedAllocation || dedAllocReq.requiresDedicatedAllocation) {
+      DxvkMemory result = this->allocateDedicatedMemory(*req, flags, &dedAllocInfo);
 
-    // Ignore most hints for host-visible allocations since they
-    // usually don't make much sense for those resources
-    if (flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
-      hints = hints & DxvkMemoryFlag::Transient;
+      if (result)
+        return result;
 
-    // On tiling GPUs, prefer cached memory for host-visible allocations
-    // to speed up readbacks. This is a preference only: if no suitable
-    // cached memory type exists, we fall back to uncached below.
-    VkMemoryPropertyFlags cachedFlags = 0;
+      if (dedAllocReq.requiresDedicatedAllocation) {
+        this->logMemoryError(*req, flags);
+        this->logMemoryStats();
 
-    if ((flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
-     && m_device->perfHints().preferCachedMemory)
-      cachedFlags = VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
-
-    // Try to allocate from a memory type which supports the given flags exactly
-    auto dedAllocPtr = dedAllocReq.prefersDedicatedAllocation ? &dedAllocInfo : nullptr;
-    DxvkMemory result = this->tryAlloc(req, dedAllocPtr, flags | cachedFlags, hints);
-
-    // If we asked for cached memory but none was available, retry uncached
-    if (!result && cachedFlags) {
-      cachedFlags = 0;
-      result = this->tryAlloc(req, dedAllocPtr, flags, hints);
-    }
-
-    // If the first attempt failed, try ignoring the dedicated allocation
-    if (!result && dedAllocPtr && !dedAllocReq.requiresDedicatedAllocation) {
-      result = this->tryAlloc(req, nullptr, flags, hints);
-      dedAllocPtr = nullptr;
-    }
-
-    // Retry without the hint constraints
-    if (!result) {
-      hints.set(DxvkMemoryFlag::IgnoreConstraints);
-      result = this->tryAlloc(req, nullptr, flags, hints);
-    }
-
-    // If that still didn't work, probe slower memory types as well
-    VkMemoryPropertyFlags optFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT
-                                   | VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
-    VkMemoryPropertyFlags remFlags = 0;
-
-    while (!result && (flags & optFlags)) {
-      remFlags |= optFlags & -optFlags;
-      optFlags &= ~remFlags;
-
-      result = this->tryAlloc(req, dedAllocPtr, flags & ~remFlags, hints);
-    }
-
-    if (!result) {
-      DxvkAdapterMemoryInfo memHeapInfo = m_device->adapter()->getMemoryHeapInfo();
-
-      Logger::err(str::format(
-        "DxvkMemoryAllocator: Memory allocation failed",
-        "\n  Size:      ", req->size,
-        "\n  Alignment: ", req->alignment,
-        "\n  Mem flags: ", "0x", std::hex, flags,
-        "\n  Mem types: ", "0x", std::hex, req->memoryTypeBits));
-
-      for (uint32_t i = 0; i < m_memProps.memoryHeapCount; i++) {
-        Logger::err(str::format("Heap ", i, ": ",
-          (m_memHeaps[i].stats.memoryAllocated >> 20), " MB allocated, ",
-          (m_memHeaps[i].stats.memoryUsed      >> 20), " MB used, ",
-          m_device->extensions().extMemoryBudget
-            ? str::format(
-                (memHeapInfo.heaps[i].memoryAllocated >> 20), " MB allocated (driver), ",
-                (memHeapInfo.heaps[i].memoryBudget    >> 20), " MB budget (driver), ",
-                (m_memHeaps[i].properties.size        >> 20), " MB total")
-            : str::format(
-                (m_memHeaps[i].properties.size        >> 20), " MB total")));
-      }
-
-      throw DxvkError("DxvkMemoryAllocator: Memory allocation failed");
-    }
-
-    return result;
-  }
-
-
-  DxvkMemory DxvkMemoryAllocator::tryAlloc(
-    const VkMemoryRequirements*             req,
-    const VkMemoryDedicatedAllocateInfo*    dedAllocInfo,
-          VkMemoryPropertyFlags             flags,
-          DxvkMemoryFlags                   hints) {
-    DxvkMemory result;
-
-    for (uint32_t i = 0; i < m_memProps.memoryTypeCount && !result; i++) {
-      const bool supported = (req->memoryTypeBits & (1u << i)) != 0;
-      const bool adequate  = (m_memTypes[i].memType.propertyFlags & flags) == flags;
-
-      if (supported && adequate) {
-        result = this->tryAllocFromType(&m_memTypes[i],
-          flags, req->size, req->alignment, hints, dedAllocInfo);
+        throw DxvkError("DxvkMemoryAllocator: Memory allocation failed");
       }
     }
 
-    return result;
+    // Suballocate from a memory pool of a suitable memory type
+    DxvkMemory result = this->allocateMemory(*req, flags);
+
+    if (result)
+      return result;
+
+    // If that failed, probe slower memory types as well
+    VkMemoryPropertyFlags optionalFlags = flags & (
+      VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
+      VK_MEMORY_PROPERTY_HOST_CACHED_BIT);
+
+    if (optionalFlags) {
+      result = this->allocateMemory(*req, flags & ~optionalFlags);
+
+      if (result)
+        return result;
+    }
+
+    this->logMemoryError(*req, flags);
+    this->logMemoryStats();
+
+    throw DxvkError("DxvkMemoryAllocator: Memory allocation failed");
   }
 
 
-  DxvkMemory DxvkMemoryAllocator::tryAllocFromType(
-          DxvkMemoryType*                   type,
-          VkMemoryPropertyFlags             flags,
-          VkDeviceSize                      size,
-          VkDeviceSize                      align,
-          DxvkMemoryFlags                   hints,
-    const VkMemoryDedicatedAllocateInfo*    dedAllocInfo) {
-    constexpr VkDeviceSize DedicatedAllocationThreshold = 3;
+  DxvkMemory DxvkMemoryAllocator::allocateMemory(
+    const VkMemoryRequirements& req,
+          VkMemoryPropertyFlags properties) {
+    // Ensure the allocation size is also aligned
+    VkDeviceSize size = align(req.size, req.alignment);
 
-    // System memory allocations tend to be volatile and short-lived, so let a
-    // single resource fill an entire chunk there rather than forcing it onto a
-    // dedicated allocation. On 32-bit titles the host-visible chunk size is
-    // capped at 16 MiB, so a flat threshold would send every mappable buffer
-    // above ~5.3 MiB to its own vkAllocateMemory and vkMapMemory, which chews
-    // through the address space.
-    VkDeviceSize dedicatedThreshold = DedicatedAllocationThreshold;
+    uint32_t memoryTypeMask = req.memoryTypeBits & getMemoryTypeMask(properties);
 
-    if ((flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
-     && !(flags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT))
-      dedicatedThreshold = 1;
+    for (uint32_t i = 0; i < m_memTypeCount; i++) {
+      if (!(memoryTypeMask & (1u << i)))
+        continue;
 
-    VkDeviceSize chunkSize = pickChunkSize(type->memTypeId,
-      DedicatedAllocationThreshold * size, hints);
+      auto& type = m_memTypes[i];
 
-    DxvkMemory memory;
+      // Use the correct memory pool depending on property flags. This way
+      // we avoid wasting address space on unmapped allocations, and mapped
+      // allocations cannot fragment device-local memory.
+      auto& selectedPool = (properties & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
+        ? type.mappedPool
+        : type.devicePool;
 
-    // Require dedicated allocations for resources that use the Vulkan dedicated
-    // allocation bits, or are too large to fit into a single full-sized chunk
-    bool needsDedicatedAlocation = size >= chunkSize || dedAllocInfo;
+      // Always try to suballocate first, even if the allocation is
+      // very large. We will decide what to do if this fails.
+      int64_t address = selectedPool.alloc(size, req.alignment);
 
-    // Prefer a dedicated allocation for very large resources in order to
-    // reduce fragmentation if a large number of those resources are in use
-    bool wantsDedicatedAllocation = dedicatedThreshold * size > chunkSize;
+      if (likely(address >= 0))
+        return createMemory(type, selectedPool, address, size);
 
-    // Try to reuse existing memory as much as possible in case the heap is nearly full
-    bool heapBudgedExceeded = 5 * type->heap->stats.memoryUsed + size > 4 * type->heap->properties.size;
+      // If the allocation is very large, use a dedicated allocation instead
+      // of creating a new chunk. This way we avoid excessive fragmentation,
+      // especially when multiple such resources are created at once.
+      VkDeviceSize maxChunkSize = selectedPool.maxChunkSize;
+      uint32_t minResourcesPerChunk = 4u;
 
-    if (!needsDedicatedAlocation && (!wantsDedicatedAllocation || heapBudgedExceeded)) {
-      // Attempt to suballocate from existing chunks first
-      for (uint32_t i = 0; i < type->chunks.size() && !memory; i++)
-        memory = type->chunks[i]->alloc(flags, size, align, hints);
+      if (properties & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) {
+        if (properties & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) {
+          // For HVV allocations, it may be beneficial to ignore the chunk
+          // size limit if the resource is large. HVV is usually slow to
+          // allocate from and may be very limited in size, so we should
+          // avoid dedicated allocations as well as fragmentation.
+          maxChunkSize = DxvkPageAllocator::MaxChunkSize / (env::is32BitHostPlatform() ? 4u : 1u);
+          maxChunkSize = std::min(maxChunkSize, type.heap->properties.size / MinAllocationsPerHeap);
+          maxChunkSize = std::max(maxChunkSize, selectedPool.maxChunkSize);
 
-      // If no existing chunk can accomodate the allocation, and if a dedicated
-      // allocation is not preferred, create a new chunk and suballocate from it
-      if (!memory && !wantsDedicatedAllocation) {
-        DxvkDeviceMemory devMem;
-
-        if (this->shouldFreeEmptyChunks(type->heap, chunkSize))
-          this->freeEmptyChunks(type->heap);
-
-        for (uint32_t i = 0; i < 6 && (chunkSize >> i) >= size && !devMem.memHandle; i++)
-          devMem = tryAllocDeviceMemory(type, flags, chunkSize >> i, hints, nullptr);
-
-        if (devMem.memHandle) {
-          Rc<DxvkMemoryChunk> chunk = new DxvkMemoryChunk(this, type, devMem, hints);
-          memory = chunk->alloc(flags, size, align, hints);
-
-          type->chunks.push_back(std::move(chunk));
-
-          adjustChunkSize(type->memTypeId, devMem.memSize, hints);
+          minResourcesPerChunk = std::clamp(uint32_t(maxChunkSize / size), 1u, 3u);
+        } else {
+          // System memory allocations tend to be more volatile, so be
+          // lenient and allow a single resource to fill an entire chunk.
+          minResourcesPerChunk = 1u;
         }
       }
-    }
 
-    // If a dedicated allocation is required or preferred and we haven't managed
-    // to suballocate any memory before, try to create a dedicated allocation
-    if (!memory && (needsDedicatedAlocation || wantsDedicatedAllocation)) {
-      if (this->shouldFreeEmptyChunks(type->heap, size))
-        this->freeEmptyChunks(type->heap);
+      if (size * minResourcesPerChunk > maxChunkSize) {
+        DxvkDeviceMemory memory = allocateDeviceMemory(type, req.size, properties, nullptr);
 
-      DxvkDeviceMemory devMem = this->tryAllocDeviceMemory(
-        type, flags, size, hints, dedAllocInfo);
+        if (!memory.memHandle)
+          continue;
 
-      if (devMem.memHandle != VK_NULL_HANDLE) {
-        if (unlikely(devMem.memPointer && this->zeroMappedMemory()))
-          std::memset(devMem.memPointer, 0, size);
+        return createMemory(type, memory);
+      }
 
-        memory = DxvkMemory(this, nullptr, type, devMem.memHandle, 0, size, devMem.memPointer);
+      // Try to allocate a new chunk that is large enough to hold
+      // multiple resources of the type we are trying to allocate.
+      VkDeviceSize desiredSize = selectedPool.nextChunkSize;
+
+      while (desiredSize < size * minResourcesPerChunk)
+        desiredSize *= 2u;
+
+      if (allocateChunkInPool(type, selectedPool, properties, size, desiredSize)) {
+        address = selectedPool.alloc(size, req.alignment);
+
+        if (likely(address >= 0))
+          return createMemory(type, selectedPool, address, size);
       }
     }
 
-    if (memory)
-      type->heap->stats.memoryUsed += memory.m_length;
-
-    return memory;
+    return DxvkMemory();
   }
 
 
-  DxvkDeviceMemory DxvkMemoryAllocator::tryAllocDeviceMemory(
-          DxvkMemoryType*                   type,
-          VkMemoryPropertyFlags             flags,
-          VkDeviceSize                      size,
-          DxvkMemoryFlags                   hints,
-    const VkMemoryDedicatedAllocateInfo*    dedAllocInfo) {
-    bool useMemoryPriority = (flags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)
-                          && (m_device->features().extMemoryPriority.memoryPriority);
+  DxvkMemory DxvkMemoryAllocator::allocateDedicatedMemory(
+    const VkMemoryRequirements& req,
+          VkMemoryPropertyFlags properties,
+    const void*                 next) {
+    uint32_t memoryTypeMask = req.memoryTypeBits & getMemoryTypeMask(properties);
 
-    if (type->heap->budget && type->heap->stats.memoryAllocated + size > type->heap->budget)
+    for (uint32_t i = 0; i < m_memTypeCount; i++) {
+      if (!(memoryTypeMask & (1u << i)))
+        continue;
+
+      auto& type = m_memTypes[i];
+      DxvkDeviceMemory memory = allocateDeviceMemory(type, req.size, properties, next);
+
+      if (memory.memHandle)
+        return createMemory(type, memory);
+    }
+
+    return DxvkMemory();
+  }
+
+
+  DxvkDeviceMemory DxvkMemoryAllocator::allocateDeviceMemory(
+          DxvkMemoryType&       type,
+          VkDeviceSize          size,
+          VkMemoryPropertyFlags properties,
+    const void*                 next) {
+    // Re-query the driver budget before deciding anything, since chunk
+    // allocations are rare enough for this not to matter for performance.
+    updateMemoryHeapBudgets();
+
+    // Preemptively free some unused allocations to reduce memory waste
+    freeEmptyChunksInHeap(*type.heap, size);
+
+    // If we would exceed the vram budget on a dedicated GPU, give up so
+    // that the caller can fall back to a system memory type.
+    if (!next && type.heap->enforceBudget
+     && getMemoryStats(type.heap->index).memoryAllocated + size > type.heap->memoryBudget)
       return DxvkDeviceMemory();
 
-    float priority = 0.0f;
+    VkMemoryAllocateInfo memoryInfo = { VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO, next };
+    memoryInfo.allocationSize  = size;
+    memoryInfo.memoryTypeIndex = type.index;
 
-    if (hints.test(DxvkMemoryFlag::GpuReadable))
-      priority = 0.5f;
-    if (hints.test(DxvkMemoryFlag::GpuWritable))
-      priority = 1.0f;
+    // Decide on a memory priority based on the memory type. Dedicated
+    // allocations are expected to be high-bandwidth resources such as
+    // render targets, while BAR memory is most useful in system memory.
+    VkMemoryPriorityAllocateInfoEXT priorityInfo = { VK_STRUCTURE_TYPE_MEMORY_PRIORITY_ALLOCATE_INFO_EXT };
+
+    if (type.memType.propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) {
+      if (type.memType.propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
+        priorityInfo.priority = 0.0f;
+      else if (next)
+        priorityInfo.priority = 1.0f;
+      else
+        priorityInfo.priority = 0.5f;
+
+      if (m_device->features().extMemoryPriority.memoryPriority)
+        priorityInfo.pNext = std::exchange(memoryInfo.pNext, &priorityInfo);
+    }
 
     DxvkDeviceMemory result;
     result.memSize  = size;
-    result.memFlags = flags;
-    result.priority = priority;
+    result.memFlags = properties;
+    result.priority = priorityInfo.priority;
 
-    VkMemoryPriorityAllocateInfoEXT prio;
-    prio.sType            = VK_STRUCTURE_TYPE_MEMORY_PRIORITY_ALLOCATE_INFO_EXT;
-    prio.pNext            = dedAllocInfo;
-    prio.priority         = priority;
-
-    VkMemoryAllocateInfo info;
-    info.sType            = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-    info.pNext            = useMemoryPriority ? &prio : prio.pNext;
-    info.allocationSize   = size;
-    info.memoryTypeIndex  = type->memTypeId;
-
-    if (m_vkd->vkAllocateMemory(m_vkd->device(), &info, nullptr, &result.memHandle) != VK_SUCCESS)
+    if (m_vkd->vkAllocateMemory(m_vkd->device(), &memoryInfo, nullptr, &result.memHandle) != VK_SUCCESS)
       return DxvkDeviceMemory();
 
-    if (flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) {
+    if (properties & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) {
       VkResult status = m_vkd->vkMapMemory(m_vkd->device(), result.memHandle, 0, VK_WHOLE_SIZE, 0, &result.memPointer);
 
       if (status != VK_SUCCESS) {
@@ -517,160 +334,365 @@ namespace dxvk {
       }
     }
 
-    type->heap->stats.memoryAllocated += size;
-    m_device->adapter()->notifyHeapMemoryAlloc(type->heapId, size);
+    result.cookie = ++m_nextCookie;
+
+    type.stats.memoryAllocated += size;
+    m_device->adapter()->notifyHeapMemoryAlloc(type.heap->index, size);
     return result;
+  }
+
+
+  bool DxvkMemoryAllocator::allocateChunkInPool(
+          DxvkMemoryType&       type,
+          DxvkMemoryPool&       pool,
+          VkMemoryPropertyFlags properties,
+          VkDeviceSize          requiredSize,
+          VkDeviceSize          desiredSize) {
+    // Try to allocate device memory. If the allocation fails, retry with a
+    // smaller size until we reach a point where we cannot service it at all.
+    DxvkDeviceMemory chunk = { };
+
+    while (!chunk.memHandle && desiredSize >= std::max(requiredSize, DxvkMemoryPool::MinChunkSize)) {
+      chunk = allocateDeviceMemory(type, desiredSize, properties, nullptr);
+      desiredSize /= 2u;
+    }
+
+    if (!chunk.memHandle)
+      return false;
+
+    // If we expect the application to require more memory in the
+    // future, increase the chunk size for subsequent allocations.
+    if (pool.nextChunkSize < pool.maxChunkSize
+     && pool.nextChunkSize <= type.stats.memoryAllocated / 2u)
+      pool.nextChunkSize *= 2u;
+
+    // Add the newly created chunk to the pool
+    uint32_t chunkIndex = pool.pageAllocator.addChunk(chunk.memSize);
+
+    pool.chunks.resize(std::max<size_t>(pool.chunks.size(), chunkIndex + 1u));
+    pool.chunks[chunkIndex].memory = chunk;
+    return true;
+  }
+
+
+  DxvkMemory DxvkMemoryAllocator::createMemory(
+          DxvkMemoryType&       type,
+          DxvkMemoryPool&       pool,
+          VkDeviceSize          address,
+          VkDeviceSize          size) {
+    type.stats.memoryUsed += size;
+
+    uint32_t chunkIndex = address >> DxvkPageAllocator::ChunkAddressBits;
+    VkDeviceSize offset = address & DxvkPageAllocator::ChunkAddressMask;
+
+    auto& chunk = pool.chunks[chunkIndex];
+
+    void* mapPtr = chunk.memory.memPointer
+      ? reinterpret_cast<char*>(chunk.memory.memPointer) + offset
+      : nullptr;
+
+    // Some games assume freshly mapped buffers are zero-initialized and
+    // break on stale data. Clear the slice on hand-out if requested, which
+    // also covers reused slices from recycled chunks.
+    if (unlikely(mapPtr && this->zeroMappedMemory()))
+      std::memset(mapPtr, 0, size);
+
+    return DxvkMemory(this, &type, chunk.memory.memHandle,
+      address, offset, size, mapPtr);
+  }
+
+
+  DxvkMemory DxvkMemoryAllocator::createMemory(
+          DxvkMemoryType&       type,
+    const DxvkDeviceMemory&     memory) {
+    type.stats.memoryUsed += memory.memSize;
+
+    if (unlikely(memory.memPointer && this->zeroMappedMemory()))
+      std::memset(memory.memPointer, 0, memory.memSize);
+
+    return DxvkMemory(this, &type, memory.memHandle,
+      DedicatedChunkAddress, 0, memory.memSize, memory.memPointer);
   }
 
 
   void DxvkMemoryAllocator::free(
     const DxvkMemory&           memory) {
     std::lock_guard<dxvk::mutex> lock(m_mutex);
-    memory.m_type->heap->stats.memoryUsed -= memory.m_length;
 
-    if (memory.m_chunk != nullptr) {
-      this->freeChunkMemory(
-        memory.m_type,
-        memory.m_chunk,
-        memory.m_offset,
-        memory.m_length);
-    } else {
+    auto& type = *memory.m_type;
+    type.stats.memoryUsed -= memory.m_length;
+
+    if (memory.m_address & DedicatedChunkAddress) {
       DxvkDeviceMemory devMem;
       devMem.memHandle  = memory.m_memory;
       devMem.memPointer = nullptr;
       devMem.memSize    = memory.m_length;
-      this->freeDeviceMemory(memory.m_type, devMem);
-    }
-  }
 
+      this->freeDeviceMemory(type, devMem);
+    } else {
+      // Mapped chunks only ever come from the mapped pool, so the map
+      // pointer tells us which pool the address belongs to.
+      auto& pool = memory.m_mapPtr ? type.mappedPool : type.devicePool;
 
-  void DxvkMemoryAllocator::freeChunkMemory(
-          DxvkMemoryType*       type,
-          DxvkMemoryChunk*      chunk,
-          VkDeviceSize          offset,
-          VkDeviceSize          length) {
-    chunk->free(offset, length);
-
-    if (chunk->isEmpty()) {
-      Rc<DxvkMemoryChunk> chunkRef = chunk;
-
-      // Free the chunk if we have to, or at least put it at the end of
-      // the list so that chunks that are already in use and cannot be
-      // freed are prioritized for allocations to reduce memory pressure.
-      type->chunks.erase(std::remove(type->chunks.begin(), type->chunks.end(), chunkRef));
-
-      if (!this->shouldFreeChunk(type, chunkRef))
-        type->chunks.push_back(std::move(chunkRef));
+      if (unlikely(pool.free(memory.m_address, memory.m_length)))
+        this->freeEmptyChunksInPool(type, pool, 0);
     }
   }
 
 
   void DxvkMemoryAllocator::freeDeviceMemory(
-          DxvkMemoryType*       type,
+          DxvkMemoryType&       type,
           DxvkDeviceMemory      memory) {
     m_vkd->vkFreeMemory(m_vkd->device(), memory.memHandle, nullptr);
-    type->heap->stats.memoryAllocated -= memory.memSize;
-    m_device->adapter()->notifyHeapMemoryFree(type->heapId, memory.memSize);
+
+    type.stats.memoryAllocated -= memory.memSize;
+    m_device->adapter()->notifyHeapMemoryFree(type.heap->index, memory.memSize);
   }
 
 
-  VkDeviceSize DxvkMemoryAllocator::pickChunkSize(uint32_t memTypeId, VkDeviceSize requiredSize, DxvkMemoryFlags hints) const {
-    VkMemoryType type = m_memProps.memoryTypes[memTypeId];
-    VkMemoryHeap heap = m_memProps.memoryHeaps[type.heapIndex];
+  bool DxvkMemoryAllocator::freeEmptyChunksInPool(
+          DxvkMemoryType&       type,
+          DxvkMemoryPool&       pool,
+          VkDeviceSize          allocationSize) {
+    // Allow for one unused max-size chunk on device-local memory types.
+    // For mapped memory allocations we need to be more lenient, since
+    // applications frequently allocate staging buffers.
+    VkDeviceSize maxUnusedMemory = pool.maxChunkSize;
 
-    // Start from the current per-type chunk size and grow it
-    // up to the maximum until it can serve the request.
-    VkDeviceSize chunkSize = m_memTypes[memTypeId].chunkSize;
+    if (&pool == &type.mappedPool)
+      maxUnusedMemory *= 4u;
 
-    while (chunkSize < requiredSize && chunkSize < MaxChunkSize)
-      chunkSize <<= 1u;
+    // Factor the current memory allocation into the decision to free chunks
+    VkDeviceSize heapBudget = type.heap->memoryBudget;
+    VkDeviceSize heapAllocated = getMemoryStats(type.heap->index).memoryAllocated;
 
-    if (hints.test(DxvkMemoryFlag::Small))
-      chunkSize = std::min<VkDeviceSize>(chunkSize, 16 << 20);
+    VkDeviceSize unusedMemory = 0u;
 
-    // Try to waste a bit less system memory especially in
-    // 32-bit applications due to address space constraints
-    if (type.propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
-      chunkSize = std::min<VkDeviceSize>((env::is32BitHostPlatform() ? 16 : 64) << 20, chunkSize);
+    bool chunkFreed = false;
 
-    // Reduce the chunk size on small heaps so
-    // we can at least fit in 15 allocations
-    while (chunkSize * 15 > heap.size)
-      chunkSize >>= 1;
+    for (uint32_t i = 0; i < pool.chunks.size(); i++) {
+      DxvkMemoryChunk& chunk = pool.chunks[i];
 
-    return chunkSize;
-  }
-
-
-  void DxvkMemoryAllocator::adjustChunkSize(
-          uint32_t              memTypeId,
-          VkDeviceSize          allocatedSize,
-          DxvkMemoryFlags       hints) {
-    VkDeviceSize chunkSize = m_memTypes[memTypeId].chunkSize;
-
-    // Don't bump chunk size if we reached the maximum or if
-    // we already were unable to allocate a full chunk.
-    if (chunkSize <= allocatedSize && chunkSize <= m_memTypes[memTypeId].heap->stats.memoryAllocated)
-      m_memTypes[memTypeId].chunkSize = pickChunkSize(memTypeId, chunkSize * 2, DxvkMemoryFlags());
-  }
-
-
-  bool DxvkMemoryAllocator::shouldFreeChunk(
-    const DxvkMemoryType*       type,
-    const Rc<DxvkMemoryChunk>&  chunk) const {
-    // Under memory pressure, we should start freeing everything.
-    if (this->shouldFreeEmptyChunks(type->heap, 0))
-      return true;
-
-    // Free chunks that are below the current chunk size since it probably
-    // not going to be able to serve enough allocations to be useful.
-    if (chunk->size() < type->chunkSize)
-      return true;
-
-    // Only keep a small number of chunks of each type around to save memory.
-    uint32_t numEmptyChunks = 0;
-
-    for (const auto& c : type->chunks) {
-      if (c != chunk && c->isEmpty() && c->isCompatible(chunk))
-        numEmptyChunks += 1;
-    }
-
-    // Be a bit more lenient on system memory since data uploads may otherwise
-    // lead to a large number of allocations and deallocations at runtime.
-    uint32_t maxEmptyChunks = env::is32BitHostPlatform() ? 2 : 4;
-
-    if ((type->memType.propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)
-     || !(type->memType.propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT))
-      maxEmptyChunks = 1;
-
-    return numEmptyChunks >= maxEmptyChunks;
-  }
-
-
-  bool DxvkMemoryAllocator::shouldFreeEmptyChunks(
-    const DxvkMemoryHeap*       heap,
-          VkDeviceSize          allocationSize) const {
-    VkDeviceSize budget = heap->budget;
-
-    if (!budget)
-      budget = (heap->properties.size * 4) / 5;
-
-    return heap->stats.memoryAllocated + allocationSize > budget;
-  }
-
-
-  void DxvkMemoryAllocator::freeEmptyChunks(
-    const DxvkMemoryHeap*       heap) {
-    for (uint32_t i = 0; i < m_memProps.memoryTypeCount; i++) {
-      DxvkMemoryType* type = &m_memTypes[i];
-
-      if (type->heap != heap)
+      if (!chunk.memory.memHandle || pool.pageAllocator.pagesUsed(i))
         continue;
 
-      type->chunks.erase(
-        std::remove_if(type->chunks.begin(), type->chunks.end(),
-          [] (const Rc<DxvkMemoryChunk>& chunk) { return chunk->isEmpty(); }),
-        type->chunks.end());
+      // Free the chunk if it is smaller than the current chunk size of the
+      // pool, since it is unlikely to be useful for future allocations.
+      // Also free if the pending allocation would exceed the heap budget.
+      bool shouldFree = chunk.memory.memSize < pool.nextChunkSize
+        || allocationSize + heapAllocated > heapBudget
+        || allocationSize > heapBudget;
+
+      // If we still don't free the chunk under these conditions, count it
+      // towards unused memory in the current memory pool. Once we exceed
+      // the limit, free any empty chunk we encounter.
+      if (!shouldFree) {
+        unusedMemory += chunk.memory.memSize;
+        shouldFree = unusedMemory > maxUnusedMemory;
+      }
+
+      if (shouldFree) {
+        freeDeviceMemory(type, chunk.memory);
+        heapAllocated -= chunk.memory.memSize;
+
+        chunk = DxvkMemoryChunk();
+        pool.pageAllocator.removeChunk(i);
+
+        chunkFreed = true;
+      }
+    }
+
+    return chunkFreed;
+  }
+
+
+  void DxvkMemoryAllocator::freeEmptyChunksInHeap(
+    const DxvkMemoryHeap&       heap,
+          VkDeviceSize          allocationSize) {
+    for (uint32_t i = 0; i < m_memTypeCount; i++) {
+      if (!(heap.memoryTypes & (1u << i)))
+        continue;
+
+      auto& type = m_memTypes[i];
+
+      freeEmptyChunksInPool(type, type.devicePool, allocationSize);
+      freeEmptyChunksInPool(type, type.mappedPool, allocationSize);
+    }
+  }
+
+
+  void DxvkMemoryAllocator::freeAllChunksInPool(
+          DxvkMemoryType&       type,
+          DxvkMemoryPool&       pool) {
+    for (uint32_t i = 0; i < pool.chunks.size(); i++) {
+      if (pool.chunks[i].memory.memHandle) {
+        freeDeviceMemory(type, pool.chunks[i].memory);
+        pool.chunks[i] = DxvkMemoryChunk();
+      }
+    }
+  }
+
+
+  VkDeviceSize DxvkMemoryAllocator::determineMaxChunkSize(
+    const DxvkMemoryType&       type,
+          bool                  mappable) const {
+    VkDeviceSize size = DxvkMemoryPool::MaxChunkSize;
+
+    // Prefer smaller chunks for host-visible allocations in order to
+    // reduce the amount of address space required. We compensate for
+    // the smaller size by allowing more unused memory on these heaps.
+    if (mappable)
+      size /= env::is32BitHostPlatform() ? 16u : 4u;
+
+    // Ensure that we can at least do a handful of allocations to fill
+    // the heap. Important on systems with a small BAR or a small heap.
+    while (MinAllocationsPerHeap * size > type.heap->properties.size)
+      size /= 2u;
+
+    // Always use at least the minimum chunk size
+    return std::max(size, DxvkMemoryPool::MinChunkSize);
+  }
+
+
+  void DxvkMemoryAllocator::determineMemoryTypesWithPropertyFlags() {
+    // Initialize look-up table for memory type masks based on required
+    // property flags. This lets us avoid iterating over unsuitable types.
+    for (uint32_t i = 0; i < m_memTypesByPropertyFlags.size(); i++) {
+      VkMemoryPropertyFlags flags = VkMemoryPropertyFlags(i);
+
+      uint32_t vidmemMask = 0u;
+      uint32_t sysmemMask = 0u;
+
+      for (uint32_t j = 0; j < m_memTypeCount; j++) {
+        VkMemoryPropertyFlags typeFlags = m_memTypes[j].memType.propertyFlags;
+
+        if ((typeFlags & flags) != flags)
+          continue;
+
+        if (typeFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)
+          vidmemMask |= 1u << j;
+        else
+          sysmemMask |= 1u << j;
+      }
+
+      // If a system memory type exists with the given properties, do not
+      // include any device-local memory types. This way we won't ever pick
+      // host-visible vram when explicitly trying to allocate system memory.
+      m_memTypesByPropertyFlags[i] = sysmemMask ? sysmemMask : vidmemMask;
+    }
+
+    uint32_t hostCachedIndex = uint32_t(
+      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+      VK_MEMORY_PROPERTY_HOST_COHERENT_BIT |
+      VK_MEMORY_PROPERTY_HOST_CACHED_BIT);
+
+    uint32_t hostCoherentIndex = uint32_t(
+      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+      VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+
+    uint32_t hostVisibleVramIndex = uint32_t(
+      VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
+      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+      VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+
+    // If there is no cached coherent memory type, reuse the uncached
+    // one. This is likely slow, but API front-ends rely on it.
+    if (!m_memTypesByPropertyFlags[hostCachedIndex])
+      m_memTypesByPropertyFlags[hostCachedIndex] = m_memTypesByPropertyFlags[hostCoherentIndex];
+
+    // If we zero mapped memory, we need good CPU memory bandwidth.
+    // Prefer uncached system memory over HVV in that case.
+    if (m_device->config().zeroMappedMemory)
+      m_memTypesByPropertyFlags[hostVisibleVramIndex] = m_memTypesByPropertyFlags[hostCoherentIndex];
+
+    // On tilers, uncached stores are expected to be very slow. Always
+    // use cached memory for mapped allocations there. This replaces the
+    // cached-first, uncached-on-failure retry the allocator used to do.
+    if (m_device->perfHints().preferCachedMemory) {
+      m_memTypesByPropertyFlags[hostCoherentIndex] = m_memTypesByPropertyFlags[hostCachedIndex];
+      m_memTypesByPropertyFlags[hostVisibleVramIndex] = m_memTypesByPropertyFlags[hostCachedIndex];
+    }
+  }
+
+
+  uint32_t DxvkMemoryAllocator::getMemoryTypeMask(
+          VkMemoryPropertyFlags properties) const {
+    return m_memTypesByPropertyFlags[uint32_t(properties) % uint32_t(m_memTypesByPropertyFlags.size())];
+  }
+
+
+  DxvkMemoryStats DxvkMemoryAllocator::getMemoryStats(uint32_t heap) const {
+    DxvkMemoryStats result = { };
+
+    for (uint32_t i = 0; i < m_memTypeCount; i++) {
+      if (!(m_memHeaps[heap].memoryTypes & (1u << i)))
+        continue;
+
+      result.memoryAllocated += m_memTypes[i].stats.memoryAllocated;
+      result.memoryUsed      += m_memTypes[i].stats.memoryUsed;
+    }
+
+    result.memoryBudget = m_memHeaps[heap].memoryBudget;
+    return result;
+  }
+
+
+  void DxvkMemoryAllocator::updateMemoryHeapBudgets() {
+    if (!m_device->extensions().extMemoryBudget)
+      return;
+
+    VkDeviceSize maxBudget = m_device->config().maxMemoryBudget;
+
+    DxvkAdapterMemoryInfo memHeapInfo = m_device->adapter()->getMemoryHeapInfo();
+
+    for (uint32_t i = 0; i < m_memHeapCount; i++) {
+      if (!memHeapInfo.heaps[i].memoryBudget)
+        continue;
+
+      // Deduct driver-internal allocations from the resource budget
+      VkDeviceSize allocated = getMemoryStats(i).memoryAllocated;
+
+      VkDeviceSize internal = std::max(memHeapInfo.heaps[i].memoryAllocated, allocated) - allocated;
+                   internal = std::min(memHeapInfo.heaps[i].memoryBudget, internal);
+
+      m_memHeaps[i].memoryBudget = std::min(
+        memHeapInfo.heaps[i].memoryBudget - internal,
+        m_memHeaps[i].properties.size);
+
+      if (maxBudget)
+        m_memHeaps[i].memoryBudget = std::min(m_memHeaps[i].memoryBudget, maxBudget);
+    }
+  }
+
+
+  void DxvkMemoryAllocator::logMemoryError(
+    const VkMemoryRequirements& req,
+          VkMemoryPropertyFlags flags) const {
+    Logger::err(str::format(
+      "DxvkMemoryAllocator: Memory allocation failed",
+      "\n  Size:      ", req.size,
+      "\n  Alignment: ", req.alignment,
+      "\n  Mem flags: ", "0x", std::hex, flags,
+      "\n  Mem types: ", "0x", std::hex, req.memoryTypeBits));
+  }
+
+
+  void DxvkMemoryAllocator::logMemoryStats() const {
+    DxvkAdapterMemoryInfo memHeapInfo = m_device->adapter()->getMemoryHeapInfo();
+
+    for (uint32_t i = 0; i < m_memHeapCount; i++) {
+      DxvkMemoryStats stats = getMemoryStats(i);
+
+      Logger::err(str::format("Heap ", i, ": ",
+        (stats.memoryAllocated >> 20), " MB allocated, ",
+        (stats.memoryUsed      >> 20), " MB used, ",
+        m_device->extensions().extMemoryBudget
+          ? str::format(
+              (memHeapInfo.heaps[i].memoryAllocated >> 20), " MB allocated (driver), ",
+              (memHeapInfo.heaps[i].memoryBudget    >> 20), " MB budget (driver), ",
+              (m_memHeaps[i].properties.size        >> 20), " MB total")
+          : str::format(
+              (m_memHeaps[i].properties.size        >> 20), " MB total")));
     }
   }
 

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include "dxvk_adapter.h"
+#include "dxvk_allocator.h"
 
 namespace dxvk {
 
   class DxvkMemoryAllocator;
-  class DxvkMemoryChunk;
 
   /**
    * \brief Memory stats
@@ -16,6 +16,7 @@ namespace dxvk {
   struct DxvkMemoryStats {
     VkDeviceSize memoryAllocated = 0;
     VkDeviceSize memoryUsed      = 0;
+    VkDeviceSize memoryBudget    = 0;
   };
 
 
@@ -57,6 +58,58 @@ namespace dxvk {
     VkDeviceSize          memSize    = 0;
     VkMemoryPropertyFlags memFlags   = 0;
     float                 priority   = 0.0f;
+    uint64_t              cookie     = 0;
+  };
+
+
+  /**
+   * \brief Memory chunk
+   *
+   * Stores a device memory object with some metadata.
+   * Chunks are addressed by index within their pool.
+   */
+  struct DxvkMemoryChunk {
+    DxvkDeviceMemory memory;
+  };
+
+
+  /**
+   * \brief Memory pool
+   *
+   * Stores a list of memory chunks, as well as an
+   * allocator covering the entire pool. Small
+   * allocations are served from size-class pools
+   * so that they cannot fragment larger regions.
+   */
+  struct DxvkMemoryPool {
+    constexpr static VkDeviceSize MaxChunkSize = DxvkPageAllocator::MaxChunkSize;
+    constexpr static VkDeviceSize MinChunkSize = MaxChunkSize / 64u;
+
+    /// Backing storage for allocated memory chunks
+    std::vector<DxvkMemoryChunk> chunks;
+    /// Memory allocator covering the entire memory pool
+    DxvkPageAllocator pageAllocator;
+    /// Pool allocator that sits on top of the page allocator
+    DxvkPoolAllocator poolAllocator = { pageAllocator };
+    /// Minimum desired allocation size for the next chunk.
+    /// Always a power of two.
+    VkDeviceSize nextChunkSize = MinChunkSize;
+    /// Maximum chunk size for the memory pool. Hard limit.
+    VkDeviceSize maxChunkSize = MaxChunkSize;
+
+    int64_t alloc(uint64_t size, uint64_t align) {
+      if (size <= DxvkPoolAllocator::MaxSize)
+        return poolAllocator.alloc(size);
+      else
+        return pageAllocator.alloc(size, align);
+    }
+
+    bool free(uint64_t address, uint64_t size) {
+      if (size <= DxvkPoolAllocator::MaxSize)
+        return poolAllocator.free(address, size);
+      else
+        return pageAllocator.free(address, size);
+    }
   };
 
 
@@ -64,12 +117,14 @@ namespace dxvk {
    * \brief Memory heap
    *
    * Corresponds to a Vulkan memory heap and stores
-   * its properties as well as allocation statistics.
+   * its properties as well as the current budget.
    */
   struct DxvkMemoryHeap {
-    VkMemoryHeap      properties;
-    DxvkMemoryStats   stats;
-    VkDeviceSize      budget;
+    uint32_t          index         = 0u;
+    uint32_t          memoryTypes   = 0u;
+    VkMemoryHeap      properties    = { };
+    VkDeviceSize      memoryBudget  = 0u;
+    VkBool32          enforceBudget = VK_FALSE;
   };
 
 
@@ -77,19 +132,20 @@ namespace dxvk {
    * \brief Memory type
    *
    * Corresponds to a Vulkan memory type and stores
-   * memory chunks used to sub-allocate memory on
-   * this memory type.
+   * the memory pools used to sub-allocate memory on
+   * this memory type. Mappable and non-mappable
+   * allocations are kept in separate pools.
    */
   struct DxvkMemoryType {
-    DxvkMemoryHeap*   heap;
-    uint32_t          heapId;
+    uint32_t          index         = 0u;
+    VkMemoryType      memType       = { };
 
-    VkMemoryType      memType;
-    uint32_t          memTypeId;
+    DxvkMemoryHeap*   heap          = nullptr;
 
-    VkDeviceSize      chunkSize;
+    DxvkMemoryStats   stats         = { };
 
-    std::vector<Rc<DxvkMemoryChunk>> chunks;
+    DxvkMemoryPool    devicePool;
+    DxvkMemoryPool    mappedPool;
   };
 
 
@@ -104,14 +160,6 @@ namespace dxvk {
   public:
 
     DxvkMemory();
-    DxvkMemory(
-      DxvkMemoryAllocator*  alloc,
-      DxvkMemoryChunk*      chunk,
-      DxvkMemoryType*       type,
-      VkDeviceMemory        memory,
-      VkDeviceSize          offset,
-      VkDeviceSize          length,
-      void*                 mapPtr);
     DxvkMemory             (DxvkMemory&& other);
     DxvkMemory& operator = (DxvkMemory&& other);
     ~DxvkMemory();
@@ -169,13 +217,22 @@ namespace dxvk {
 
   private:
 
-    DxvkMemoryAllocator*  m_alloc  = nullptr;
-    DxvkMemoryChunk*      m_chunk  = nullptr;
-    DxvkMemoryType*       m_type   = nullptr;
-    VkDeviceMemory        m_memory = VK_NULL_HANDLE;
-    VkDeviceSize          m_offset = 0;
-    VkDeviceSize          m_length = 0;
-    void*                 m_mapPtr = nullptr;
+    DxvkMemory(
+      DxvkMemoryAllocator*  alloc,
+      DxvkMemoryType*       type,
+      VkDeviceMemory        memory,
+      VkDeviceSize          address,
+      VkDeviceSize          offset,
+      VkDeviceSize          length,
+      void*                 mapPtr);
+
+    DxvkMemoryAllocator*  m_alloc   = nullptr;
+    DxvkMemoryType*       m_type    = nullptr;
+    VkDeviceMemory        m_memory  = VK_NULL_HANDLE;
+    VkDeviceSize          m_address = 0;
+    VkDeviceSize          m_offset  = 0;
+    VkDeviceSize          m_length  = 0;
+    void*                 m_mapPtr  = nullptr;
 
     void free();
 
@@ -185,8 +242,9 @@ namespace dxvk {
   /**
    * \brief Memory allocation flags
    *
-   * Used to batch similar allocations into the same
-   * set of chunks, which may help with fragmentation.
+   * Retained for the benefit of callers. Chunk grouping is
+   * derived from the memory type and from the allocation
+   * size, so these no longer influence placement.
    */
   enum class DxvkMemoryFlag : uint32_t {
     Small             = 0,  ///< Small allocation
@@ -200,93 +258,6 @@ namespace dxvk {
 
 
   /**
-   * \brief Memory chunk
-   *
-   * A single chunk of memory that provides a
-   * sub-allocator. This is not thread-safe.
-   */
-  class DxvkMemoryChunk : public RcObject {
-
-  public:
-
-    DxvkMemoryChunk(
-            DxvkMemoryAllocator*  alloc,
-            DxvkMemoryType*       type,
-            DxvkDeviceMemory      memory,
-            DxvkMemoryFlags       m_hints);
-
-    ~DxvkMemoryChunk();
-
-    /**
-     * \brief Allocates memory from the chunk
-     *
-     * On failure, this returns a slice with
-     * \c VK_NULL_HANDLE as the memory handle.
-     * \param [in] flags Requested memory type flags
-     * \param [in] size Number of bytes to allocate
-     * \param [in] align Required alignment
-     * \param [in] hints Memory category
-     * \returns The allocated memory slice
-     */
-    DxvkMemory alloc(
-            VkMemoryPropertyFlags flags,
-            VkDeviceSize          size,
-            VkDeviceSize          align,
-            DxvkMemoryFlags       hints);
-
-    /**
-     * \brief Frees memory
-     *
-     * Returns a slice back to the chunk.
-     * Called automatically when a memory
-     * slice runs out of scope.
-     * \param [in] offset Slice offset
-     * \param [in] length Slice length
-     */
-    void free(
-            VkDeviceSize  offset,
-            VkDeviceSize  length);
-
-    /**
-     * \brief Checks whether the chunk is being used
-     * \returns \c true if there are no allocations left
-     */
-    bool isEmpty() const;
-
-    /**
-     * \brief Checks whether hints and flags of another chunk match
-     * \param [in] other The chunk to compare to
-     */
-    bool isCompatible(const Rc<DxvkMemoryChunk>& other) const;
-
-    /**
-     * \brief Queries chunk size
-     * \returns Chunk size, in bytes
-     */
-    VkDeviceSize size() const {
-      return m_memory.memSize;
-    }
-
-  private:
-
-    struct FreeSlice {
-      VkDeviceSize offset;
-      VkDeviceSize length;
-    };
-
-    DxvkMemoryAllocator*  m_alloc;
-    DxvkMemoryType*       m_type;
-    DxvkDeviceMemory      m_memory;
-    DxvkMemoryFlags       m_hints;
-
-    std::vector<FreeSlice> m_freeList;
-
-    bool checkHints(DxvkMemoryFlags hints) const;
-
-  };
-
-
-  /**
    * \brief Memory allocator
    *
    * Allocates device memory for Vulkan resources.
@@ -294,12 +265,16 @@ namespace dxvk {
    */
   class DxvkMemoryAllocator {
     friend class DxvkMemory;
-    friend class DxvkMemoryChunk;
 
-    constexpr static VkDeviceSize SmallAllocationThreshold = 256 << 10;
+    /// Address bit that marks a dedicated allocation. Dedicated
+    /// allocations do not belong to any chunk in any pool.
+    constexpr static VkDeviceSize DedicatedChunkAddress = VkDeviceSize(1) << 63;
 
-    constexpr static VkDeviceSize MinChunkSize =   4ull << 20;
-    constexpr static VkDeviceSize MaxChunkSize = 256ull << 20;
+    constexpr static VkDeviceSize MinChunkSize = DxvkMemoryPool::MinChunkSize;
+    constexpr static VkDeviceSize MaxChunkSize = DxvkMemoryPool::MaxChunkSize;
+
+    /// Minimum number of allocations we want to be able to fit into a heap
+    constexpr static uint32_t MinAllocationsPerHeap = 7u;
   public:
 
     DxvkMemoryAllocator(const DxvkDevice* device);
@@ -342,9 +317,7 @@ namespace dxvk {
      * \param [in] heap Heap index
      * \returns Memory stats for this heap
      */
-    DxvkMemoryStats getMemoryStats(uint32_t heap) const {
-      return m_memHeaps[heap].stats;
-    }
+    DxvkMemoryStats getMemoryStats(uint32_t heap) const;
 
     /**
      * \brief Whether mapped memory should be zero-initialized
@@ -360,63 +333,85 @@ namespace dxvk {
     const VkPhysicalDeviceMemoryProperties m_memProps;
 
     dxvk::mutex                                     m_mutex;
-    std::array<DxvkMemoryHeap, VK_MAX_MEMORY_HEAPS> m_memHeaps;
-    std::array<DxvkMemoryType, VK_MAX_MEMORY_TYPES> m_memTypes;
 
-    DxvkMemory tryAlloc(
-      const VkMemoryRequirements*             req,
-      const VkMemoryDedicatedAllocateInfo*    dedAllocInfo,
-            VkMemoryPropertyFlags             flags,
-            DxvkMemoryFlags                   hints);
+    uint32_t m_memTypeCount = 0u;
+    uint32_t m_memHeapCount = 0u;
 
-    DxvkMemory tryAllocFromType(
-            DxvkMemoryType*                   type,
-            VkMemoryPropertyFlags             flags,
-            VkDeviceSize                      size,
-            VkDeviceSize                      align,
-            DxvkMemoryFlags                   hints,
-      const VkMemoryDedicatedAllocateInfo*    dedAllocInfo);
+    std::array<DxvkMemoryHeap, VK_MAX_MEMORY_HEAPS> m_memHeaps = { };
+    std::array<DxvkMemoryType, VK_MAX_MEMORY_TYPES> m_memTypes = { };
 
-    DxvkDeviceMemory tryAllocDeviceMemory(
-            DxvkMemoryType*                   type,
-            VkMemoryPropertyFlags             flags,
-            VkDeviceSize                      size,
-            DxvkMemoryFlags                   hints,
-      const VkMemoryDedicatedAllocateInfo*    dedAllocInfo);
+    std::array<uint32_t, 16> m_memTypesByPropertyFlags = { };
+
+    uint64_t m_nextCookie = 0u;
+
+    DxvkMemory allocateMemory(
+      const VkMemoryRequirements& req,
+            VkMemoryPropertyFlags properties);
+
+    DxvkMemory allocateDedicatedMemory(
+      const VkMemoryRequirements& req,
+            VkMemoryPropertyFlags properties,
+      const void*                 next);
+
+    DxvkDeviceMemory allocateDeviceMemory(
+            DxvkMemoryType&       type,
+            VkDeviceSize          size,
+            VkMemoryPropertyFlags properties,
+      const void*                 next);
+
+    bool allocateChunkInPool(
+            DxvkMemoryType&       type,
+            DxvkMemoryPool&       pool,
+            VkMemoryPropertyFlags properties,
+            VkDeviceSize          requiredSize,
+            VkDeviceSize          desiredSize);
+
+    DxvkMemory createMemory(
+            DxvkMemoryType&       type,
+            DxvkMemoryPool&       pool,
+            VkDeviceSize          address,
+            VkDeviceSize          size);
+
+    DxvkMemory createMemory(
+            DxvkMemoryType&       type,
+      const DxvkDeviceMemory&     memory);
 
     void free(
       const DxvkMemory&           memory);
 
-    void freeChunkMemory(
-            DxvkMemoryType*       type,
-            DxvkMemoryChunk*      chunk,
-            VkDeviceSize          offset,
-            VkDeviceSize          length);
-
     void freeDeviceMemory(
-            DxvkMemoryType*       type,
+            DxvkMemoryType&       type,
             DxvkDeviceMemory      memory);
 
-    VkDeviceSize pickChunkSize(
-            uint32_t              memTypeId,
-            VkDeviceSize          requiredSize,
-            DxvkMemoryFlags       hints) const;
+    bool freeEmptyChunksInPool(
+            DxvkMemoryType&       type,
+            DxvkMemoryPool&       pool,
+            VkDeviceSize          allocationSize);
 
-    void adjustChunkSize(
-            uint32_t              memTypeId,
-            VkDeviceSize          allocatedSize,
-            DxvkMemoryFlags       hints);
+    void freeEmptyChunksInHeap(
+      const DxvkMemoryHeap&       heap,
+            VkDeviceSize          allocationSize);
 
-    bool shouldFreeChunk(
-      const DxvkMemoryType*       type,
-      const Rc<DxvkMemoryChunk>&  chunk) const;
+    void freeAllChunksInPool(
+            DxvkMemoryType&       type,
+            DxvkMemoryPool&       pool);
 
-    bool shouldFreeEmptyChunks(
-      const DxvkMemoryHeap*       heap,
-            VkDeviceSize          allocationSize) const;
+    VkDeviceSize determineMaxChunkSize(
+      const DxvkMemoryType&       type,
+            bool                  mappable) const;
 
-    void freeEmptyChunks(
-      const DxvkMemoryHeap*       heap);
+    void determineMemoryTypesWithPropertyFlags();
+
+    uint32_t getMemoryTypeMask(
+            VkMemoryPropertyFlags properties) const;
+
+    void updateMemoryHeapBudgets();
+
+    void logMemoryError(
+      const VkMemoryRequirements& req,
+            VkMemoryPropertyFlags flags) const;
+
+    void logMemoryStats() const;
 
   };
 

--- a/src/dxvk/hud/dxvk_hud_item.cpp
+++ b/src/dxvk/hud/dxvk_hud_item.cpp
@@ -530,7 +530,9 @@ namespace dxvk::hud {
 
       uint64_t memUsedMib = m_heaps[i].memoryUsed >> 20;
       uint64_t memAllocatedMib = m_heaps[i].memoryAllocated >> 20;
-      uint64_t percentage = (100 * m_heaps[i].memoryAllocated) / m_memory.memoryHeaps[i].size;
+      uint64_t percentage = m_heaps[i].memoryBudget
+        ? (100 * m_heaps[i].memoryAllocated) / m_heaps[i].memoryBudget
+        : 0u;
 
       std::string label = str::format(isDeviceLocal ? "Vidmem" : "Sysmem", " heap ", i, ": ");
       std::string text  = str::format(std::setfill(' '), std::setw(5), memAllocatedMib, " MB (", percentage, "%) ",

--- a/src/dxvk/meson.build
+++ b/src/dxvk/meson.build
@@ -60,6 +60,7 @@ dxvk_shaders = files([
 
 dxvk_src = [
   'dxvk_adapter.cpp',
+  'dxvk_allocator.cpp',
   'dxvk_asynccompiler.cpp',
   'dxvk_barrier.cpp',
   'dxvk_buffer.cpp',

--- a/src/util/util_bit.h
+++ b/src/util/util_bit.h
@@ -379,7 +379,8 @@ namespace dxvk::bit {
 
     };
 
-    BitMask() { }
+    BitMask()
+      : m_mask(0) { }
 
     BitMask(uint32_t n)
       : m_mask(n) { }

--- a/src/util/util_bit.h
+++ b/src/util/util_bit.h
@@ -92,6 +92,38 @@ namespace dxvk::bit {
     #endif
   }
 
+  inline uint32_t tzcnt(uint64_t n) {
+    #if defined(DXVK_ARCH_X86_64) && defined(_MSC_VER) && !defined(__clang__)
+    if (n == 0)
+      return 64;
+    return (uint32_t)_tzcnt_u64(n);
+    #elif defined(DXVK_ARCH_X86_64) && defined(__BMI__)
+    return __tzcnt_u64(n);
+    #elif defined(DXVK_ARCH_X86_64) && (defined(__GNUC__) || defined(__clang__))
+    uint64_t res;
+    uint64_t tmp;
+    asm (
+      "tzcnt %2, %0;"
+      "mov  $64, %1;"
+      "test  %2, %2;"
+      "cmovz %1, %0;"
+      : "=&r" (res), "=&r" (tmp)
+      : "r" (n)
+      : "cc");
+    return res;
+    #elif defined(__GNUC__) || defined(__clang__)
+    return n != 0 ? __builtin_ctzll(n) : 64;
+    #else
+    uint32_t lo = uint32_t(n);
+    if (lo) {
+      return tzcnt(lo);
+    } else {
+      uint32_t hi = uint32_t(n >> 32);
+      return tzcnt(hi) + 32;
+    }
+    #endif
+  }
+
   inline uint32_t bsf(uint32_t n) {
     #if defined(_MSC_VER) && !defined(__clang__)
     unsigned long index;


### PR DESCRIPTION
draft, replaces the old chunk allocator with upstreams page and pool
allocators. should stop memory from creeping up over long sessions and
after level transitions or menu cycling.

if you were hitting oom crashes please give this a try and let me know
if it helps. DXVK_HUD=memory is useful here, the allocated number should
stay flat instead of climbing.

@Nemris
@iWisp360

https://github.com/pythonlover02/DXVK-Sarek/issues/61
https://github.com/pythonlover02/DXVK-Sarek/issues/47
https://github.com/CachyOS/proton-cachyos/issues/250

working artifact: [artifact](https://github.com/pythonlover02/DXVK-Sarek/actions/runs/33230049091)