### PR TITLE
[build] Update the GitHub CI flows

### DIFF
--- a/.github/workflows/artifacts-steamrt.yml
+++ b/.github/workflows/artifacts-steamrt.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         include:
           - variant: sniper
-            runner: ubuntu-22.04
+            runner: ubuntu-latest
             image: registry.gitlab.steamos.cloud/proton/sniper/sdk:latest
             arches: 32 64
             make_args: >-
@@ -25,7 +25,7 @@ jobs:
               ARCHDIR_64=x86_64-windows
               MESON_OPTS_64=-Denable_ddraw=false
           - variant: steamrt4
-            runner: ubuntu-22.04
+            runner: ubuntu-latest
             image: registry.gitlab.steamos.cloud/proton/steamrt4/sdk/x86_64:latest
             arches: 32 64
             make_args: >-
@@ -53,13 +53,13 @@ jobs:
     steps:
     - name: Checkout code
       id: checkout-code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
         fetch-depth: 0
 
     - name: Setup problem matcher
-      uses: Joshua-Ashton/gcc-problem-matcher@v3
+      uses: Joshua-Ashton/gcc-problem-matcher@master
 
     - name: Get version
       id: get-version
@@ -75,7 +75,7 @@ jobs:
 
     - name: Upload artifacts
       id: upload-artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: dxvk-sarek-${{ matrix.variant }}-${{ env.VERSION_NAME }}
         path: build/dist/dxvk-sarek-${{ env.VERSION }}

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -4,18 +4,22 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   artifacts-mingw-w64:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    container: archlinux/archlinux:base-devel
 
     steps:
+    - name: Install dependencies
+      run: pacman -Syu --needed --noconfirm git meson mingw-w64-gcc glslang
+
     - name: Checkout code
       id: checkout-code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
         fetch-depth: 0
 
     - name: Setup problem matcher
-      uses: Joshua-Ashton/gcc-problem-matcher@v3
+      uses: Joshua-Ashton/gcc-problem-matcher@master
 
     - name: Get version
       id: get-version
@@ -26,15 +30,13 @@ jobs:
 
     - name: Build dist tree
       id: build-dist
-      uses: WinterSnowfall/arch-mingw-github-action@v2
-      with:
-        command: |
-          make
-          make dist
+      run: |
+        make
+        make dist
 
     - name: Upload artifacts
       id: upload-artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: dxvk-sarek-${{ env.VERSION_NAME }}
         path: build/dist/dxvk-sarek-${{ env.VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   release-container:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     env:
       CONTAINER: docker
@@ -18,7 +18,7 @@ jobs:
     steps:
     - name: Checkout code
       id: checkout-code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
         fetch-depth: 0
@@ -33,7 +33,7 @@ jobs:
 
     - name: Upload artifacts
       id: upload-artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: dxvk-sarek-${{ github.ref_name }}
         path: releases/*

--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - name: Checkout code
       id: checkout-code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
         fetch-depth: 0
@@ -82,19 +82,19 @@ jobs:
 
     - name: Upload artifacts
       id: upload-artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: dxvk-sarek-${{ env.VERSION_NAME }}-msvc-output
         path: artifacts\*
         if-no-files-found: error
 
   check-version:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code
       id: checkout-code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Check version sync
       id: check-version


### PR DESCRIPTION
Some CI tweaks in preparation for a v2.2 D7VK backport:
- use `ubuntu-latest` for runners where possible, just like upstream DXVK
- update all the third party actions to their latest revisions
- install the required dependencies directly on the `archlinux:base-devel` image rather than using an external action for that part (I plan to deprecate my action runner soon anyway, as everyone else has migrated away from it)