### PR TITLE
[d3d7] Backport D7VK v2.2 and enable per-stage color keying

### DIFF
--- a/src/d3d9/d3d9_bridge.cpp
+++ b/src/d3d9/d3d9_bridge.cpp
@@ -104,13 +104,12 @@ namespace dxvk {
     return m_device->ResetSwapChain(Params, nullptr);
   }
 
-  HRESULT DxvkLegacyD3DDeviceBridge::SetColorKeyState(bool colorKeyState) {
-    return m_device->SetColorKeyState(colorKeyState);
+  HRESULT DxvkLegacyD3DDeviceBridge::SetColorKeyState(DWORD stage, bool colorKeyState) {
+    return m_device->SetColorKeyState(stage, colorKeyState);
   }
 
-  HRESULT DxvkLegacyD3DDeviceBridge::SetColorKey(DWORD colorKeyLow, DWORD colorKeyHigh) {
-    // D7VK currently only sets color key for stage 0 due to spec consts size constraints in modern DXVK.
-    return m_device->SetColorKey(0, colorKeyLow, colorKeyHigh);
+  HRESULT DxvkLegacyD3DDeviceBridge::SetColorKey(DWORD stage, DWORD colorKeyLow, DWORD colorKeyHigh) {
+    return m_device->SetColorKey(stage, colorKeyLow, colorKeyHigh);
   }
 
   HRESULT DxvkLegacyD3DDeviceBridge::SetLegacyLightsState(bool legacyLightsState) {

--- a/src/d3d9/d3d9_bridge.h
+++ b/src/d3d9/d3d9_bridge.h
@@ -69,28 +69,31 @@ IDxvkLegacyD3DDeviceBridge : public IUnknown {
   /**
    * \brief Updates the color key transparency state in D3D9
    *
-   * \param [in] Params bool value to be used
+   * \param [in] stage DWORD texture stage to be used
+   * \param [in] colorKeyState bool value to be used
    */
-  virtual HRESULT SetColorKeyState(bool colorKeyState) = 0;
+  virtual HRESULT SetColorKeyState(DWORD stage, bool colorKeyState) = 0;
 
   /**
    * \brief Updates the color key transparency value in D3D9
    *
-   * \param [in] Params DWORD, DWORD low and high values to be used
+   * \param [in] stage DWORD texture stage to be used
+   * \param [in] colorKeyLow DWORD low color key range boundary
+   * \param [in] colorKeyHigh DWORR high color key range boundary
    */
-  virtual HRESULT SetColorKey(DWORD colorKeyLow, DWORD colorKeyHigh) = 0;
+  virtual HRESULT SetColorKey(DWORD stage, DWORD colorKeyLow, DWORD colorKeyHigh) = 0;
 
   /**
    * \brief Updates the legacy light state in D3D9
    *
-   * \param [in] Params bool value to be used
+   * \param [in] legacyLightsState bool value to be used
    */
   virtual HRESULT SetLegacyLightsState(bool legacyLightsState) = 0;
 
   /**
    * \brief Updates the alternate pixel center state in D3D9
    *
-   * \param [in] Params bool value to be used
+   * \param [in] alternatePixelCenter bool value to be used
    */
   virtual HRESULT SetAlternatePixelCenter(bool alternatePixelCenter) = 0;
 };
@@ -154,9 +157,9 @@ namespace dxvk {
 
     HRESULT ResetSwapChain(D3DPRESENT_PARAMETERS* Params);
 
-    HRESULT SetColorKeyState(bool colorKeyState);
+    HRESULT SetColorKeyState(DWORD stage, bool colorKeyState);
 
-    HRESULT SetColorKey(DWORD colorKeyLow, DWORD colorKeyHigh);
+    HRESULT SetColorKey(DWORD stage, DWORD colorKeyLow, DWORD colorKeyHigh);
 
     HRESULT SetLegacyLightsState(bool legacyLightsState);
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -7267,10 +7267,11 @@ namespace dxvk {
 
         stage.SampleDref = (m_depthTextures & (1 << idx)) != 0;
 
-        stage.ColorKeyLow  = m_colorKeyLow[idx];
-        stage.ColorKeyHigh = m_colorKeyHigh[idx];
-        stage.AddressU     = m_state.samplerStates[idx][D3DSAMP_ADDRESSU];
-        stage.AddressV     = m_state.samplerStates[idx][D3DSAMP_ADDRESSV];
+        stage.ColorKeyEnable = m_useColorKey[idx];
+        stage.ColorKeyLow    = m_colorKeyLow[idx];
+        stage.ColorKeyHigh   = m_colorKeyHigh[idx];
+        stage.AddressU       = m_state.samplerStates[idx][D3DSAMP_ADDRESSU];
+        stage.AddressV       = m_state.samplerStates[idx][D3DSAMP_ADDRESSV];
       }
 
       auto& stage0 = key.Stages[0].Contents;
@@ -7282,7 +7283,6 @@ namespace dxvk {
         stage0.AlphaArg1 = D3DTA_DIFFUSE;
       }
 
-      stage0.GlobalColorKeyEnable = m_useColorKey;
       stage0.GlobalSpecularEnable = m_state.renderStates[D3DRS_SPECULARENABLE];
       stage0.GlobalFlatShade      = m_state.renderStates[D3DRS_SHADEMODE] == D3DSHADE_FLAT;
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -927,9 +927,9 @@ namespace dxvk {
 
     HRESULT ResetState(D3DPRESENT_PARAMETERS* pPresentationParameters);
 
-    HRESULT SetColorKeyState(bool colorKeyState) {
-      if (unlikely(m_useColorKey != colorKeyState)) {
-        m_useColorKey = colorKeyState;
+    HRESULT SetColorKeyState(DWORD stage, bool colorKeyState) {
+      if (unlikely(m_useColorKey[stage] != colorKeyState)) {
+        m_useColorKey[stage] = colorKeyState;
         m_flags.set(D3D9DeviceFlag::DirtyFFPixelShader);
       }
       return D3D_OK;
@@ -1301,8 +1301,9 @@ namespace dxvk {
 
     bool                            m_isSWVP;
 
-    // D3D7 and earlier texture colorkeying
-    bool                            m_useColorKey = false;
+    // D3D7 and earlier texture color keying
+    std::array<bool,
+      caps::MaxSimultaneousTextures> m_useColorKey = { };
     std::array<DWORD,
       caps::MaxSimultaneousTextures> m_colorKeyLow = { };
     std::array<DWORD,

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -1731,8 +1731,7 @@ namespace dxvk {
           // Colorkeying reads back a texel by integer coordinate, which limits
           // it to 2D stages: the size query answers with a three component
           // vector for a volume texture, and the math below assumes two.
-          if (m_fsKey.Stages[0].Contents.GlobalColorKeyEnable
-           && D3DRESOURCETYPE(stage.Type + D3DRTYPE_TEXTURE) == D3DRTYPE_TEXTURE) {
+          if (stage.ColorKeyEnable && D3DRESOURCETYPE(stage.Type + D3DRTYPE_TEXTURE) == D3DRTYPE_TEXTURE) {
             uint32_t image = m_module.opImage(m_ps.samplers[i].origTypeId, imageVarId);
 
             // The sampling coordinate carries an extra component for projected

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -166,10 +166,10 @@ namespace dxvk {
         // Affects all stages.
         uint32_t     GlobalSpecularEnable : 1;
         uint32_t     GlobalFlatShade      : 1;
-        uint32_t     GlobalColorKeyEnable : 1;
 
         uint32_t     AddressU        : 3;
         uint32_t     AddressV        : 3;
+        uint32_t     ColorKeyEnable  : 1;
         uint32_t     ColorKeyLow     : 32;
         uint32_t     ColorKeyHigh    : 32;
       } Contents;

--- a/src/ddraw/d3d3/d3d3_device.cpp
+++ b/src/ddraw/d3d3/d3d3_device.cpp
@@ -16,6 +16,8 @@
 
 namespace dxvk {
 
+  std::atomic<D3DMATRIXHANDLE> D3D3Device::s_matrixHandle = 0;
+
   D3D3Device::D3D3Device(
         D3DCommonDevice* commonD3DDevice,
         DDrawSurface* pParent,
@@ -50,6 +52,9 @@ namespace dxvk {
         Logger::warn("D3D3Device: Force enabling AA");
         device9->SetRenderState(d3d9::D3DRS_MULTISAMPLEANTIALIAS, TRUE);
       }
+
+      // D3DRENDERSTATE_COLORKEYENABLE defaults to TRUE on a D3D3 device
+      m_commonD3DDevice->SetColorKeyEnable(TRUE);
     } else {
       device9 = m_commonD3DDevice->GetD3D9Device();
       // Very important, otherwise the depth stencil isn't dirtied on draws
@@ -91,23 +96,25 @@ namespace dxvk {
       m_commonD3DDevice->SetOrigin(nullptr);
   }
 
-  // Interlocked refcount with the origin device
+  // Interlocked refcount with the origin device, or
+  // the parent RT surface, in case of a pure D3D3 device
   ULONG STDMETHODCALLTYPE D3D3Device::AddRef() {
     IUnknown* origin = m_commonD3DDevice->GetOrigin();
     if (unlikely(origin != nullptr && origin != this)) {
       return origin->AddRef();
     } else {
-      return ComObjectClamp::AddRef();
+      return m_parent->AddRef();
     }
   }
 
-  // Interlocked refcount with the origin device
+  // Interlocked refcount with the origin device, or
+  // the parent RT surface, in case of a pure D3D3 device
   ULONG STDMETHODCALLTYPE D3D3Device::Release() {
     IUnknown* origin = m_commonD3DDevice->GetOrigin();
     if (unlikely(origin != nullptr && origin != this)) {
       return origin->Release();
     } else {
-      return ComObjectClamp::Release();
+      return m_parent->Release();
     }
   }
 
@@ -141,8 +148,7 @@ namespace dxvk {
 
       // Apparently all of these should return a reference to the parent surface
       if (riid == IID_IDirect3DHALDevice  || riid == IID_IDirect3DRGBDevice  ||
-          riid == IID_IDirect3DMMXDevice  || riid == IID_IDirect3DRampDevice ||
-          riid == IID_WineD3DDevice) {
+          riid == IID_IDirect3DRampDevice || riid == IID_WineD3DDevice) {
         *ppvObject = ref(m_parent);
         return S_OK;
       }
@@ -213,6 +219,9 @@ namespace dxvk {
 
     const D3DTEXTUREHANDLE handle1 = commonTex1->GetTextureHandle();
     const D3DTEXTUREHANDLE handle2 = commonTex2->GetTextureHandle();
+
+    if (unlikely(!handle1 || !handle2))
+      return DDERR_INVALIDPARAMS;
 
     DDrawCommonInterface::ReleaseTextureHandle(handle1);
     DDrawCommonInterface::ReleaseTextureHandle(handle2);
@@ -420,21 +429,24 @@ namespace dxvk {
     return D3D_OK;
   }
 
+  // No idea what this is supposed to do in practice, but there aren't any known uses anyway
   HRESULT STDMETHODCALLTYPE D3D3Device::Initialize(IDirect3D *d3d, GUID *lpGUID, D3DDEVICEDESC *desc) {
-    if (unlikely(d3d == nullptr))
-      return DDERR_INVALIDPARAMS;
-
-    return D3D_OK;
+    return DDERR_ALREADYINITIALIZED;
   }
 
   HRESULT STDMETHODCALLTYPE D3D3Device::CreateExecuteBuffer(D3DEXECUTEBUFFERDESC *desc, IDirect3DExecuteBuffer **buffer, IUnknown *pkOuter) {
     if (unlikely(desc == nullptr || buffer == nullptr))
       return DDERR_INVALIDPARAMS;
 
+    InitReturnPtr(buffer);
+
     if (unlikely(desc->dwSize != sizeof(D3DEXECUTEBUFFERDESC)))
       return DDERR_INVALIDPARAMS;
 
-    InitReturnPtr(buffer);
+    // "The D3DEXECUTEBUFFERDESC structure describes the execute buffer to be created.
+    //  At a minimum, the application must specify the size required."
+    if (unlikely(!(desc->dwFlags & D3DDEB_BUFSIZE)))
+      return DDERR_INVALIDPARAMS;
 
     *buffer = ref(new D3D3ExecuteBuffer(this, desc));
 
@@ -616,7 +628,7 @@ namespace dxvk {
 
                 ProcessVerticesData pvData;
                 pvData.inData = buf + executeData->dwVertexOffset + pv.wStart * sizeof(D3DVERTEX);
-                pvData.inFVF = doLighting ? D3DFVF_VERTEX : D3DFVF_LVERTEX;
+                pvData.inFVF = op == D3DPROCESSVERTICES_TRANSFORMLIGHT ? D3DFVF_VERTEX : D3DFVF_LVERTEX;
                 pvData.inStride = sizeof(D3DVERTEX);
                 pvData.outData = buf + executeData->dwHVertexOffset + pv.wDest * sizeof(D3DTLVERTEX);
                 pvData.outFVF = D3DFVF_TLVERTEX;
@@ -772,12 +784,12 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D3Device::CreateMatrix(D3DMATRIXHANDLE *matrix) {
     D3DDeviceLock lock = LockDevice();
 
-    m_matrixHandle++;
-    m_matrices.emplace(std::piecewise_construct,
-                       std::forward_as_tuple(m_matrixHandle),
+    D3DMATRIXHANDLE matrixHandle = ++s_matrixHandle;
+    s_matrices.emplace(std::piecewise_construct,
+                       std::forward_as_tuple(matrixHandle),
                        std::forward_as_tuple(D3DMATRIX()));
 
-    *matrix = m_matrixHandle;
+    *matrix = matrixHandle;
 
     return D3D_OK;
   }
@@ -788,9 +800,9 @@ namespace dxvk {
     if (unlikely(matrix == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    auto matrixIter = m_matrices.find(handle);
+    auto matrixIter = s_matrices.find(handle);
 
-    if (likely(matrixIter != m_matrices.end())) {
+    if (likely(matrixIter != s_matrices.end())) {
       matrixIter->second = *matrix;
     } else {
       Logger::warn("D3D3Device::SetMatrix: Matrix not found");
@@ -823,9 +835,9 @@ namespace dxvk {
     if (unlikely(matrix == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    auto matrixIter = m_matrices.find(handle);
+    auto matrixIter = s_matrices.find(handle);
 
-    if (likely(matrixIter != m_matrices.end())) {
+    if (likely(matrixIter != s_matrices.end())) {
       *matrix = matrixIter->second;
     } else {
       Logger::warn(str::format("D3D3Device::GetMatrix: Matrix not found: ", handle));
@@ -838,10 +850,10 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D3Device::DeleteMatrix(D3DMATRIXHANDLE D3DMatHandle) {
     D3DDeviceLock lock = LockDevice();
 
-    auto matrixIter = m_matrices.find(D3DMatHandle);
+    auto matrixIter = s_matrices.find(D3DMatHandle);
 
-    if (likely(matrixIter != m_matrices.end())) {
-      m_matrices.erase(matrixIter);
+    if (likely(matrixIter != s_matrices.end())) {
+      s_matrices.erase(matrixIter);
     } else {
       Logger::warn("D3D3Device::DeleteMatrix: Matrix not found");
       return DDERR_INVALIDPARAMS;
@@ -1012,6 +1024,7 @@ namespace dxvk {
       case D3DRENDERSTATE_FOGTABLEEND:
       case D3DRENDERSTATE_FOGTABLEDENSITY:
       //case D3DRENDERSTATE_STIPPLEENABLE:
+      //case D3DRENDERSTATE_COLORKEYENABLE: // Apparently can be toggled in D3D3 as well
       //case D3DRENDERSTATE_STIPPLEPATTERN00:
       //case D3DRENDERSTATE_STIPPLEPATTERN01:
       //case D3DRENDERSTATE_STIPPLEPATTERN02:
@@ -1280,6 +1293,27 @@ namespace dxvk {
       case D3DRENDERSTATE_STIPPLEENABLE:
         return D3D_OK;
 
+      // Technically, this doesn't exist in D3D3, but some Wine tests appear to suggest
+      // it can be toggled even with execute buffers, so handle it anyway...
+      case D3DRENDERSTATE_COLORKEYENABLE: {
+        m_commonD3DDevice->SetColorKeyEnable(dwRenderState);
+
+        const D3DTEXTUREHANDLE currentTextureHandle = m_commonD3DDevice->GetCurrentTextureHandle();
+        DDrawSurface* surface = currentTextureHandle != 0 ?
+                                DDrawCommonInterface::GetSurfaceFromTextureHandle(currentTextureHandle) : nullptr;
+        // Color keying is always enabled on RGB devices, regardless of D3DRENDERSTATE_COLORKEYENABLE
+        const bool colorKeyEnable = !m_commonD3DDevice->IsHALOrTNLHALDevice() || dwRenderState;
+        const bool validColorKey = surface != nullptr ? surface->GetCommonSurface()->HasValidColorKey() : false;
+        m_bridge->SetColorKeyState(0, colorKeyEnable && validColorKey);
+        if (colorKeyEnable && validColorKey) {
+          const DDCOLORKEY* normalizedColorKey = surface->GetCommonSurface()->GetColorKeyNormalized();
+          m_bridge->SetColorKey(0, normalizedColorKey->dwColorSpaceLowValue,
+                                normalizedColorKey->dwColorSpaceHighValue);
+        }
+
+        return D3D_OK;
+      }
+
       // Tests have shown age accurate GPUs didn't offer support for stippling at all
       case D3DRENDERSTATE_STIPPLEPATTERN00:
       case D3DRENDERSTATE_STIPPLEPATTERN01:
@@ -1503,8 +1537,11 @@ namespace dxvk {
         return hr;
       }
 
-      if (likely(m_commonD3DDevice->GetCurrentTextureHandle() != 0))
+      if (likely(m_commonD3DDevice->GetCurrentTextureHandle() != 0)) {
+        m_texture = nullptr;
         m_commonD3DDevice->SetCurrentTextureHandle(0);
+        m_bridge->SetColorKeyState(0, false);
+      }
 
       return D3D_OK;
     }
@@ -1528,13 +1565,15 @@ namespace dxvk {
 
     d3d9::IDirect3DTexture9* tex9 = commonSurface->GetD3D9Texture();
 
-    if (likely(tex9 != nullptr)) {
-      hr = device9->SetTexture(0, tex9);
-      if (unlikely(FAILED(hr))) {
-        Logger::warn("D3D3Device::SetTextureInternal: Failed to bind D3D9 texture");
-        return hr;
-      }
+    // If a surface without a D3D9 texture gets bound, simply unbind the current texture.
+    // This is needed to handle the binding of surfaces which aren't explicitly marked as textures.
+    hr = device9->SetTexture(0, tex9);
+    if (unlikely(FAILED(hr))) {
+      Logger::warn("D3D3Device::SetTextureInternal: Failed to bind D3D9 texture");
+      return hr;
+    }
 
+    if (likely(tex9 != nullptr)) {
       // "Any alpha values in the texture replace the alpha values in the colors that would
       //  have been used with no texturing; if the texture does not contain an alpha component,
       //  alpha values at the vertices in the source are interpolated between vertices."
@@ -1543,18 +1582,18 @@ namespace dxvk {
         device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP, textureOp);
       }
 
-      // D3D3 enables color key transparency globally
+      // Color keying is always enabled on RGB devices, regardless of D3DRENDERSTATE_COLORKEYENABLE
+      const bool colorKeyEnable = !m_commonD3DDevice->IsHALOrTNLHALDevice() || m_commonD3DDevice->GetColorKeyEnable();
       const bool validColorKey = commonSurface->HasValidColorKey();
-      m_bridge->SetColorKeyState(validColorKey);
-      if (validColorKey) {
-        DDCOLORKEY normalizedColorKey = commonSurface->GetColorKeyNormalized();
-        m_bridge->SetColorKey(normalizedColorKey.dwColorSpaceLowValue,
-                              normalizedColorKey.dwColorSpaceHighValue);
+      m_bridge->SetColorKeyState(0, colorKeyEnable && validColorKey);
+      if (colorKeyEnable && validColorKey) {
+        const DDCOLORKEY* normalizedColorKey = commonSurface->GetColorKeyNormalized();
+        m_bridge->SetColorKey(0, normalizedColorKey->dwColorSpaceLowValue,
+                              normalizedColorKey->dwColorSpaceHighValue);
       }
-    } else {
-      Logger::err("D3D3Device::SetTextureInternal: Found no valid D3D9 texture");
     }
 
+    m_texture = surface;
     m_commonD3DDevice->SetCurrentTextureHandle(textureHandle);
 
     return D3D_OK;

--- a/src/ddraw/d3d3/d3d3_device.h
+++ b/src/ddraw/d3d3/d3d3_device.h
@@ -95,7 +95,7 @@ namespace dxvk {
     }
 
     DDrawSurface* GetRenderTarget() const {
-      return m_rt.ptr();
+      return m_rt;
     }
 
     DDrawSurface* GetDepthStencil() const {
@@ -141,8 +141,11 @@ namespace dxvk {
 
     D3DDEVICEDESC3                  m_desc;
 
-    Com<DDrawSurface>               m_rt;
+    // In D3D3, the RT is the parent of the device
+    DDrawSurface*                   m_rt               = nullptr;
     Com<DDrawSurface, false>        m_ds;
+
+    Com<DDrawSurface, false>        m_texture;
 
     Com<D3D3Viewport>               m_currentViewport;
     std::vector<Com<D3D3Viewport>>  m_viewports;
@@ -153,8 +156,10 @@ namespace dxvk {
     D3DMATRIXHANDLE                 m_viewHandle       = 0;
     D3DMATRIXHANDLE                 m_projectionHandle = 0;
 
-    std::atomic<D3DMATRIXHANDLE>    m_matrixHandle     = 0;
-    std::unordered_map<D3DMATRIXHANDLE, D3DMATRIX> m_matrices;
+    // Tests have indicated that once created, matrix handles are
+    // shared across all devices, regardless of their relation
+    static std::atomic<D3DMATRIXHANDLE> s_matrixHandle;
+    static inline std::unordered_map<D3DMATRIXHANDLE, D3DMATRIX> s_matrices;
 
   };
 

--- a/src/ddraw/d3d3/d3d3_execute_buffer.cpp
+++ b/src/ddraw/d3d3/d3d3_execute_buffer.cpp
@@ -6,11 +6,7 @@ namespace dxvk {
 
   D3D3ExecuteBuffer::D3D3ExecuteBuffer(D3D3Device* pParent, D3DEXECUTEBUFFERDESC* pDesc)
     : DDrawChildObject<D3D3Device, IDirect3DExecuteBuffer>(pParent) {
-    if (likely(pDesc->dwFlags & D3DDEB_BUFSIZE)) {
-      m_buffer.resize(pDesc->dwBufferSize);
-    } else {
-      Logger::warn("D3D3ExecuteBuffer: No buffer size specified during initialization");
-    }
+    m_buffer.resize(pDesc->dwBufferSize);
   }
 
   D3D3ExecuteBuffer::~D3D3ExecuteBuffer() {
@@ -42,8 +38,9 @@ namespace dxvk {
     if (unlikely(lpData == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    if (unlikely(m_buffer.size() == 0))
-      return DDERR_INVALIDPARAMS;
+    // Not validated by native for GetExecuteData() calls
+    //if (unlikely(lpData->dwSize != sizeof(D3DEXECUTEDATA)))
+      //return DDERR_INVALIDPARAMS;
 
     *lpData = m_executeData;
 
@@ -65,11 +62,11 @@ namespace dxvk {
     if (unlikely(lpDesc == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    if (unlikely(m_locked))
-      return D3DERR_EXECUTE_LOCKED;
-
     if (unlikely(lpDesc->dwSize != sizeof(D3DEXECUTEBUFFERDESC)))
       return DDERR_INVALIDPARAMS;
+
+    if (unlikely(m_locked))
+      return D3DERR_EXECUTE_LOCKED;
 
     lpDesc->dwFlags = D3DDEB_BUFSIZE | D3DDEB_LPDATA;
     lpDesc->dwBufferSize = m_buffer.size();
@@ -91,14 +88,25 @@ namespace dxvk {
     if (unlikely(m_executed))
       lock = m_parent->LockDevice();
 
-    if (unlikely(lpData == nullptr || m_buffer.size() == 0))
+    if (unlikely(lpData == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    if (unlikely(lpData->dwInstructionOffset + lpData->dwInstructionLength > m_buffer.size()))
+    if (unlikely(lpData->dwSize != sizeof(D3DEXECUTEDATA)))
       return DDERR_INVALIDPARAMS;
 
-    if (unlikely(lpData->dwVertexOffset + lpData->dwVertexCount > m_buffer.size()))
-      return DDERR_INVALIDPARAMS;
+    const size_t instructionSize = lpData->dwInstructionOffset + lpData->dwInstructionLength;
+    const size_t vertexSize      = lpData->dwVertexOffset + lpData->dwVertexCount * sizeof(D3DVERTEX);
+    const size_t hVertexSize     = lpData->dwHVertexOffset + lpData->dwVertexCount * sizeof(D3DTLVERTEX);
+    const size_t bufferSize      = m_buffer.size();
+
+    // Not validated by native, thus the call will succeed even if the buffer size is insufficient.
+    // Incoming sends a lot of such junk calls, but apparently doesn't blow up because of it.
+    if (unlikely(instructionSize > bufferSize || vertexSize > bufferSize || hVertexSize > bufferSize)) {
+      static bool s_bufferSizeWarningShow;
+
+      if (!std::exchange(s_bufferSizeWarningShow, true))
+        Logger::warn("D3D3ExecuteBuffer::SetExecuteData: Buffer size is insufficient for specified data");
+    }
 
     m_executeData = *lpData;
 

--- a/src/ddraw/d3d3/d3d3_execute_buffer.h
+++ b/src/ddraw/d3d3/d3d3_execute_buffer.h
@@ -51,10 +51,10 @@ namespace dxvk {
 
   private:
 
-    bool                 m_locked     = false;
-    bool                 m_executed   = false;
+    std::atomic<bool>    m_locked      = false;
+    std::atomic<bool>    m_executed    = false;
 
-    D3DEXECUTEDATA       m_executeData;
+    D3DEXECUTEDATA       m_executeData = { };
 
     std::vector<uint8_t> m_buffer;
 

--- a/src/ddraw/d3d3/d3d3_interface.cpp
+++ b/src/ddraw/d3d3/d3d3_interface.cpp
@@ -269,7 +269,7 @@ namespace dxvk {
 
     InitReturnPtr(lplpDirect3DMaterial);
 
-    *lplpDirect3DMaterial = ref(new D3D3Material(this));
+    *lplpDirect3DMaterial = ref(new D3D3Material(nullptr, this));
 
     return D3D_OK;
   }
@@ -328,8 +328,8 @@ namespace dxvk {
     lpD3DFRD3.dwSize = sizeof(D3DFINDDEVICERESULT3);
 
     if (lpD3DFDS->dwFlags & D3DFDS_GUID) {
+      // IID_IDirect3DMMXDevice returns DDERR_NOTFOUND in D3D3
       if (lpD3DFDS->guid == IID_IDirect3DRGBDevice ||
-          lpD3DFDS->guid == IID_IDirect3DMMXDevice ||
           lpD3DFDS->guid == IID_IDirect3DRampDevice) {
         lpD3DFRD3.guid = IID_IDirect3DRGBDevice;
         lpD3DFRD3.ddHwDesc = descRGB_HAL;
@@ -338,8 +338,10 @@ namespace dxvk {
         lpD3DFRD3.guid = IID_IDirect3DHALDevice;
         lpD3DFRD3.ddHwDesc = descHAL_HAL;
         lpD3DFRD3.ddSwDesc = descHAL_HEL;
+      } else if (lpD3DFDS->guid == IID_IDirect3DMMXDevice) {
+        return DDERR_NOTFOUND;
       } else {
-        Logger::err(str::format("D3D3Interface::FindDevice: Unknown device type: ", lpD3DFDS->guid));
+        Logger::warn(str::format("D3D3Interface::FindDevice: Unknown device type: ", lpD3DFDS->guid));
         return DDERR_NOTFOUND;
       }
 

--- a/src/ddraw/d3d3/d3d3_material.cpp
+++ b/src/ddraw/d3d3/d3d3_material.cpp
@@ -12,9 +12,12 @@
 namespace dxvk {
 
   D3D3Material::D3D3Material(
+        D3DCommonMaterial* commonMaterial,
         D3D3Interface* pParent)
-    : DDrawChildObject<D3D3Interface, IDirect3DMaterial>(pParent) {
-    m_commonMaterial = new D3DCommonMaterial();
+    : DDrawChildObject<D3D3Interface, IDirect3DMaterial>(pParent)
+    , m_commonMaterial ( commonMaterial ) {
+    if (m_commonMaterial == nullptr)
+      m_commonMaterial = new D3DCommonMaterial();
 
     m_commonMaterial->SetD3D3Material(this);
   }

--- a/src/ddraw/d3d3/d3d3_material.h
+++ b/src/ddraw/d3d3/d3d3_material.h
@@ -13,7 +13,7 @@ namespace dxvk {
 
   public:
 
-    D3D3Material(D3D3Interface* pParent);
+    D3D3Material(D3DCommonMaterial* commonMaterial, D3D3Interface* pParent);
 
     ~D3D3Material();
 

--- a/src/ddraw/d3d3/d3d3_texture.cpp
+++ b/src/ddraw/d3d3/d3d3_texture.cpp
@@ -116,6 +116,10 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D3Texture::Load(LPDIRECT3DTEXTURE lpD3DTexture) {
     Com<D3D3Texture> d3d3Texture = static_cast<D3D3Texture*>(lpD3DTexture);
 
+    // Fast skip
+    if (unlikely(d3d3Texture == this))
+      return D3D_OK;
+
     // Note: Will not work if IDirect3DTexture is queried directly
     // from IDirectDrawSurface4, though that shouldn't happen in practice
     DDrawSurface* parentSurf = d3d3Texture->GetCommonTexture()->GetDDSurface();

--- a/src/ddraw/d3d5/d3d5_device.cpp
+++ b/src/ddraw/d3d5/d3d5_device.cpp
@@ -208,6 +208,9 @@ namespace dxvk {
     const D3DTEXTUREHANDLE handle1 = commonTex1->GetTextureHandle();
     const D3DTEXTUREHANDLE handle2 = commonTex2->GetTextureHandle();
 
+    if (unlikely(!handle1 || !handle2))
+      return DDERR_INVALIDPARAMS;
+
     DDrawCommonInterface::ReleaseTextureHandle(handle1);
     DDrawCommonInterface::ReleaseTextureHandle(handle2);
 
@@ -543,9 +546,20 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D5Device::Begin(D3DPRIMITIVETYPE d3dptPrimitiveType, D3DVERTEXTYPE dwVertexTypeDesc, DWORD dwFlags) {
     D3DDeviceLock lock = LockDevice();
 
-    m_vertexStreamInfo.d3dpt = d3dptPrimitiveType;
-    m_vertexStreamInfo.d3dvt = dwVertexTypeDesc;
-    m_vertexStreamInfo.dwFlags = dwFlags;
+    if (unlikely(m_vertexStream.isInitialized()))
+      return DDERR_INVALIDPARAMS;
+
+    if (unlikely(dwVertexTypeDesc != D3DVT_VERTEX
+              && dwVertexTypeDesc != D3DVT_LVERTEX
+              && dwVertexTypeDesc != D3DVT_TLVERTEX)) {
+      Logger::err(">>> D3D5Device::Begin: Invalid vertex type");
+      return DDERR_INVALIDPARAMS;
+    }
+
+    m_vertexStream.d3dpt = d3dptPrimitiveType;
+    m_vertexStream.d3dvt = dwVertexTypeDesc;
+    m_vertexStream.dwFlags = dwFlags;
+    m_vertexStream.initialize();
 
     return D3D_OK;
   }
@@ -561,18 +575,20 @@ namespace dxvk {
     if (unlikely(vertex == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    switch (m_vertexStreamInfo.d3dvt) {
+    if (unlikely(!m_vertexStream.isInitialized()))
+      return DDERR_INVALIDPARAMS;
+
+    switch (m_vertexStream.d3dvt) {
       case D3DVT_VERTEX:
-        m_vertexStream.push_back(*reinterpret_cast<D3DVERTEX*>(vertex));
+        m_vertexStream.stream.vertex->push_back(*reinterpret_cast<D3DVERTEX*>(vertex));
         break;
       case D3DVT_LVERTEX:
-        m_lvertexStream.push_back(*reinterpret_cast<D3DLVERTEX*>(vertex));
+        m_vertexStream.stream.lvertex->push_back(*reinterpret_cast<D3DLVERTEX*>(vertex));
         break;
       case D3DVT_TLVERTEX:
-        m_tlvertexStream.push_back(*reinterpret_cast<D3DTLVERTEX*>(vertex));
+        m_vertexStream.stream.tlvertex->push_back(*reinterpret_cast<D3DTLVERTEX*>(vertex));
         break;
       default:
-        Logger::warn(">>> D3D5Device::Vertex: Invalid vertex type");
         return DDERR_INVALIDPARAMS;
     }
 
@@ -587,33 +603,35 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D5Device::End(DWORD dwFlags) {
     D3DDeviceLock lock = LockDevice();
 
+    if (unlikely(!m_vertexStream.isInitialized()))
+      return DDERR_INVALIDPARAMS;
+
     HRESULT hr;
 
-    switch (m_vertexStreamInfo.d3dvt) {
+    switch (m_vertexStream.d3dvt) {
       case D3DVT_VERTEX:
-        hr = DrawPrimitive(m_vertexStreamInfo.d3dpt, m_vertexStreamInfo.d3dvt, m_vertexStream.data(),
-                           m_vertexStream.size(), m_vertexStreamInfo.dwFlags);
-        m_vertexStream.clear();
+        hr = DrawPrimitive(m_vertexStream.d3dpt, m_vertexStream.d3dvt,
+                           m_vertexStream.stream.vertex->data(),
+                           m_vertexStream.stream.vertex->size(), m_vertexStream.dwFlags);
         break;
       case D3DVT_LVERTEX:
-        hr = DrawPrimitive(m_vertexStreamInfo.d3dpt, m_vertexStreamInfo.d3dvt, m_lvertexStream.data(),
-                           m_lvertexStream.size(), m_vertexStreamInfo.dwFlags);
-        m_lvertexStream.clear();
+        hr = DrawPrimitive(m_vertexStream.d3dpt, m_vertexStream.d3dvt,
+                           m_vertexStream.stream.lvertex->data(),
+                           m_vertexStream.stream.lvertex->size(), m_vertexStream.dwFlags);
         break;
       case D3DVT_TLVERTEX:
-        hr = DrawPrimitive(m_vertexStreamInfo.d3dpt, m_vertexStreamInfo.d3dvt, m_tlvertexStream.data(),
-                           m_tlvertexStream.size(), m_vertexStreamInfo.dwFlags);
-        m_tlvertexStream.clear();
+        hr = DrawPrimitive(m_vertexStream.d3dpt, m_vertexStream.d3dvt,
+                           m_vertexStream.stream.tlvertex->data(),
+                           m_vertexStream.stream.tlvertex->size(), m_vertexStream.dwFlags);
         break;
       default:
-        Logger::warn(">>> D3D5Device::End: Invalid vertex type");
         return DDERR_INVALIDPARAMS;
     }
 
     if (unlikely(FAILED(hr)))
       Logger::err(">>> D3D5Device::End: Failed call to DrawPrimitive");
 
-    m_vertexStreamInfo = { };
+    m_vertexStream.reset();
 
     return hr;
   }
@@ -1001,9 +1019,6 @@ namespace dxvk {
         if (unlikely(FAILED(hr)))
           return hr;
 
-        if (unlikely(surface == nullptr))
-          m_bridge->SetColorKeyState(false);
-
         return D3D_OK;
       }
 
@@ -1242,11 +1257,12 @@ namespace dxvk {
         DDrawSurface* surface = currentTextureHandle != 0 ?
                                 DDrawCommonInterface::GetSurfaceFromTextureHandle(currentTextureHandle) : nullptr;
         const bool validColorKey = surface != nullptr ? surface->GetCommonSurface()->HasValidColorKey() : false;
-        m_bridge->SetColorKeyState(dwRenderState && validColorKey);
+        m_bridge->SetColorKeyState(0, dwRenderState && validColorKey);
+
         if (dwRenderState && validColorKey) {
-          DDCOLORKEY normalizedColorKey = surface->GetCommonSurface()->GetColorKeyNormalized();
-          m_bridge->SetColorKey(normalizedColorKey.dwColorSpaceLowValue,
-                                normalizedColorKey.dwColorSpaceHighValue);
+          const DDCOLORKEY* normalizedColorKey = surface->GetCommonSurface()->GetColorKeyNormalized();
+          m_bridge->SetColorKey(0, normalizedColorKey->dwColorSpaceLowValue,
+                                normalizedColorKey->dwColorSpaceHighValue);
         }
 
         return D3D_OK;
@@ -1444,13 +1460,15 @@ namespace dxvk {
     d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     const DWORD vertex_type5 = ConvertVertexType(vertex_type);
+    const bool isTransformed = vertex_type5 & D3DFVF_XYZRHW;
     const bool useLighting = !(flags & D3DDP_DONOTLIGHT) &&
                               (vertex_type5 & D3DFVF_NORMAL) &&
                               m_commonD3DDevice->GetCurrentMaterialHandle() != 0;
 
     if (!useLighting)
       device9->SetRenderState(d3d9::D3DRS_LIGHTING, FALSE);
-    HandlePreDrawLegacyProjection(device9, flags);
+    if (!isTransformed)
+      HandlePreDrawLegacyProjection(device9, flags);
 
     device9->SetFVF(vertex_type5);
     HRESULT hr = device9->DrawPrimitiveUP(
@@ -1461,7 +1479,8 @@ namespace dxvk {
 
     if (!useLighting)
       device9->SetRenderState(d3d9::D3DRS_LIGHTING, TRUE);
-    HandlePostDrawLegacyProjection(device9);
+    if (!isTransformed)
+      HandlePostDrawLegacyProjection(device9);
 
     if (unlikely(FAILED(hr))) {
       Logger::err("D3D5Device::DrawPrimitive: Failed D3D9 call to DrawPrimitiveUP");
@@ -1489,13 +1508,15 @@ namespace dxvk {
     d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
     const DWORD fvf5 = ConvertVertexType(fvf);
+    const bool isTransformed = fvf5 & D3DFVF_XYZRHW;
     const bool useLighting = !(flags & D3DDP_DONOTLIGHT) &&
                               (fvf5 & D3DFVF_NORMAL) &&
                               m_commonD3DDevice->GetCurrentMaterialHandle() != 0;
 
     if (!useLighting)
       device9->SetRenderState(d3d9::D3DRS_LIGHTING, FALSE);
-    HandlePreDrawLegacyProjection(device9, flags);
+    if (!isTransformed)
+      HandlePreDrawLegacyProjection(device9, flags);
 
     device9->SetFVF(fvf5);
     HRESULT hr = device9->DrawIndexedPrimitiveUP(
@@ -1510,7 +1531,8 @@ namespace dxvk {
 
     if (!useLighting)
       device9->SetRenderState(d3d9::D3DRS_LIGHTING, TRUE);
-    HandlePostDrawLegacyProjection(device9);
+    if (!isTransformed)
+      HandlePostDrawLegacyProjection(device9);
 
     if (unlikely(FAILED(hr))) {
       Logger::err("D3D5Device::DrawIndexedPrimitive: Failed D3D9 call to DrawIndexedPrimitiveUP");
@@ -1623,8 +1645,11 @@ namespace dxvk {
         return hr;
       }
 
-      if (likely(m_commonD3DDevice->GetCurrentTextureHandle() != 0))
+      if (likely(m_commonD3DDevice->GetCurrentTextureHandle() != 0)) {
+        m_texture = nullptr;
         m_commonD3DDevice->SetCurrentTextureHandle(0);
+        m_bridge->SetColorKeyState(0, false);
+      }
 
       return D3D_OK;
     }
@@ -1648,13 +1673,15 @@ namespace dxvk {
 
     d3d9::IDirect3DTexture9* tex9 = commonSurface->GetD3D9Texture();
 
-    if (likely(tex9 != nullptr)) {
-      hr = device9->SetTexture(0, tex9);
-      if (unlikely(FAILED(hr))) {
-        Logger::warn("D3D5Device::SetTextureInternal: Failed to bind D3D9 texture");
-        return hr;
-      }
+    // If a surface without a D3D9 texture gets bound, simply unbind the current texture.
+    // This is needed to handle the binding of surfaces which aren't explicitly marked as textures.
+    hr = device9->SetTexture(0, tex9);
+    if (unlikely(FAILED(hr))) {
+      Logger::warn("D3D5Device::SetTextureInternal: Failed to bind D3D9 texture");
+      return hr;
+    }
 
+    if (likely(tex9 != nullptr)) {
       // "Any alpha values in the texture replace the alpha values in the colors that would
       //  have been used with no texturing; if the texture does not contain an alpha component,
       //  alpha values at the vertices in the source are interpolated between vertices."
@@ -1665,16 +1692,16 @@ namespace dxvk {
 
       const bool colorKeyEnable = m_commonD3DDevice->GetColorKeyEnable();
       const bool validColorKey = commonSurface->HasValidColorKey();
-      m_bridge->SetColorKeyState(colorKeyEnable && validColorKey);
+      m_bridge->SetColorKeyState(0, colorKeyEnable && validColorKey);
+
       if (colorKeyEnable && validColorKey) {
-        DDCOLORKEY normalizedColorKey = commonSurface->GetColorKeyNormalized();
-        m_bridge->SetColorKey(normalizedColorKey.dwColorSpaceLowValue,
-                              normalizedColorKey.dwColorSpaceHighValue);
+        const DDCOLORKEY* normalizedColorKey = commonSurface->GetColorKeyNormalized();
+        m_bridge->SetColorKey(0, normalizedColorKey->dwColorSpaceLowValue,
+                              normalizedColorKey->dwColorSpaceHighValue);
       }
-    } else {
-      Logger::err("D3D5Device::SetTextureInternal: Found no valid D3D9 texture");
     }
 
+    m_texture = surface;
     m_commonD3DDevice->SetCurrentTextureHandle(textureHandle);
 
     return D3D_OK;

--- a/src/ddraw/d3d5/d3d5_device.h
+++ b/src/ddraw/d3d5/d3d5_device.h
@@ -148,7 +148,8 @@ namespace dxvk {
 
         if (m_legacyProjection != nullptr) {
           device9->GetTransform(d3d9::D3DTS_PROJECTION, &m_projectionMatrix);
-          device9->MultiplyTransform(d3d9::D3DTS_PROJECTION, m_legacyProjection);
+          device9->SetTransform(d3d9::D3DTS_PROJECTION, m_legacyProjection);
+          device9->MultiplyTransform(d3d9::D3DTS_PROJECTION, &m_projectionMatrix);
         }
       }
     }
@@ -174,16 +175,15 @@ namespace dxvk {
     Com<DDrawSurface>               m_rt;
     Com<DDrawSurface, false>        m_ds;
 
+    Com<DDrawSurface, false>        m_texture;
+
     Com<D3D5Viewport>               m_currentViewport;
     std::vector<Com<D3D5Viewport>>  m_viewports;
 
     D3DMATRIX                       m_projectionMatrix = { };
     const D3DMATRIX*                m_legacyProjection = nullptr;
 
-    VertexStreamInfo                m_vertexStreamInfo;
-    std::vector<D3DVERTEX>          m_vertexStream;
-    std::vector<D3DLVERTEX>         m_lvertexStream;
-    std::vector<D3DTLVERTEX>        m_tlvertexStream;
+    VertexStream                    m_vertexStream;
 
   };
 

--- a/src/ddraw/d3d5/d3d5_interface.cpp
+++ b/src/ddraw/d3d5/d3d5_interface.cpp
@@ -264,7 +264,7 @@ namespace dxvk {
 
     InitReturnPtr(lplpDirect3DMaterial);
 
-    *lplpDirect3DMaterial = ref(new D3D5Material(this));
+    *lplpDirect3DMaterial = ref(new D3D5Material(nullptr, this));
 
     return D3D_OK;
   }
@@ -335,7 +335,7 @@ namespace dxvk {
         lpD3DFRD2.ddHwDesc = descHAL_HAL;
         lpD3DFRD2.ddSwDesc = descHAL_HEL;
       } else {
-        Logger::err(str::format("D3D5Interface::FindDevice: Unknown device type: ", lpD3DFDS->guid));
+        Logger::warn(str::format("D3D5Interface::FindDevice: Unknown device type: ", lpD3DFDS->guid));
         return DDERR_NOTFOUND;
       }
 
@@ -388,29 +388,31 @@ namespace dxvk {
     bool  halFallback          = false;
     bool  rgbFallback          = false;
 
-    if (likely(!d3dOptions->forceSWVP)) {
-      if (rclsid == IID_IDirect3DHALDevice) {
-        Logger::info("D3D5Interface::CreateDevice: Creating an IID_IDirect3DHALDevice device");
+    if (rclsid == IID_IDirect3DHALDevice) {
+      Logger::info("D3D5Interface::CreateDevice: Creating an IID_IDirect3DHALDevice device");
+      if (likely(!d3dOptions->forceSWVP))
         deviceCreationFlags9 = D3DCREATE_MIXED_VERTEXPROCESSING;
-        isHALDevice = true;
-      } else if (rclsid == IID_IDirect3DRGBDevice) {
-        Logger::info("D3D5Interface::CreateDevice: Creating an IID_IDirect3DRGBDevice device");
-      } else if (rclsid == IID_IDirect3DMMXDevice) {
-        Logger::warn("D3D5Interface::CreateDevice: Unsupported MMX device, falling back to RGB");
-        rgbFallback = true;
-      } else if (rclsid == IID_IDirect3DRampDevice) {
-        Logger::warn("D3D5Interface::CreateDevice: Unsupported Ramp device, falling back to RGB");
-        rgbFallback = true;
+      isHALDevice = true;
+    } else if (rclsid == IID_IDirect3DRGBDevice) {
+      Logger::info("D3D5Interface::CreateDevice: Creating an IID_IDirect3DRGBDevice device");
+    } else if (rclsid == IID_IDirect3DMMXDevice) {
+      Logger::warn("D3D5Interface::CreateDevice: Unsupported MMX device, falling back to RGB");
+      rgbFallback = true;
+    } else if (rclsid == IID_IDirect3DRampDevice) {
+      Logger::warn("D3D5Interface::CreateDevice: Unsupported Ramp device, falling back to RGB");
+      rgbFallback = true;
+    } else if (unlikely(rclsid == IID_IUnknown)) {
+      Logger::warn("D3D5Interface::CreateDevice: Unsupported IID_IUnknown, falling back to RGB");
+      rgbFallback = true;
+    } else {
+      if (unlikely(rclsid != IID_WineD3DDevice)) {
+        Logger::warn("D3D5Interface::CreateDevice: Unknown device type, falling back to HAL");
+        Logger::warn(str::format(rclsid));
       } else {
-        if (unlikely(rclsid != IID_WineD3DDevice)) {
-          Logger::warn("D3D5Interface::CreateDevice: Unknown device type, falling back to HAL");
-          Logger::warn(str::format(rclsid));
-        } else {
-          Logger::info("D3D5Interface::CreateDevice: Creating an IID_WineD3DDevice HAL device");
-        }
-        halFallback = true;
-        // Don't enforce isHALDevice RT validations
+        Logger::info("D3D5Interface::CreateDevice: Creating an IID_WineD3DDevice HAL device");
       }
+      halFallback = true;
+      // Don't enforce isHALDevice RT validations
     }
 
     const IID rclsidOverride = halFallback ? IID_IDirect3DHALDevice :

--- a/src/ddraw/d3d5/d3d5_material.cpp
+++ b/src/ddraw/d3d5/d3d5_material.cpp
@@ -12,9 +12,12 @@
 namespace dxvk {
 
   D3D5Material::D3D5Material(
+        D3DCommonMaterial* commonMaterial,
         D3D5Interface* pParent)
-    : DDrawChildObject<D3D5Interface, IDirect3DMaterial2>(pParent) {
-    m_commonMaterial = new D3DCommonMaterial();
+    : DDrawChildObject<D3D5Interface, IDirect3DMaterial2>(pParent)
+    , m_commonMaterial ( commonMaterial ) {
+    if (m_commonMaterial == nullptr)
+      m_commonMaterial = new D3DCommonMaterial();
 
     m_commonMaterial->SetD3D5Material(this);
   }

--- a/src/ddraw/d3d5/d3d5_material.h
+++ b/src/ddraw/d3d5/d3d5_material.h
@@ -13,7 +13,7 @@ namespace dxvk {
 
   public:
 
-    D3D5Material(D3D5Interface* pParent);
+    D3D5Material(D3DCommonMaterial* commonMaterial, D3D5Interface* pParent);
 
     ~D3D5Material();
 

--- a/src/ddraw/d3d5/d3d5_texture.cpp
+++ b/src/ddraw/d3d5/d3d5_texture.cpp
@@ -16,18 +16,16 @@ namespace dxvk {
         IUnknown* pParent,
         bool isD3D6Texture)
     : DDrawWrappedObject<IUnknown, IDirect3DTexture2>(pParent, std::move(proxyTexture))
-    , m_commonTex ( commonTex )
-    , m_commonIntf ( commonSurf->GetCommonInterface() ) {
+    , m_commonTex  ( commonTex )
+    , m_commonIntf ( commonSurf->GetCommonInterface() )
+    // D3D5Texture is shared between D3D5/6, however textures used in a D3D6 context
+    // typically come from an IDirectDrawSurface4 parent. This isn't a hard requirement,
+    // but is true in the vast majority of cases, so use the distinction for logging purposes.
+    , m_objectType ( isD3D6Texture ? "D3D6Texture" : "D3D5Texture" ) {
     if (m_commonTex == nullptr)
       m_commonTex = new D3DCommonTexture(commonSurf);
 
     m_commonTex->SetD3D5Texture(this);
-
-    // D3D5Texture is shared between D3D5/6, however textures used in a D3D6 context
-    // typically come from an IDirectDrawSurface4 parent. This isn't a hard requirement,
-    // but is true in the vast majority of cases, so use the distinction for logging purposes.
-    if (isD3D6Texture)
-      m_objectType = "D3D6Texture";
   }
 
   D3D5Texture::~D3D5Texture() {
@@ -123,6 +121,10 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D5Texture::Load(LPDIRECT3DTEXTURE2 lpD3DTexture2) {
     Com<D3D5Texture> d3d5Texture = static_cast<D3D5Texture*>(lpD3DTexture2);
+
+    // Fast skip
+    if (unlikely(d3d5Texture == this))
+      return D3D_OK;
 
     // IDirect3DTexture2 is guaranteed to have a IDirectDrawSurface4 parent,
     // because we create and cache one ourselves on creation if it doesn't exist

--- a/src/ddraw/d3d5/d3d5_texture.h
+++ b/src/ddraw/d3d5/d3d5_texture.h
@@ -48,7 +48,7 @@ namespace dxvk {
 
     DDrawCommonInterface* m_commonIntf = nullptr;
 
-    const char*           m_objectType = "D3D5Texture";
+    const char*           m_objectType = nullptr;
 
   };
 

--- a/src/ddraw/d3d6/d3d6_buffer.cpp
+++ b/src/ddraw/d3d6/d3d6_buffer.cpp
@@ -7,29 +7,27 @@
 #include "../d3d_process_vertices.h"
 #include "../d3d_multithread.h"
 
-#include "../ddraw4/ddraw4_interface.h"
-
 #include <vector>
 
 namespace dxvk {
 
   D3D6VertexBuffer::D3D6VertexBuffer(
+        D3DCommonBuffer* commonBuffer,
         D3D6Interface* pParent,
-        DWORD creationFlags,
-        D3DVERTEXBUFFERDESC* pDesc)
+        D3DVERTEXBUFFERDESC* pDesc,
+        DWORD creationFlags)
     : DDrawChildObject<D3D6Interface, IDirect3DVertexBuffer>(pParent)
-    , m_commonIntf ( pParent->GetCommonInterface() )
-    , m_creationFlags ( creationFlags )
-    , m_desc ( *pDesc )
-    , m_stride ( GetFVFSize(pDesc->dwFVF) )
-    , m_size ( m_stride * pDesc->dwNumVertices ) {
+    , m_commonBuffer ( commonBuffer ) {
+    if (m_commonBuffer == nullptr)
+      m_commonBuffer = new D3DCommonBuffer(pParent->GetCommonInterface(), pDesc, creationFlags);
+
     // In the fortunate scenario where a D3D6 device is already present
     // when a vertex buffer is created, initialize the buffer on the spot
     // rather than deferring the initialization to the first Lock()
     // or ProcessVertices() call, since that can cause hitching
-    RefreshD3DDevice();
-    if (m_d3d6Device != nullptr)
-      InitializeD3D9();
+    m_commonBuffer->RefreshD3DDevice();
+    if (m_commonBuffer->GetCommonD3DDevice() != nullptr)
+      m_commonBuffer->InitializeD3D9();
   }
 
   D3D6VertexBuffer::~D3D6VertexBuffer() {
@@ -58,7 +56,7 @@ namespace dxvk {
 
     const DWORD dwSize = lpVBDesc->dwSize;
 
-    *lpVBDesc = m_desc;
+    *lpVBDesc = m_commonBuffer->GetDesc();
     // The value passed in dwSize during the query is expected to be
     // preserved, even if it is not equal to sizeof(D3DVERTEXBUFFERDESC)
     lpVBDesc->dwSize = dwSize;
@@ -67,20 +65,21 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D6VertexBuffer::Lock(DWORD flags, void **data, DWORD *data_size) {
-    if (unlikely(IsOptimized()))
+    if (unlikely(m_commonBuffer->IsOptimized()))
       return D3DERR_VERTEXBUFFEROPTIMIZED;
 
-    RefreshD3DDevice();
-    if (unlikely(!IsInitialized())) {
-      HRESULT hrInit = InitializeD3D9();
+    m_commonBuffer->RefreshD3DDevice();
+    if (unlikely(!m_commonBuffer->IsInitialized())) {
+      HRESULT hrInit = m_commonBuffer->InitializeD3D9();
       if (unlikely(FAILED(hrInit)))
         return hrInit;
     }
 
     if (data_size != nullptr)
-      *data_size = m_size;
+      *data_size = m_commonBuffer->GetSize();
 
-    HRESULT hr = m_vb9->Lock(0, 0, data, ConvertD3D6LockFlags(flags, false));
+    d3d9::IDirect3DVertexBuffer9* vb9 = m_commonBuffer->GetD3D9VertexBuffer();
+    HRESULT hr = vb9->Lock(0, 0, data, ConvertD3DLockFlags(flags, false, false));
     if (unlikely(FAILED(hr)))
       return hr;
 
@@ -92,10 +91,13 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D6VertexBuffer::Unlock() {
     // Ignore the unlock call if the D3D9 buffer
     // was lost since the previous Lock() call
-    if (unlikely(!IsInitialized()))
+    if (unlikely(!m_commonBuffer->IsInitialized())) {
+      m_locked = false;
       return D3D_OK;
+    }
 
-    HRESULT hr = m_vb9->Unlock();
+    d3d9::IDirect3DVertexBuffer9* vb9 = m_commonBuffer->GetD3D9VertexBuffer();
+    HRESULT hr = vb9->Unlock();
     if (unlikely(FAILED(hr)))
       return D3DERR_VERTEXBUFFERUNLOCKFAILED;
 
@@ -117,47 +119,50 @@ namespace dxvk {
     D3D6Device* device6 = static_cast<D3D6Device*>(lpD3DDevice);
     D3D6VertexBuffer* srcBuffer6 = static_cast<D3D6VertexBuffer*>(lpSrcBuffer);
 
+    D3DCommonBuffer* srcCommonBuffer = srcBuffer6->GetCommonBuffer();
     // Check and initialize the source buffer
-    srcBuffer6->RefreshD3DDevice();
-    if (unlikely(!srcBuffer6->IsInitialized())) {
-      HRESULT hrInit = srcBuffer6->InitializeD3D9();
+    srcCommonBuffer->RefreshD3DDevice();
+    if (unlikely(!srcCommonBuffer->IsInitialized())) {
+      HRESULT hrInit = srcCommonBuffer->InitializeD3D9();
       if (unlikely(FAILED(hrInit)))
         return hrInit;
     }
 
     // Check and initialize the destination buffer (this buffer)
-    RefreshD3DDevice();
-    if (unlikely(!IsInitialized())) {
-      HRESULT hrInit = InitializeD3D9();
+    m_commonBuffer->RefreshD3DDevice();
+    if (unlikely(!m_commonBuffer->IsInitialized())) {
+      HRESULT hrInit = m_commonBuffer->InitializeD3D9();
       if (unlikely(FAILED(hrInit)))
         return hrInit;
     }
 
-    if (unlikely(m_d3d6Device != device6)) {
+    if (unlikely(m_commonBuffer->GetCommonD3DDevice()->GetD3D6Device() != device6)) {
       Logger::err("D3D6VertexBuffer::ProcessVertices: Invalid device");
       return DDERR_GENERIC;
     }
 
     D3DDeviceLock lock = device6->LockDevice();
 
+    d3d9::IDirect3DVertexBuffer9* dstBuffer9 = m_commonBuffer->GetD3D9VertexBuffer();
     d3d9::IDirect3DDevice9* device9 = device6->GetCommonD3DDevice()->GetD3D9Device();
 
-    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
+    const D3DOptions* d3dOptions = m_commonBuffer->GetCommonInterface()->GetOptions();
 
     if (likely(d3dOptions->cpuProcessVertices)) {
       uint8_t *inData = nullptr;
       uint8_t *outData = nullptr;
 
-      d3d9::IDirect3DVertexBuffer9* srcBuffer9 = srcBuffer6->GetD3D9VertexBuffer();
-
-      HRESULT hr = srcBuffer9->Lock(dwSrcIndex * srcBuffer6->GetStride(), dwCount * srcBuffer6->GetStride(),
+      d3d9::IDirect3DVertexBuffer9* srcBuffer9 = srcCommonBuffer->GetD3D9VertexBuffer();
+      const DWORD srcStride = srcCommonBuffer->GetStride();
+      HRESULT hr = srcBuffer9->Lock(dwSrcIndex * srcStride, dwCount * srcStride,
                                     reinterpret_cast<void**>(&inData), D3DLOCK_READONLY);
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D6VertexBuffer::ProcessVertices: Failed to lock source buffer");
         return D3DERR_VERTEXBUFFERLOCKED;
       }
 
-      hr = m_vb9->Lock(dwDestIndex * m_stride, dwCount * m_stride, reinterpret_cast<void**>(&outData), 0);
+      const DWORD dstStride = m_commonBuffer->GetStride();
+      hr = dstBuffer9->Lock(dwDestIndex * dstStride, dwCount * dstStride, reinterpret_cast<void**>(&outData), 0);
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D6VertexBuffer::ProcessVertices: Failed to lock destination buffer");
         srcBuffer9->Unlock();
@@ -168,18 +173,18 @@ namespace dxvk {
       //  IDirect3DVertexBuffer::ProcessVertices method to enable or disable lighting for that vertex buffer."
       // "If the rendering device does not have a material assigned to it, the Direct3D lighting engine is disabled."
       const bool doLighting = (dwVertexOp & D3DVOP_LIGHT) &&
-                              (srcBuffer6->GetFVF() & D3DFVF_NORMAL) &&
+                              (srcCommonBuffer->GetFVF() & D3DFVF_NORMAL) &&
                               device6->GetCommonD3DDevice()->GetCurrentMaterialHandle() != 0;
 
       D3DCommonViewport* commonViewport = device6->GetCurrentViewportInternal()->GetCommonViewport();
 
       ProcessVerticesData pvData;
       pvData.inData = inData;
-      pvData.inFVF = srcBuffer6->GetFVF();
-      pvData.inStride = srcBuffer6->GetStride();
+      pvData.inFVF = srcCommonBuffer->GetFVF();
+      pvData.inStride = srcStride;
       pvData.outData = outData;
-      pvData.outFVF = m_desc.dwFVF;
-      pvData.outStride = m_stride;
+      pvData.outFVF = m_commonBuffer->GetFVF();
+      pvData.outStride = dstStride;
       pvData.vertexCount = dwCount;
       pvData.correction = commonViewport->GetLegacyProjectionMatrix(0);
       pvData.dsStatus = nullptr;
@@ -197,9 +202,9 @@ namespace dxvk {
         pvData.lights = nullptr;
       }
 
-      ProcessVerticesSW(device9, m_commonIntf->GetOptions(), &pvData);
+      ProcessVerticesSW(device9, d3dOptions, &pvData);
 
-      m_vb9->Unlock();
+      dstBuffer9->Unlock();
       srcBuffer9->Unlock();
 
     } else {
@@ -221,9 +226,9 @@ namespace dxvk {
         }
       }
 
-      device9->SetFVF(srcBuffer6->GetFVF());
-      device9->SetStreamSource(0, srcBuffer6->GetD3D9VertexBuffer(), 0, srcBuffer6->GetStride());
-      HRESULT hr = device9->ProcessVertices(dwSrcIndex, dwDestIndex, dwCount, m_vb9.ptr(), nullptr, dwFlags);
+      device9->SetFVF(srcCommonBuffer->GetFVF());
+      device9->SetStreamSource(0, srcCommonBuffer->GetD3D9VertexBuffer(), 0, srcCommonBuffer->GetStride());
+      HRESULT hr = device9->ProcessVertices(dwSrcIndex, dwDestIndex, dwCount, dstBuffer9, nullptr, dwFlags);
 
       if (legacyProjection != nullptr) {
         //Logger::debug("D3D6Device: Reverting legacy projection");
@@ -243,53 +248,15 @@ namespace dxvk {
     if (unlikely(lpD3DDevice == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    if (unlikely(IsLocked()))
+    if (unlikely(m_locked))
       return D3DERR_VERTEXBUFFERLOCKED;
 
-    if (unlikely(IsOptimized()))
+    if (unlikely(m_commonBuffer->IsOptimized()))
       return D3DERR_VERTEXBUFFEROPTIMIZED;
 
-    m_desc.dwCaps |= D3DVBCAPS_OPTIMIZED;
+    m_commonBuffer->MarkAsOptimized();
 
     return D3D_OK;
   };
-
-  HRESULT D3D6VertexBuffer::InitializeD3D9() {
-    // Can't create anything without a valid device
-    if (unlikely(m_d3d6Device == nullptr)) {
-      Logger::warn("D3D6VertexBuffer::InitializeD3D9: Null D3D6 device, can't initialize right now");
-      return DDERR_GENERIC;
-    }
-
-    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
-
-    const d3d9::D3DPOOL pool = (m_desc.dwCaps & D3DVBCAPS_SYSTEMMEMORY) ? d3d9::D3DPOOL_SYSTEMMEM :
-                               d3dOptions->managedVertexBuffers ? d3d9::D3DPOOL_MANAGED : d3d9::D3DPOOL_DEFAULT;
-    const DWORD usage = ConvertD3D6UsageFlags(m_desc.dwCaps, m_creationFlags, pool);
-
-    d3d9::IDirect3DDevice9* device9 = m_d3d6Device->GetCommonD3DDevice()->GetD3D9Device();
-    HRESULT hr = device9->CreateVertexBuffer(m_size, usage, m_desc.dwFVF, pool, &m_vb9, nullptr);
-
-    if (unlikely(FAILED(hr))) {
-      Logger::err("D3D6VertexBuffer::InitializeD3D9: Failed to create D3D9 vertex buffer");
-      return hr;
-    }
-
-    return D3D_OK;
-  }
-
-  void D3D6VertexBuffer::RefreshD3DDevice() {
-    D3DCommonDevice* commonD3DDevice = m_commonIntf->GetCommonD3DDevice();
-
-    D3D6Device* d3d6Device = commonD3DDevice != nullptr ? commonD3DDevice->GetD3D6Device() : nullptr;
-    if (unlikely(m_d3d6Device != d3d6Device)) {
-      // Check if the device has been recreated and reset all D3D9 resources
-      if (unlikely(m_d3d6Device != nullptr)) {
-        Logger::debug("D3D6VertexBuffer::RefreshD3DDevice: Device context has changed, clearing D3D9 buffers");
-        m_vb9 = nullptr;
-      }
-      m_d3d6Device = d3d6Device;
-    }
-  }
 
 }

--- a/src/ddraw/d3d6/d3d6_buffer.h
+++ b/src/ddraw/d3d6/d3d6_buffer.h
@@ -4,6 +4,7 @@
 #include "../ddraw_child_object.h"
 
 #include "../ddraw_common_interface.h"
+#include "../d3d_common_buffer.h"
 
 #include "d3d6_interface.h"
 #include "d3d6_device.h"
@@ -15,9 +16,10 @@ namespace dxvk {
   public:
 
     D3D6VertexBuffer(
+          D3DCommonBuffer* commonBuffer,
           D3D6Interface* pParent,
-          DWORD creationFlags,
-          D3DVERTEXBUFFERDESC* pDesc);
+          D3DVERTEXBUFFERDESC* pDesc,
+          DWORD creationFlags);
 
     ~D3D6VertexBuffer();
 
@@ -33,57 +35,19 @@ namespace dxvk {
 
     HRESULT STDMETHODCALLTYPE Optimize(LPDIRECT3DDEVICE3 lpD3DDevice, DWORD dwFlags);
 
-    HRESULT InitializeD3D9();
-
-    void RefreshD3DDevice();
-
-    bool IsInitialized() const {
-      return m_vb9 != nullptr;
-    }
-
-    d3d9::IDirect3DVertexBuffer9* GetD3D9VertexBuffer() const {
-      return m_vb9.ptr();
-    }
-
-    DWORD GetFVF() const {
-      return m_desc.dwFVF;
-    }
-
-    DWORD GetStride() const {
-      return m_stride;
-    }
-
-    DWORD GetNumVertices() const {
-      return m_size / m_stride;
+    D3DCommonBuffer* GetCommonBuffer() const {
+      return m_commonBuffer.ptr();
     }
 
     bool IsLocked() const {
       return m_locked;
     }
 
-    D3D6Device* GetDevice() const {
-      return m_d3d6Device;
-    }
-
   private:
 
-    inline bool IsOptimized() const {
-      return m_desc.dwCaps & D3DVBCAPS_OPTIMIZED;
-    }
+    std::atomic<bool>    m_locked = false;
 
-    bool                              m_locked        = false;
-
-    DDrawCommonInterface*             m_commonIntf    = nullptr;
-
-    DWORD                             m_creationFlags = 0;
-    D3DVERTEXBUFFERDESC               m_desc;
-
-    UINT                              m_stride        = 0;
-    UINT                              m_size          = 0;
-
-    D3D6Device*                       m_d3d6Device    = nullptr;
-
-    Com<d3d9::IDirect3DVertexBuffer9> m_vb9;
+    Com<D3DCommonBuffer> m_commonBuffer;
 
   };
 

--- a/src/ddraw/d3d6/d3d6_device.cpp
+++ b/src/ddraw/d3d6/d3d6_device.cpp
@@ -61,8 +61,8 @@ namespace dxvk {
     // Common D3D9 index buffers
     static constexpr DWORD Usage = D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY;
 
-    for (uint8_t ibIndex = 0; ibIndex < ddrawCaps::IndexBufferCount ; ibIndex++) {
-      const UINT ibSize = ddrawCaps::IndexCount[ibIndex] * sizeof(WORD);
+    for (uint32_t ibIndex = 0; ibIndex < ddrawCaps::IndexBufferCount ; ibIndex++) {
+      const uint32_t ibSize = ddrawCaps::IndexCount[ibIndex] * sizeof(WORD);
 
       HRESULT hr = device9->CreateIndexBuffer(ibSize, Usage, d3d9::D3DFMT_INDEX16,
                                               d3d9::D3DPOOL_DEFAULT, &m_ib9[ibIndex], nullptr);
@@ -566,18 +566,22 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D6Device::Begin(D3DPRIMITIVETYPE d3dptPrimitiveType, DWORD dwVertexTypeDesc, DWORD dwFlags) {
     D3DDeviceLock lock = LockDevice();
 
+    if (unlikely(m_vertexStream.isInitialized()))
+      return DDERR_INVALIDPARAMS;
+
     // All FVF combinations are technically supported,
     // but I doubt that is the case in practice
     if (dwVertexTypeDesc != D3DFVF_VERTEX &&
         dwVertexTypeDesc != D3DFVF_LVERTEX &&
         dwVertexTypeDesc != D3DFVF_TLVERTEX) {
-      Logger::warn("D3D6Device::Begin: Unsupported FVF format");
+      Logger::err("D3D6Device::Begin: Unsupported FVF format");
       return DDERR_INVALIDPARAMS;
     }
 
-    m_vertexStreamInfo.d3dpt = d3dptPrimitiveType;
-    m_vertexStreamInfo.d3dvt = ConvertFVFType(dwVertexTypeDesc);
-    m_vertexStreamInfo.dwFlags = dwFlags;
+    m_vertexStream.d3dpt = d3dptPrimitiveType;
+    m_vertexStream.d3dvt = ConvertFVFType(dwVertexTypeDesc);
+    m_vertexStream.dwFlags = dwFlags;
+    m_vertexStream.initialize();
 
     return D3D_OK;
   }
@@ -593,18 +597,20 @@ namespace dxvk {
     if (unlikely(vertex == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    switch (m_vertexStreamInfo.d3dvt) {
+    if (unlikely(!m_vertexStream.isInitialized()))
+      return DDERR_INVALIDPARAMS;
+
+    switch (m_vertexStream.d3dvt) {
       case D3DVT_VERTEX:
-        m_vertexStream.push_back(*reinterpret_cast<D3DVERTEX*>(vertex));
+        m_vertexStream.stream.vertex->push_back(*reinterpret_cast<D3DVERTEX*>(vertex));
         break;
       case D3DVT_LVERTEX:
-        m_lvertexStream.push_back(*reinterpret_cast<D3DLVERTEX*>(vertex));
+        m_vertexStream.stream.lvertex->push_back(*reinterpret_cast<D3DLVERTEX*>(vertex));
         break;
       case D3DVT_TLVERTEX:
-        m_tlvertexStream.push_back(*reinterpret_cast<D3DTLVERTEX*>(vertex));
+        m_vertexStream.stream.tlvertex->push_back(*reinterpret_cast<D3DTLVERTEX*>(vertex));
         break;
       default:
-        Logger::warn(">>> D3D6Device::Vertex: Invalid vertex type");
         return DDERR_INVALIDPARAMS;
     }
 
@@ -619,33 +625,35 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D6Device::End(DWORD dwFlags) {
     D3DDeviceLock lock = LockDevice();
 
+    if (unlikely(!m_vertexStream.isInitialized()))
+      return DDERR_INVALIDPARAMS;
+
     HRESULT hr;
 
-    switch (m_vertexStreamInfo.d3dvt) {
+    switch (m_vertexStream.d3dvt) {
       case D3DVT_VERTEX:
-        hr = DrawPrimitive(m_vertexStreamInfo.d3dpt, m_vertexStreamInfo.d3dvt, m_vertexStream.data(),
-                           m_vertexStream.size(), m_vertexStreamInfo.dwFlags);
-        m_vertexStream.clear();
+        hr = DrawPrimitive(m_vertexStream.d3dpt, ConvertVertexType(m_vertexStream.d3dvt),
+                           m_vertexStream.stream.vertex->data(),
+                           m_vertexStream.stream.vertex->size(), m_vertexStream.dwFlags);
         break;
       case D3DVT_LVERTEX:
-        hr = DrawPrimitive(m_vertexStreamInfo.d3dpt, m_vertexStreamInfo.d3dvt, m_lvertexStream.data(),
-                           m_lvertexStream.size(), m_vertexStreamInfo.dwFlags);
-        m_lvertexStream.clear();
+        hr = DrawPrimitive(m_vertexStream.d3dpt, ConvertVertexType(m_vertexStream.d3dvt),
+                           m_vertexStream.stream.lvertex->data(),
+                           m_vertexStream.stream.lvertex->size(), m_vertexStream.dwFlags);
         break;
       case D3DVT_TLVERTEX:
-        hr = DrawPrimitive(m_vertexStreamInfo.d3dpt, m_vertexStreamInfo.d3dvt, m_tlvertexStream.data(),
-                           m_tlvertexStream.size(), m_vertexStreamInfo.dwFlags);
-        m_tlvertexStream.clear();
+        hr = DrawPrimitive(m_vertexStream.d3dpt, ConvertVertexType(m_vertexStream.d3dvt),
+                           m_vertexStream.stream.tlvertex->data(),
+                           m_vertexStream.stream.tlvertex->size(), m_vertexStream.dwFlags);
         break;
       default:
-        Logger::warn(">>> D3D6Device::End: Invalid vertex type");
         return DDERR_INVALIDPARAMS;
     }
 
     if (unlikely(FAILED(hr)))
       Logger::err(">>> D3D6Device::End: Failed call to DrawPrimitive");
 
-    m_vertexStreamInfo = { };
+    m_vertexStream.reset();
 
     return hr;
   }
@@ -1067,9 +1075,6 @@ namespace dxvk {
         if (unlikely(FAILED(hr)))
           return hr;
 
-        if (unlikely(surface4 == nullptr))
-          m_bridge->SetColorKeyState(false);
-
         return D3D_OK;
       }
 
@@ -1299,14 +1304,19 @@ namespace dxvk {
       case D3DRENDERSTATE_COLORKEYENABLE: {
         m_commonD3DDevice->SetColorKeyEnable(dwRenderState);
 
-        DDrawCommonSurface* commonSurf = m_textures[0] != nullptr ?
-                                         m_textures[0]->GetCommonTexture()->GetCommonSurface() : nullptr;
-        const bool validColorKey = commonSurf != nullptr ? commonSurf->HasValidColorKey() : false;
-        m_bridge->SetColorKeyState(dwRenderState && validColorKey);
-        if (dwRenderState && validColorKey) {
-          DDCOLORKEY normalizedColorKey = commonSurf->GetColorKeyNormalized();
-          m_bridge->SetColorKey(normalizedColorKey.dwColorSpaceLowValue,
-                                normalizedColorKey.dwColorSpaceHighValue);
+        for (DWORD stage = 0; stage < ddrawCaps::TextureStageCount; stage++) {
+          if (m_textures[stage] == nullptr)
+            continue;
+
+          DDrawCommonSurface* commonSurf = m_textures[stage]->GetCommonTexture()->GetCommonSurface();
+          const bool validColorKey = commonSurf != nullptr ? commonSurf->HasValidColorKey() : false;
+          m_bridge->SetColorKeyState(stage, dwRenderState && validColorKey);
+
+          if (dwRenderState && validColorKey) {
+            const DDCOLORKEY* normalizedColorKey = commonSurf->GetColorKeyNormalized();
+            m_bridge->SetColorKey(stage, normalizedColorKey->dwColorSpaceLowValue,
+                                  normalizedColorKey->dwColorSpaceHighValue);
+          }
         }
 
         return D3D_OK;
@@ -1513,13 +1523,15 @@ namespace dxvk {
 
     d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
+    const bool isTransformed = vertex_type & D3DFVF_XYZRHW;
     const bool useLighting = !(flags & D3DDP_DONOTLIGHT) &&
                               (vertex_type & D3DFVF_NORMAL) &&
                               m_commonD3DDevice->GetCurrentMaterialHandle() != 0;
 
     if (!useLighting)
       device9->SetRenderState(d3d9::D3DRS_LIGHTING, FALSE);
-    HandlePreDrawLegacyProjection(device9, flags);
+    if (!isTransformed)
+      HandlePreDrawLegacyProjection(device9, flags);
 
     device9->SetFVF(vertex_type);
     HRESULT hr = device9->DrawPrimitiveUP(
@@ -1530,7 +1542,8 @@ namespace dxvk {
 
     if (!useLighting)
       device9->SetRenderState(d3d9::D3DRS_LIGHTING, TRUE);
-    HandlePostDrawLegacyProjection(device9);
+    if (!isTransformed)
+      HandlePostDrawLegacyProjection(device9);
 
     if (unlikely(FAILED(hr))) {
       Logger::err("D3D6Device::DrawPrimitive: Failed D3D9 call to DrawPrimitiveUP");
@@ -1557,13 +1570,15 @@ namespace dxvk {
 
     d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
+    const bool isTransformed = fvf & D3DFVF_XYZRHW;
     const bool useLighting = !(flags & D3DDP_DONOTLIGHT) &&
                               (fvf & D3DFVF_NORMAL) &&
                               m_commonD3DDevice->GetCurrentMaterialHandle() != 0;
 
     if (!useLighting)
       device9->SetRenderState(d3d9::D3DRS_LIGHTING, FALSE);
-    HandlePreDrawLegacyProjection(device9, flags);
+    if (!isTransformed)
+      HandlePreDrawLegacyProjection(device9, flags);
 
     device9->SetFVF(fvf);
     HRESULT hr = device9->DrawIndexedPrimitiveUP(
@@ -1578,7 +1593,8 @@ namespace dxvk {
 
     if (!useLighting)
       device9->SetRenderState(d3d9::D3DRS_LIGHTING, TRUE);
-    HandlePostDrawLegacyProjection(device9);
+    if (!isTransformed)
+      HandlePostDrawLegacyProjection(device9);
 
     if (unlikely(FAILED(hr))) {
       Logger::err("D3D6Device::DrawIndexedPrimitive: Failed D3D9 call to DrawIndexedPrimitiveUP");
@@ -1634,13 +1650,15 @@ namespace dxvk {
     // Transform strided vertex data to a standard vertex buffer stream
     PackedVertexBuffer pvb = TransformStridedtoUP(fvf, strided_data, vertex_count);
 
+    const bool isTransformed = fvf & D3DFVF_XYZRHW;
     const bool useLighting = !(flags & D3DDP_DONOTLIGHT) &&
                               (fvf & D3DFVF_NORMAL) &&
                               m_commonD3DDevice->GetCurrentMaterialHandle() != 0;
 
     if (!useLighting)
       device9->SetRenderState(d3d9::D3DRS_LIGHTING, FALSE);
-    HandlePreDrawLegacyProjection(device9, flags);
+    if (!isTransformed)
+      HandlePreDrawLegacyProjection(device9, flags);
 
     device9->SetFVF(fvf);
     HRESULT hr = device9->DrawPrimitiveUP(
@@ -1651,7 +1669,8 @@ namespace dxvk {
 
     if (!useLighting)
       device9->SetRenderState(d3d9::D3DRS_LIGHTING, TRUE);
-    HandlePostDrawLegacyProjection(device9);
+    if (!isTransformed)
+      HandlePostDrawLegacyProjection(device9);
 
     if (unlikely(FAILED(hr))) {
       Logger::err("D3D6Device::DrawPrimitiveStrided: Failed D3D9 call to DrawPrimitiveUP");
@@ -1681,13 +1700,15 @@ namespace dxvk {
     // Transform strided vertex data to a standard vertex buffer stream
     PackedVertexBuffer pvb = TransformStridedtoUP(fvf, strided_data, vertex_count);
 
+    const bool isTransformed = fvf & D3DFVF_XYZRHW;
     const bool useLighting = !(flags & D3DDP_DONOTLIGHT) &&
                               (fvf & D3DFVF_NORMAL) &&
                               m_commonD3DDevice->GetCurrentMaterialHandle() != 0;
 
     if (!useLighting)
       device9->SetRenderState(d3d9::D3DRS_LIGHTING, FALSE);
-    HandlePreDrawLegacyProjection(device9, flags);
+    if (!isTransformed)
+      HandlePreDrawLegacyProjection(device9, flags);
 
     device9->SetFVF(fvf);
     HRESULT hr = device9->DrawIndexedPrimitiveUP(
@@ -1702,7 +1723,8 @@ namespace dxvk {
 
     if (!useLighting)
       device9->SetRenderState(d3d9::D3DRS_LIGHTING, TRUE);
-    HandlePostDrawLegacyProjection(device9);
+    if (!isTransformed)
+      HandlePostDrawLegacyProjection(device9);
 
     if (unlikely(FAILED(hr))) {
       Logger::err("D3D6Device::DrawIndexedPrimitiveStrided: Failed D3D9 call to DrawIndexedPrimitiveUP");
@@ -1726,31 +1748,35 @@ namespace dxvk {
       return DDERR_INVALIDPARAMS;
 
     Com<D3D6VertexBuffer> vb6 = static_cast<D3D6VertexBuffer*>(vb);
-
-    if (unlikely(vb6->GetDevice() != this)) {
-      Logger::err("D3D6Device::DrawIndexedPrimitiveVB: Invalid vertex buffer parent device");
-      return DDERR_GENERIC;
-    }
+    D3DCommonBuffer* commonBuffer = vb6->GetCommonBuffer();
 
     if (unlikely(vb6->IsLocked())) {
       Logger::err("D3D6Device::DrawPrimitiveVB: Buffer is locked");
       return D3DERR_VERTEXBUFFERLOCKED;
     }
 
+    if (unlikely(m_commonD3DDevice != commonBuffer->GetCommonD3DDevice())) {
+      Logger::err("D3D6Device::DrawIndexedPrimitiveVB: Invalid vertex buffer parent device");
+      return DDERR_GENERIC;
+    }
+
     DDrawDirtySurfaceUpload();
 
     d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
+    const DWORD fvf = commonBuffer->GetFVF();
+    const bool isTransformed = fvf & D3DFVF_XYZRHW;
     const bool useLighting = !(flags & D3DDP_DONOTLIGHT) &&
-                              (vb6->GetFVF() & D3DFVF_NORMAL) &&
+                              (fvf & D3DFVF_NORMAL) &&
                               m_commonD3DDevice->GetCurrentMaterialHandle() != 0;
 
     if (!useLighting)
       device9->SetRenderState(d3d9::D3DRS_LIGHTING, FALSE);
-    HandlePreDrawLegacyProjection(device9, flags);
+    if (!isTransformed)
+      HandlePreDrawLegacyProjection(device9, flags);
 
-    device9->SetFVF(vb6->GetFVF());
-    device9->SetStreamSource(0, vb6->GetD3D9VertexBuffer(), 0, vb6->GetStride());
+    device9->SetFVF(fvf);
+    device9->SetStreamSource(0, commonBuffer->GetD3D9VertexBuffer(), 0, commonBuffer->GetStride());
     HRESULT hr = device9->DrawPrimitive(
                       d3d9::D3DPRIMITIVETYPE(primitive_type),
                       start_vertex,
@@ -1758,7 +1784,8 @@ namespace dxvk {
 
     if (!useLighting)
       device9->SetRenderState(d3d9::D3DRS_LIGHTING, TRUE);
-    HandlePostDrawLegacyProjection(device9);
+    if (!isTransformed)
+      HandlePostDrawLegacyProjection(device9);
 
     if (unlikely(FAILED(hr))) {
       Logger::err("D3D6Device::DrawPrimitiveVB: Failed D3D9 call to DrawPrimitive");
@@ -1782,15 +1809,16 @@ namespace dxvk {
       return DDERR_INVALIDPARAMS;
 
     Com<D3D6VertexBuffer> vb6 = static_cast<D3D6VertexBuffer*>(vb);
-
-    if (unlikely(vb6->GetDevice() != this)) {
-      Logger::err("D3D6Device::DrawIndexedPrimitiveVB: Invalid vertex buffer parent device");
-      return DDERR_GENERIC;
-    }
+    D3DCommonBuffer* commonBuffer = vb6->GetCommonBuffer();
 
     if (unlikely(vb6->IsLocked())) {
       Logger::err("D3D6Device::DrawIndexedPrimitiveVB: Buffer is locked");
       return D3DERR_VERTEXBUFFERLOCKED;
+    }
+
+    if (unlikely(m_commonD3DDevice != commonBuffer->GetCommonD3DDevice())) {
+      Logger::err("D3D6Device::DrawIndexedPrimitiveVB: Invalid vertex buffer parent device");
+      return DDERR_GENERIC;
     }
 
     if (unlikely(index_count > ddrawCaps::MaxIndexCount)) {
@@ -1802,13 +1830,16 @@ namespace dxvk {
 
     d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
+    const DWORD fvf = commonBuffer->GetFVF();
+    const bool isTransformed = fvf & D3DFVF_XYZRHW;
     const bool useLighting = !(flags & D3DDP_DONOTLIGHT) &&
-                              (vb6->GetFVF() & D3DFVF_NORMAL) &&
+                              (fvf & D3DFVF_NORMAL) &&
                               m_commonD3DDevice->GetCurrentMaterialHandle() != 0;
 
     if (!useLighting)
       device9->SetRenderState(d3d9::D3DRS_LIGHTING, FALSE);
-    HandlePreDrawLegacyProjection(device9, flags);
+    if (!isTransformed)
+      HandlePreDrawLegacyProjection(device9, flags);
 
     uint8_t ibIndex = 0;
     // Fit index buffer uploads into the smallest buffer size possible
@@ -1826,19 +1857,20 @@ namespace dxvk {
     ib9->Unlock();
 
     device9->SetIndices(ib9);
-    device9->SetFVF(vb6->GetFVF());
-    device9->SetStreamSource(0, vb6->GetD3D9VertexBuffer(), 0, vb6->GetStride());
+    device9->SetFVF(fvf);
+    device9->SetStreamSource(0, commonBuffer->GetD3D9VertexBuffer(), 0, commonBuffer->GetStride());
     HRESULT hr = device9->DrawIndexedPrimitive(
                       d3d9::D3DPRIMITIVETYPE(primitive_type),
                       0,
                       0,
-                      vb6->GetNumVertices(),
+                      commonBuffer->GetNumVertices(),
                       0,
                       GetPrimitiveCount(primitive_type, index_count));
 
     if (!useLighting)
       device9->SetRenderState(d3d9::D3DRS_LIGHTING, TRUE);
-    HandlePostDrawLegacyProjection(device9);
+    if (!isTransformed)
+      HandlePostDrawLegacyProjection(device9);
 
     if (unlikely(FAILED(hr))) {
       Logger::err("D3D6Device::DrawIndexedPrimitiveVB: Failed D3D9 call to DrawIndexedPrimitive");
@@ -1902,9 +1934,7 @@ namespace dxvk {
 
       if (likely(m_textures[stage] != nullptr)) {
         m_textures[stage] = nullptr;
-
-        if (likely(stage == 0))
-          m_bridge->SetColorKeyState(false);
+        m_bridge->SetColorKeyState(stage, false);
       }
 
       return D3D_OK;
@@ -1939,13 +1969,15 @@ namespace dxvk {
 
     d3d9::IDirect3DTexture9* tex9 = commonSurface->GetD3D9Texture();
 
-    if (likely(tex9 != nullptr)) {
-      hr = device9->SetTexture(stage, tex9);
-      if (unlikely(FAILED(hr))) {
-        Logger::warn("D3D6Device::SetTexture: Failed to bind D3D9 texture");
-        return hr;
-      }
+    // If a surface without a D3D9 texture gets bound, simply unbind the current texture.
+    // This is needed to handle the binding of surfaces which aren't explicitly marked as textures.
+    hr = device9->SetTexture(stage, tex9);
+    if (unlikely(FAILED(hr))) {
+      Logger::warn("D3D6Device::SetTexture: Failed to bind D3D9 texture");
+      return hr;
+    }
 
+    if (likely(tex9 != nullptr)) {
       if (likely(stage == 0)) {
         // "Any alpha values in the texture replace the alpha values in the colors that would
         //  have been used with no texturing; if the texture does not contain an alpha component,
@@ -1954,18 +1986,17 @@ namespace dxvk {
           const DWORD textureOp = commonSurface->IsAlphaFormat() ? D3DTOP_SELECTARG1 : D3DTOP_SELECTARG2;
           device9->SetTextureStageState(0, d3d9::D3DTSS_ALPHAOP, textureOp);
         }
-
-        const bool colorKeyEnable = m_commonD3DDevice->GetColorKeyEnable();
-        const bool validColorKey = commonSurface->HasValidColorKey();
-        m_bridge->SetColorKeyState(colorKeyEnable && validColorKey);
-        if (colorKeyEnable && validColorKey) {
-          DDCOLORKEY normalizedColorKey = commonSurface->GetColorKeyNormalized();
-          m_bridge->SetColorKey(normalizedColorKey.dwColorSpaceLowValue,
-                                normalizedColorKey.dwColorSpaceHighValue);
-        }
       }
-    } else {
-      Logger::err("D3D6Device::SetTexture: Found no valid D3D9 texture");
+
+      const bool colorKeyEnable = m_commonD3DDevice->GetColorKeyEnable();
+      const bool validColorKey = commonSurface->HasValidColorKey();
+      m_bridge->SetColorKeyState(stage, colorKeyEnable && validColorKey);
+
+      if (colorKeyEnable && validColorKey) {
+        const DDCOLORKEY* normalizedColorKey = commonSurface->GetColorKeyNormalized();
+        m_bridge->SetColorKey(stage, normalizedColorKey->dwColorSpaceLowValue,
+                              normalizedColorKey->dwColorSpaceHighValue);
+      }
     }
 
     m_textures[stage] = texture6;
@@ -2167,8 +2198,11 @@ namespace dxvk {
         return hr;
       }
 
-      if (likely(m_commonD3DDevice->GetCurrentTextureHandle() != 0))
+      if (likely(m_commonD3DDevice->GetCurrentTextureHandle() != 0)) {
+        m_texture = nullptr;
         m_commonD3DDevice->SetCurrentTextureHandle(0);
+        m_bridge->SetColorKeyState(0, false);
+      }
 
       return D3D_OK;
     }
@@ -2192,13 +2226,15 @@ namespace dxvk {
 
     d3d9::IDirect3DTexture9* tex9 = commonSurface->GetD3D9Texture();
 
-    if (likely(tex9 != nullptr)) {
-      hr = device9->SetTexture(0, tex9);
-      if (unlikely(FAILED(hr))) {
-        Logger::warn("D3D6Device::SetTextureInternal: Failed to bind D3D9 texture");
-        return hr;
-      }
+    // If a surface without a D3D9 texture gets bound, simply unbind the current texture.
+    // This is needed to handle the binding of surfaces which aren't explicitly marked as textures.
+    hr = device9->SetTexture(0, tex9);
+    if (unlikely(FAILED(hr))) {
+      Logger::warn("D3D6Device::SetTextureInternal: Failed to bind D3D9 texture");
+      return hr;
+    }
 
+    if (likely(tex9 != nullptr)) {
       // "Any alpha values in the texture replace the alpha values in the colors that would
       //  have been used with no texturing; if the texture does not contain an alpha component,
       //  alpha values at the vertices in the source are interpolated between vertices."
@@ -2209,16 +2245,16 @@ namespace dxvk {
 
       const bool colorKeyEnable = m_commonD3DDevice->GetColorKeyEnable();
       const bool validColorKey = commonSurface->HasValidColorKey();
-      m_bridge->SetColorKeyState(colorKeyEnable && validColorKey);
+      m_bridge->SetColorKeyState(0, colorKeyEnable && validColorKey);
+
       if (colorKeyEnable && validColorKey) {
-        DDCOLORKEY normalizedColorKey = commonSurface->GetColorKeyNormalized();
-        m_bridge->SetColorKey(normalizedColorKey.dwColorSpaceLowValue,
-                              normalizedColorKey.dwColorSpaceHighValue);
+        const DDCOLORKEY* normalizedColorKey = commonSurface->GetColorKeyNormalized();
+        m_bridge->SetColorKey(0, normalizedColorKey->dwColorSpaceLowValue,
+                              normalizedColorKey->dwColorSpaceHighValue);
       }
-    } else {
-      Logger::err("D3D6Device::SetTextureInternal: Found no valid D3D9 texture");
     }
 
+    m_texture = surface;
     m_commonD3DDevice->SetCurrentTextureHandle(textureHandle);
 
     return D3D_OK;

--- a/src/ddraw/d3d6/d3d6_device.h
+++ b/src/ddraw/d3d6/d3d6_device.h
@@ -173,7 +173,8 @@ namespace dxvk {
 
         if (m_legacyProjection != nullptr) {
           device9->GetTransform(d3d9::D3DTS_PROJECTION, &m_projectionMatrix);
-          device9->MultiplyTransform(d3d9::D3DTS_PROJECTION, m_legacyProjection);
+          device9->SetTransform(d3d9::D3DTS_PROJECTION, m_legacyProjection);
+          device9->MultiplyTransform(d3d9::D3DTS_PROJECTION, &m_projectionMatrix);
         }
       }
     }
@@ -184,11 +185,11 @@ namespace dxvk {
       }
     }
 
-    bool                            m_alphaOpSet         = false;
+    bool                            m_alphaOpSet       = false;
 
     Com<D3DCommonDevice>            m_commonD3DDevice;
 
-    DDrawCommonInterface*           m_commonIntf         = nullptr;
+    DDrawCommonInterface*           m_commonIntf       = nullptr;
 
     Com<IDxvkLegacyD3DDeviceBridge> m_bridge;
 
@@ -202,16 +203,16 @@ namespace dxvk {
     Com<DDraw4Surface>              m_rt;
     Com<DDraw4Surface, false>       m_ds;
 
+    // Only for the legacy D3DTEXTUREHANDLE texture path
+    Com<DDraw4Surface, false>       m_texture;
+
     Com<D3D6Viewport>               m_currentViewport;
     std::vector<Com<D3D6Viewport>>  m_viewports;
 
-    D3DMATRIX                       m_projectionMatrix   = { };
-    const D3DMATRIX*                m_legacyProjection   = nullptr;
+    D3DMATRIX                       m_projectionMatrix = { };
+    const D3DMATRIX*                m_legacyProjection = nullptr;
 
-    VertexStreamInfo                m_vertexStreamInfo;
-    std::vector<D3DVERTEX>          m_vertexStream;
-    std::vector<D3DLVERTEX>         m_lvertexStream;
-    std::vector<D3DTLVERTEX>        m_tlvertexStream;
+    VertexStream                    m_vertexStream;
 
     // D3D5Texture (aka IDirect3DTexture2) is shared between D3D5 and D3D6
     std::array<Com<D3D5Texture, false>, ddrawCaps::TextureStageCount> m_textures;

--- a/src/ddraw/d3d6/d3d6_interface.cpp
+++ b/src/ddraw/d3d6/d3d6_interface.cpp
@@ -215,7 +215,7 @@ namespace dxvk {
 
     InitReturnPtr(lplpDirect3DMaterial);
 
-    *lplpDirect3DMaterial = ref(new D3D6Material(this));
+    *lplpDirect3DMaterial = ref(new D3D6Material(nullptr, this));
 
     return D3D_OK;
   }
@@ -283,8 +283,11 @@ namespace dxvk {
         lpD3DFDR->guid = IID_IDirect3DHALDevice;
         lpD3DFDR->ddHwDesc = descHAL_HAL;
         lpD3DFDR->ddSwDesc = descHAL_HEL;
+      } else if (lpD3DFDS->guid == IID_IDirect3DRampDevice
+              || lpD3DFDS->guid == IID_IDirect3DMMXDevice) {
+        return DDERR_NOTFOUND;
       } else {
-        Logger::err(str::format("D3D6Interface::FindDevice: Unknown device type: ", lpD3DFDS->guid));
+        Logger::warn(str::format("D3D6Interface::FindDevice: Unknown device type: ", lpD3DFDS->guid));
         return DDERR_NOTFOUND;
       }
     } else if (lpD3DFDS->dwFlags & D3DFDS_HARDWARE) {
@@ -329,30 +332,33 @@ namespace dxvk {
     bool  halFallback          = false;
     bool  rgbFallback          = false;
 
-    if (likely(!d3dOptions->forceSWVP)) {
-      if (rclsid == IID_IDirect3DHALDevice) {
-        Logger::info("D3D6Interface::CreateDevice: Creating an IID_IDirect3DHALDevice device");
+    if (rclsid == IID_IDirect3DHALDevice) {
+      Logger::info("D3D6Interface::CreateDevice: Creating an IID_IDirect3DHALDevice device");
+      if (likely(!d3dOptions->forceSWVP))
         deviceCreationFlags9 = D3DCREATE_MIXED_VERTEXPROCESSING;
-        isHALDevice = true;
-      } else if (rclsid == IID_IDirect3DRGBDevice) {
-        Logger::info("D3D6Interface::CreateDevice: Creating an IID_IDirect3DRGBDevice device");
-      } else if (rclsid == IID_IDirect3DMMXDevice) {
-        Logger::warn("D3D6Interface::CreateDevice: Unsupported MMX device, falling back to RGB");
-        rgbFallback = true;
-      } else if (rclsid == IID_IDirect3DRampDevice) {
-        Logger::warn("D3D6Interface::CreateDevice: Unsupported Ramp device, falling back to RGB");
-        rgbFallback = true;
+      isHALDevice = true;
+    } else if (rclsid == IID_IDirect3DRGBDevice) {
+      Logger::info("D3D6Interface::CreateDevice: Creating an IID_IDirect3DRGBDevice device");
+    } else if (rclsid == IID_IDirect3DMMXDevice) {
+      Logger::warn("D3D6Interface::CreateDevice: Unsupported MMX device, falling back to RGB");
+      rgbFallback = true;
+    } else if (rclsid == IID_IDirect3DRampDevice) {
+      Logger::warn("D3D6Interface::CreateDevice: Unsupported Ramp device, falling back to RGB");
+      rgbFallback = true;
+    // The Sims sends a rclsid of IID_IUnknown and expects a RGB device
+    } else if (unlikely(rclsid == IID_IUnknown)) {
+      Logger::warn("D3D6Interface::CreateDevice: Unsupported IID_IUnknown, falling back to RGB");
+      rgbFallback = true;
+    } else {
+      // Revenant uses a bogus rclsid (not WineD3D's), so fall back to HAL in these cases
+      if (unlikely(rclsid != IID_WineD3DDevice)) {
+        Logger::warn("D3D6Interface::CreateDevice: Unknown device type, falling back to HAL");
+        Logger::warn(str::format(rclsid));
       } else {
-        // Revenant uses a bogus rclsid (not WineD3D's), so fall back to HAL in these cases
-        if (unlikely(rclsid != IID_WineD3DDevice)) {
-          Logger::warn("D3D6Interface::CreateDevice: Unknown device type, falling back to HAL");
-          Logger::warn(str::format(rclsid));
-        } else {
-          Logger::info("D3D6Interface::CreateDevice: Creating an IID_WineD3DDevice HAL device");
-        }
-        halFallback = true;
-        // Don't enforce isHALDevice RT validations
+        Logger::info("D3D6Interface::CreateDevice: Creating an IID_WineD3DDevice HAL device");
       }
+      halFallback = true;
+      // Don't enforce isHALDevice RT validations
     }
 
     const IID rclsidOverride = halFallback ? IID_IDirect3DHALDevice :
@@ -485,7 +491,7 @@ namespace dxvk {
 
     InitReturnPtr(lpD3DVertexBuffer);
 
-    *lpD3DVertexBuffer = ref(new D3D6VertexBuffer(this, dwFlags, lpVBDesc));
+    *lpD3DVertexBuffer = ref(new D3D6VertexBuffer(nullptr, this, lpVBDesc, dwFlags));
 
     return D3D_OK;
   }

--- a/src/ddraw/d3d6/d3d6_material.cpp
+++ b/src/ddraw/d3d6/d3d6_material.cpp
@@ -12,9 +12,12 @@
 namespace dxvk {
 
   D3D6Material::D3D6Material(
+        D3DCommonMaterial* commonMaterial,
         D3D6Interface* pParent)
-    : DDrawChildObject<D3D6Interface, IDirect3DMaterial3>(pParent) {
-    m_commonMaterial = new D3DCommonMaterial();
+    : DDrawChildObject<D3D6Interface, IDirect3DMaterial3>(pParent)
+    , m_commonMaterial ( commonMaterial ) {
+    if (m_commonMaterial == nullptr)
+      m_commonMaterial = new D3DCommonMaterial();
 
     m_commonMaterial->SetD3D6Material(this);
   }

--- a/src/ddraw/d3d6/d3d6_material.h
+++ b/src/ddraw/d3d6/d3d6_material.h
@@ -13,7 +13,7 @@ namespace dxvk {
 
   public:
 
-    D3D6Material(D3D6Interface* pParent);
+    D3D6Material(D3DCommonMaterial* commonMaterial, D3D6Interface* pParent);
 
     ~D3D6Material();
 

--- a/src/ddraw/d3d7/d3d7_buffer.cpp
+++ b/src/ddraw/d3d7/d3d7_buffer.cpp
@@ -7,29 +7,28 @@
 #include "../d3d_process_vertices.h"
 #include "../d3d_multithread.h"
 
-#include "../ddraw7/ddraw7_interface.h"
-
 #include <vector>
 
 namespace dxvk {
 
   D3D7VertexBuffer::D3D7VertexBuffer(
+        D3DCommonBuffer* commonBuffer,
         D3D7Interface* pParent,
         D3DVERTEXBUFFERDESC* pDesc)
     : DDrawChildObject<D3D7Interface, IDirect3DVertexBuffer7>(pParent)
-    , m_commonIntf ( pParent->GetCommonInterface() )
-    , m_desc ( *pDesc )
-    , m_stride ( GetFVFSize(pDesc->dwFVF) )
-    , m_size ( m_stride * pDesc->dwNumVertices ) {
+    , m_commonBuffer ( commonBuffer ) {
+    if (m_commonBuffer == nullptr)
+      m_commonBuffer = new D3DCommonBuffer(pParent->GetCommonInterface(), pDesc, 0u);
+
     m_parent->AddRef();
 
     // In the fortunate scenario where a D3D7 device is already present
     // when a vertex buffer is created, initialize the buffer on the spot
     // rather than deferring the initialization to the first Lock()
     // or ProcessVertices() call, since that can cause hitching
-    RefreshD3DDevice();
-    if (m_d3d7Device != nullptr)
-      InitializeD3D9();
+    m_commonBuffer->RefreshD3DDevice();
+    if (m_commonBuffer->GetCommonD3DDevice() != nullptr)
+      m_commonBuffer->InitializeD3D9();
   }
 
   D3D7VertexBuffer::~D3D7VertexBuffer() {
@@ -59,7 +58,7 @@ namespace dxvk {
 
     const DWORD dwSize = lpVBDesc->dwSize;
 
-    *lpVBDesc = m_desc;
+    *lpVBDesc = m_commonBuffer->GetDesc();
     // The value passed in dwSize during the query is expected to be
     // preserved, even if it is not equal to sizeof(D3DVERTEXBUFFERDESC)
     lpVBDesc->dwSize = dwSize;
@@ -68,25 +67,21 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D7VertexBuffer::Lock(DWORD flags, void **data, DWORD *data_size) {
-    if (unlikely(IsOptimized()))
+    if (unlikely(m_commonBuffer->IsOptimized()))
       return D3DERR_VERTEXBUFFEROPTIMIZED;
 
-    RefreshD3DDevice();
-    if (unlikely(!IsInitialized())) {
-      HRESULT hrInit = InitializeD3D9();
+    m_commonBuffer->RefreshD3DDevice();
+    if (unlikely(!m_commonBuffer->IsInitialized())) {
+      HRESULT hrInit = m_commonBuffer->InitializeD3D9();
       if (unlikely(FAILED(hrInit)))
         return hrInit;
     }
 
     if (data_size != nullptr)
-      *data_size = m_size;
+      *data_size = m_commonBuffer->GetSize();
 
-    // Cops 2170: The Power of Law relies on us not discarding on any write only lock
-    // to render geometry, and does not mark the affected buffers with D3DVBCAPS_WRITEONLY
-    const bool legacyDiscard = m_legacyDiscard | (m_commonIntf->GetOptions()->forceLegacyDiscard
-                                                  && (flags & DDLOCK_WRITEONLY));
-
-    HRESULT hr = m_vb9->Lock(0, 0, data, ConvertD3D7LockFlags(flags, legacyDiscard, false));
+    d3d9::IDirect3DVertexBuffer9* vb9 = m_commonBuffer->GetD3D9VertexBuffer();
+    HRESULT hr = vb9->Lock(0, 0, data, ConvertD3DLockFlags(flags, m_commonBuffer->GetLegacyDiscard(flags), true));
     if (unlikely(FAILED(hr)))
       return hr;
 
@@ -98,10 +93,13 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D7VertexBuffer::Unlock() {
     // Ignore the unlock call if the D3D9 buffer
     // was lost since the previous Lock() call
-    if (unlikely(!IsInitialized()))
+    if (unlikely(!m_commonBuffer->IsInitialized())) {
+      m_locked = false;
       return D3D_OK;
+    }
 
-    HRESULT hr = m_vb9->Unlock();
+    d3d9::IDirect3DVertexBuffer9* vb9 = m_commonBuffer->GetD3D9VertexBuffer();
+    HRESULT hr = vb9->Unlock();
     if (unlikely(FAILED(hr)))
       return D3DERR_VERTEXBUFFERUNLOCKFAILED;
 
@@ -123,47 +121,50 @@ namespace dxvk {
     D3D7Device* device7 = static_cast<D3D7Device*>(lpD3DDevice);
     D3D7VertexBuffer* srcBuffer7 = static_cast<D3D7VertexBuffer*>(lpSrcBuffer);
 
+    D3DCommonBuffer* srcCommonBuffer = srcBuffer7->GetCommonBuffer();
     // Check and initialize the source buffer
-    srcBuffer7->RefreshD3DDevice();
-    if (unlikely(!srcBuffer7->IsInitialized())) {
-      HRESULT hrInit = srcBuffer7->InitializeD3D9();
+    srcCommonBuffer->RefreshD3DDevice();
+    if (unlikely(!srcCommonBuffer->IsInitialized())) {
+      HRESULT hrInit = srcCommonBuffer->InitializeD3D9();
       if (unlikely(FAILED(hrInit)))
         return hrInit;
     }
 
     // Check and initialize the destination buffer (this buffer)
-    RefreshD3DDevice();
-    if (unlikely(!IsInitialized())) {
-      HRESULT hrInit = InitializeD3D9();
+    m_commonBuffer->RefreshD3DDevice();
+    if (unlikely(!m_commonBuffer->IsInitialized())) {
+      HRESULT hrInit = m_commonBuffer->InitializeD3D9();
       if (unlikely(FAILED(hrInit)))
         return hrInit;
     }
 
-    if (unlikely(m_d3d7Device != device7)) {
+    if (unlikely(m_commonBuffer->GetCommonD3DDevice()->GetD3D7Device() != device7)) {
       Logger::err("D3D7VertexBuffer::ProcessVertices: Invalid device");
       return DDERR_GENERIC;
     }
 
     D3DDeviceLock lock = device7->LockDevice();
 
+    d3d9::IDirect3DVertexBuffer9* dstBuffer9 = m_commonBuffer->GetD3D9VertexBuffer();
     d3d9::IDirect3DDevice9* device9 = device7->GetCommonD3DDevice()->GetD3D9Device();
 
-    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
+    const D3DOptions* d3dOptions = m_commonBuffer->GetCommonInterface()->GetOptions();
 
     if (likely(d3dOptions->cpuProcessVertices)) {
       uint8_t *inData = nullptr;
       uint8_t *outData = nullptr;
 
-      d3d9::IDirect3DVertexBuffer9* srcBuffer9 = srcBuffer7->GetD3D9VertexBuffer();
-
-      HRESULT hr = srcBuffer9->Lock(dwSrcIndex * srcBuffer7->GetStride(), dwCount * srcBuffer7->GetStride(),
+      d3d9::IDirect3DVertexBuffer9* srcBuffer9 = srcCommonBuffer->GetD3D9VertexBuffer();
+      const DWORD srcStride = srcCommonBuffer->GetStride();
+      HRESULT hr = srcBuffer9->Lock(dwSrcIndex * srcStride, dwCount * srcStride,
                                     reinterpret_cast<void**>(&inData), D3DLOCK_READONLY);
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D7VertexBuffer::ProcessVertices: Failed to lock source buffer");
         return D3DERR_VERTEXBUFFERLOCKED;
       }
 
-      hr = m_vb9->Lock(dwDestIndex * m_stride, dwCount * m_stride, reinterpret_cast<void**>(&outData), 0);
+      const DWORD dstStride = m_commonBuffer->GetStride();
+      hr = dstBuffer9->Lock(dwDestIndex * dstStride, dwCount * dstStride, reinterpret_cast<void**>(&outData), 0);
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D7VertexBuffer::ProcessVertices: Failed to lock destination buffer");
         srcBuffer9->Unlock();
@@ -174,11 +175,11 @@ namespace dxvk {
 
       ProcessVerticesData pvData;
       pvData.inData = inData;
-      pvData.inFVF = srcBuffer7->GetFVF();
-      pvData.inStride = srcBuffer7->GetStride();
+      pvData.inFVF = srcCommonBuffer->GetFVF();
+      pvData.inStride = srcStride;
       pvData.outData = outData;
-      pvData.outFVF = m_desc.dwFVF;
-      pvData.outStride = m_stride;
+      pvData.outFVF = m_commonBuffer->GetFVF();
+      pvData.outStride = dstStride;
       pvData.vertexCount = dwCount;
       pvData.correction = nullptr;
       pvData.dsStatus = nullptr;
@@ -196,9 +197,9 @@ namespace dxvk {
         pvData.lights = nullptr;
       }
 
-      ProcessVerticesSW(device9, m_commonIntf->GetOptions(), &pvData);
+      ProcessVerticesSW(device9, d3dOptions, &pvData);
 
-      m_vb9->Unlock();
+      dstBuffer9->Unlock();
       srcBuffer9->Unlock();
 
     } else {
@@ -206,9 +207,9 @@ namespace dxvk {
       if (unlikely(dwVertexOp & D3DVOP_LIGHT))
         Logger::warn("D3D7VertexBuffer::ProcessVertices: Unsupported operation D3DVOP_LIGHT");
 
-      device9->SetFVF(srcBuffer7->GetFVF());
-      device9->SetStreamSource(0, srcBuffer7->GetD3D9VertexBuffer(), 0, srcBuffer7->GetStride());
-      HRESULT hr = device9->ProcessVertices(dwSrcIndex, dwDestIndex, dwCount, m_vb9.ptr(), nullptr, dwFlags);
+      device9->SetFVF(srcCommonBuffer->GetFVF());
+      device9->SetStreamSource(0, srcCommonBuffer->GetD3D9VertexBuffer(), 0, srcCommonBuffer->GetStride());
+      HRESULT hr = device9->ProcessVertices(dwSrcIndex, dwDestIndex, dwCount, dstBuffer9, nullptr, dwFlags);
       if (unlikely(FAILED(hr))) {
         Logger::err("D3D7VertexBuffer::ProcessVertices: Failed call to D3D9 ProcessVertices");
         return hr;
@@ -230,14 +231,14 @@ namespace dxvk {
     D3D7Device* device7 = static_cast<D3D7Device*>(lpD3DDevice);
 
     // Check and initialize the destination buffer (this buffer)
-    RefreshD3DDevice();
-    if (unlikely(!IsInitialized())) {
-      HRESULT hrInit = InitializeD3D9();
+    m_commonBuffer->RefreshD3DDevice();
+    if (unlikely(!m_commonBuffer->IsInitialized())) {
+      HRESULT hrInit = m_commonBuffer->InitializeD3D9();
       if (unlikely(FAILED(hrInit)))
         return hrInit;
     }
 
-    if (unlikely(m_d3d7Device != device7)) {
+    if (unlikely(m_commonBuffer->GetCommonD3DDevice()->GetD3D7Device() != device7)) {
       Logger::err("D3D7VertexBuffer::ProcessVerticesStrided: Invalid device");
       return DDERR_GENERIC;
     }
@@ -255,54 +256,15 @@ namespace dxvk {
     if (unlikely(lpD3DDevice == nullptr))
       return DDERR_INVALIDPARAMS;
 
-    if (unlikely(IsLocked()))
+    if (unlikely(m_locked))
       return D3DERR_VERTEXBUFFERLOCKED;
 
-    if (unlikely(IsOptimized()))
+    if (unlikely(m_commonBuffer->IsOptimized()))
       return D3DERR_VERTEXBUFFEROPTIMIZED;
 
-    m_desc.dwCaps |= D3DVBCAPS_OPTIMIZED;
+    m_commonBuffer->MarkAsOptimized();
 
     return D3D_OK;
   };
-
-  HRESULT D3D7VertexBuffer::InitializeD3D9() {
-    // Can't create anything without a valid device
-    if (unlikely(m_d3d7Device == nullptr)) {
-      Logger::warn("D3D7VertexBuffer::InitializeD3D9: Null D3D7 device, can't initialize right now");
-      return DDERR_GENERIC;
-    }
-
-    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
-
-    const d3d9::D3DPOOL pool = (m_desc.dwCaps & D3DVBCAPS_SYSTEMMEMORY) ? d3d9::D3DPOOL_SYSTEMMEM :
-                               d3dOptions->managedVertexBuffers ? d3d9::D3DPOOL_MANAGED : d3d9::D3DPOOL_DEFAULT;
-    const DWORD usage = ConvertD3D7UsageFlags(m_desc.dwCaps, pool);
-    m_legacyDiscard = m_commonIntf->GetOptions()->forceLegacyDiscard &&
-                      (usage & D3DUSAGE_DYNAMIC) && (usage & D3DUSAGE_WRITEONLY);
-
-    d3d9::IDirect3DDevice9* device9 = m_d3d7Device->GetCommonD3DDevice()->GetD3D9Device();
-    HRESULT hr = device9->CreateVertexBuffer(m_size, usage, m_desc.dwFVF, pool, &m_vb9, nullptr);
-    if (unlikely(FAILED(hr))) {
-      Logger::err("D3D7VertexBuffer::InitializeD3D9: Failed to create D3D9 vertex buffer");
-      return hr;
-    }
-
-    return D3D_OK;
-  }
-
-  void D3D7VertexBuffer::RefreshD3DDevice() {
-    D3DCommonDevice* commonD3DDevice = m_commonIntf->GetCommonD3DDevice();
-
-    D3D7Device* d3d7Device = commonD3DDevice != nullptr ? commonD3DDevice->GetD3D7Device() : nullptr;
-    if (unlikely(m_d3d7Device != d3d7Device)) {
-      // Check if the device has been recreated and reset all D3D9 resources
-      if (unlikely(m_d3d7Device != nullptr)) {
-        Logger::debug("D3D7VertexBuffer::RefreshD3DDevice: Device context has changed, clearing D3D9 buffers");
-        m_vb9 = nullptr;
-      }
-      m_d3d7Device = d3d7Device;
-    }
-  }
 
 }

--- a/src/ddraw/d3d7/d3d7_buffer.h
+++ b/src/ddraw/d3d7/d3d7_buffer.h
@@ -4,6 +4,7 @@
 #include "../ddraw_child_object.h"
 
 #include "../ddraw_common_interface.h"
+#include "../d3d_common_buffer.h"
 
 #include "d3d7_interface.h"
 #include "d3d7_device.h"
@@ -15,6 +16,7 @@ namespace dxvk {
   public:
 
     D3D7VertexBuffer(
+          D3DCommonBuffer* commonBuffer,
           D3D7Interface* pParent,
           D3DVERTEXBUFFERDESC* pDesc);
 
@@ -34,53 +36,19 @@ namespace dxvk {
 
     HRESULT STDMETHODCALLTYPE Optimize(LPDIRECT3DDEVICE7 lpD3DDevice, DWORD dwFlags);
 
-    HRESULT InitializeD3D9();
-
-    void RefreshD3DDevice();
-
-    bool IsInitialized() const {
-      return m_vb9 != nullptr;
-    }
-
-    d3d9::IDirect3DVertexBuffer9* GetD3D9VertexBuffer() const {
-      return m_vb9.ptr();
-    }
-
-    DWORD GetFVF() const {
-      return m_desc.dwFVF;
-    }
-
-    DWORD GetStride() const {
-      return m_stride;
+    D3DCommonBuffer* GetCommonBuffer() const {
+      return m_commonBuffer.ptr();
     }
 
     bool IsLocked() const {
       return m_locked;
     }
 
-    D3D7Device* GetDevice() const {
-      return m_d3d7Device;
-    }
-
   private:
 
-    inline bool IsOptimized() const {
-      return m_desc.dwCaps & D3DVBCAPS_OPTIMIZED;
-    }
+    std::atomic<bool>    m_locked = false;
 
-    bool                              m_locked        = false;
-    bool                              m_legacyDiscard = false;
-
-    DDrawCommonInterface*             m_commonIntf    = nullptr;
-
-    D3DVERTEXBUFFERDESC               m_desc;
-
-    UINT                              m_stride        = 0;
-    UINT                              m_size          = 0;
-
-    D3D7Device*                       m_d3d7Device    = nullptr;
-
-    Com<d3d9::IDirect3DVertexBuffer9> m_vb9;
+    Com<D3DCommonBuffer> m_commonBuffer;
 
   };
 

--- a/src/ddraw/d3d7/d3d7_device.cpp
+++ b/src/ddraw/d3d7/d3d7_device.cpp
@@ -56,8 +56,8 @@ namespace dxvk {
     // Common D3D9 index buffers
     static constexpr DWORD Usage = D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY;
 
-    for (uint8_t ibIndex = 0; ibIndex < ddrawCaps::IndexBufferCount ; ibIndex++) {
-      const UINT ibSize = ddrawCaps::IndexCount[ibIndex] * sizeof(WORD);
+    for (uint32_t ibIndex = 0; ibIndex < ddrawCaps::IndexBufferCount ; ibIndex++) {
+      const uint32_t ibSize = ddrawCaps::IndexCount[ibIndex] * sizeof(WORD);
 
       HRESULT hr = device9->CreateIndexBuffer(ibSize, Usage, d3d9::D3DFMT_INDEX16,
                                               d3d9::D3DPOOL_DEFAULT, &m_ib9[ibIndex], nullptr);
@@ -624,12 +624,18 @@ namespace dxvk {
       case D3DRENDERSTATE_COLORKEYENABLE: {
         m_commonD3DDevice->SetColorKeyEnable(dwRenderState);
 
-        const bool validColorKey = m_textures[0] != nullptr ? m_textures[0]->GetCommonSurface()->HasValidColorKey() : false;
-        m_bridge->SetColorKeyState(dwRenderState && validColorKey);
-        if (dwRenderState && validColorKey) {
-          DDCOLORKEY normalizedColorKey = m_textures[0]->GetCommonSurface()->GetColorKeyNormalized();
-          m_bridge->SetColorKey(normalizedColorKey.dwColorSpaceLowValue,
-                                normalizedColorKey.dwColorSpaceHighValue);
+        for (DWORD stage = 0; stage < ddrawCaps::TextureStageCount; stage++) {
+          if (m_textures[stage] == nullptr)
+            continue;
+
+          const bool validColorKey = m_textures[stage]->GetCommonSurface()->HasValidColorKey();
+          m_bridge->SetColorKeyState(stage, dwRenderState && validColorKey);
+
+          if (dwRenderState && validColorKey) {
+            const DDCOLORKEY* normalizedColorKey = m_textures[stage]->GetCommonSurface()->GetColorKeyNormalized();
+            m_bridge->SetColorKey(stage, normalizedColorKey->dwColorSpaceLowValue,
+                                  normalizedColorKey->dwColorSpaceHighValue);
+          }
         }
 
         return D3D_OK;
@@ -1139,23 +1145,24 @@ namespace dxvk {
       return DDERR_INVALIDPARAMS;
 
     Com<D3D7VertexBuffer> vb7 = static_cast<D3D7VertexBuffer*>(lpd3dVertexBuffer);
-
-    if (unlikely(vb7->GetDevice() != this)) {
-      Logger::err("D3D7Device::DrawPrimitiveVB: Invalid vertex buffer parent device");
-      return DDERR_GENERIC;
-    }
+    D3DCommonBuffer* commonBuffer = vb7->GetCommonBuffer();
 
     if (unlikely(vb7->IsLocked())) {
       Logger::err("D3D7Device::DrawPrimitiveVB: Buffer is locked");
       return D3DERR_VERTEXBUFFERLOCKED;
     }
 
+    if (unlikely(m_commonD3DDevice != commonBuffer->GetCommonD3DDevice())) {
+      Logger::err("D3D7Device::DrawPrimitiveVB: Invalid vertex buffer parent device");
+      return DDERR_GENERIC;
+    }
+
     DDrawDirtySurfaceUpload();
 
     d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
 
-    device9->SetFVF(vb7->GetFVF());
-    device9->SetStreamSource(0, vb7->GetD3D9VertexBuffer(), 0, vb7->GetStride());
+    device9->SetFVF(commonBuffer->GetFVF());
+    device9->SetStreamSource(0, commonBuffer->GetD3D9VertexBuffer(), 0, commonBuffer->GetStride());
     HRESULT hr = device9->DrawPrimitive(
                       d3d9::D3DPRIMITIVETYPE(d3dptPrimitiveType),
                       dwStartVertex,
@@ -1183,15 +1190,16 @@ namespace dxvk {
       return DDERR_INVALIDPARAMS;
 
     Com<D3D7VertexBuffer> vb7 = static_cast<D3D7VertexBuffer*>(lpd3dVertexBuffer);
-
-    if (unlikely(vb7->GetDevice() != this)) {
-      Logger::err("D3D7Device::DrawIndexedPrimitiveVB: Invalid vertex buffer parent device");
-      return DDERR_GENERIC;
-    }
+    D3DCommonBuffer* commonBuffer = vb7->GetCommonBuffer();
 
     if (unlikely(vb7->IsLocked())) {
       Logger::err("D3D7Device::DrawIndexedPrimitiveVB: Buffer is locked");
       return D3DERR_VERTEXBUFFERLOCKED;
+    }
+
+    if (unlikely(m_commonD3DDevice != commonBuffer->GetCommonD3DDevice())) {
+      Logger::err("D3D7Device::DrawIndexedPrimitiveVB: Invalid vertex buffer parent device");
+      return DDERR_GENERIC;
     }
 
     if (unlikely(dwIndexCount > ddrawCaps::MaxIndexCount)) {
@@ -1219,8 +1227,8 @@ namespace dxvk {
     ib9->Unlock();
 
     device9->SetIndices(ib9);
-    device9->SetFVF(vb7->GetFVF());
-    device9->SetStreamSource(0, vb7->GetD3D9VertexBuffer(), 0, vb7->GetStride());
+    device9->SetFVF(commonBuffer->GetFVF());
+    device9->SetStreamSource(0, commonBuffer->GetD3D9VertexBuffer(), 0, commonBuffer->GetStride());
     HRESULT hr = device9->DrawIndexedPrimitive(
                       d3d9::D3DPRIMITIVETYPE(d3dptPrimitiveType),
                       dwStartVertex,
@@ -1294,9 +1302,7 @@ namespace dxvk {
 
       if (likely(m_textures[stage] != nullptr)) {
         m_textures[stage] = nullptr;
-
-        if (likely(stage == 0))
-          m_bridge->SetColorKeyState(false);
+        m_bridge->SetColorKeyState(stage, false);
       }
 
       return D3D_OK;
@@ -1327,41 +1333,58 @@ namespace dxvk {
     //if (unlikely(m_textures[stage] == surface7))
       //return D3D_OK;
 
-    d3d9::IDirect3DTexture9*     tex9  = commonSurface->GetD3D9Texture();
-    d3d9::IDirect3DCubeTexture9* cube9 = commonSurface->GetD3D9CubeTexture();
+    const D3D9SurfaceType d3d9SurfaceType = commonSurface->GetD3D9SurfaceType();
 
-    if (likely(tex9 != nullptr)) {
-      hr = device9->SetTexture(stage, tex9);
-      if (unlikely(FAILED(hr))) {
-        Logger::warn("D3D7Device::SetTexture: Failed to bind D3D9 texture");
-        return hr;
-      }
+    switch (d3d9SurfaceType) {
+      default:
+      case D3D9SurfaceType::Texture: {
+        d3d9::IDirect3DTexture9* tex9 = commonSurface->GetD3D9Texture();
 
-      if (likely(stage == 0)) {
-        const bool colorKeyEnable = m_commonD3DDevice->GetColorKeyEnable();
-        const bool validColorKey = commonSurface->HasValidColorKey();
-        m_bridge->SetColorKeyState(colorKeyEnable && validColorKey);
-        if (colorKeyEnable && validColorKey) {
-          DDCOLORKEY normalizedColorKey = commonSurface->GetColorKeyNormalized();
-          m_bridge->SetColorKey(normalizedColorKey.dwColorSpaceLowValue,
-                                normalizedColorKey.dwColorSpaceHighValue);
+        // If a surface without a D3D9 texture gets bound, simply unbind the current texture.
+        // This is needed to handle the binding of surfaces which aren't explicitly marked as textures.
+        hr = device9->SetTexture(stage, tex9);
+        if (unlikely(FAILED(hr))) {
+          Logger::warn("D3D7Device::SetTexture: Failed to bind D3D9 texture");
+          return hr;
         }
-      }
-    } else if (likely(cube9 != nullptr)) {
-      hr = device9->SetTexture(stage, cube9);
-      if (unlikely(FAILED(hr))) {
-        Logger::warn("D3D7Device::SetTexture: Failed to bind D3D9 cube texture");
-        return hr;
+
+        if (likely(tex9 != nullptr)) {
+          const bool colorKeyEnable = m_commonD3DDevice->GetColorKeyEnable();
+          const bool validColorKey = commonSurface->HasValidColorKey();
+          m_bridge->SetColorKeyState(stage, colorKeyEnable && validColorKey);
+
+          if (colorKeyEnable && validColorKey) {
+            const DDCOLORKEY* normalizedColorKey = commonSurface->GetColorKeyNormalized();
+            m_bridge->SetColorKey(stage, normalizedColorKey->dwColorSpaceLowValue,
+                                  normalizedColorKey->dwColorSpaceHighValue);
+          }
+        }
+
+        break;
       }
 
-      if (likely(stage == 0)) {
+      case D3D9SurfaceType::CubeTexture: {
+        d3d9::IDirect3DCubeTexture9* cube9 = commonSurface->GetD3D9CubeTexture();
+
+        hr = device9->SetTexture(stage, cube9);
+        if (unlikely(FAILED(hr))) {
+          Logger::warn("D3D7Device::SetTexture: Failed to bind D3D9 cube texture");
+          return hr;
+        }
+
         const bool colorKeyEnable = m_commonD3DDevice->GetColorKeyEnable();
         const bool validColorKey = commonSurface->HasValidColorKey();
-        if (unlikely(colorKeyEnable && validColorKey))
-          Logger::warn("D3D7Device::SetTexture: Unsupported use of cube texture color key");
+        m_bridge->SetColorKeyState(stage, false);
+
+        if (unlikely(colorKeyEnable && validColorKey)) {
+          static bool s_cubeTextureColorKeyWarningShown;
+
+          if (!std::exchange(s_cubeTextureColorKeyWarningShown, true))
+            Logger::warn("D3D7Device::SetTexture: Unsupported use of cube texture color key");
+        }
+
+        break;
       }
-    } else {
-      Logger::err("D3D7Device::SetTexture: Found no valid D3D9 texture");
     }
 
     m_textures[stage] = surface7;

--- a/src/ddraw/d3d7/d3d7_device.h
+++ b/src/ddraw/d3d7/d3d7_device.h
@@ -181,7 +181,7 @@ namespace dxvk {
 
     Com<D3DCommonDevice>            m_commonD3DDevice;
 
-    DDrawCommonInterface*           m_commonIntf            = nullptr;
+    DDrawCommonInterface*           m_commonIntf     = nullptr;
 
     Com<IDxvkLegacyD3DDeviceBridge> m_bridge;
 
@@ -197,9 +197,9 @@ namespace dxvk {
     std::unordered_map<DWORD, d3d9::D3DLIGHT9> m_lights;
     std::unordered_map<DWORD, BOOL>            m_lightsStates;
 
-    D3D7StateBlock*                 m_recorder              = nullptr;
-    DWORD                           m_recorderHandle        = 0;
-    DWORD                           m_handle                = 0;
+    D3D7StateBlock*                 m_recorder       = nullptr;
+    DWORD                           m_recorderHandle = 0;
+    DWORD                           m_handle         = 0;
     std::unordered_map<DWORD, D3D7StateBlock> m_stateBlocks;
 
     std::array<Com<d3d9::IDirect3DIndexBuffer9>, ddrawCaps::IndexBufferCount> m_ib9;

--- a/src/ddraw/d3d7/d3d7_interface.cpp
+++ b/src/ddraw/d3d7/d3d7_interface.cpp
@@ -174,33 +174,36 @@ namespace dxvk {
     bool  halFallback          = false;
     bool  rgbFallback          = false;
 
-    if (likely(!d3dOptions->forceSWVP)) {
-      if (rclsid == IID_IDirect3DTnLHalDevice) {
-        Logger::info("D3D7Interface::CreateDevice: Creating an IID_IDirect3DTnLHalDevice device");
+    if (rclsid == IID_IDirect3DTnLHalDevice) {
+      Logger::info("D3D7Interface::CreateDevice: Creating an IID_IDirect3DTnLHalDevice device");
+      if (likely(!d3dOptions->forceSWVP))
         deviceCreationFlags9 = D3DCREATE_HARDWARE_VERTEXPROCESSING;
-        isHALOrTNLHALDevice = true;
-      } else if (rclsid == IID_IDirect3DHALDevice) {
-        Logger::info("D3D7Interface::CreateDevice: Creating an IID_IDirect3DHALDevice device");
+      isHALOrTNLHALDevice = true;
+    } else if (rclsid == IID_IDirect3DHALDevice) {
+      Logger::info("D3D7Interface::CreateDevice: Creating an IID_IDirect3DHALDevice device");
+      if (likely(!d3dOptions->forceSWVP))
         deviceCreationFlags9 = D3DCREATE_MIXED_VERTEXPROCESSING;
-        isHALOrTNLHALDevice = true;
-      } else if (rclsid == IID_IDirect3DRGBDevice) {
-        Logger::info("D3D7Interface::CreateDevice: Creating an IID_IDirect3DRGBDevice device");
-      } else if (rclsid == IID_IDirect3DMMXDevice) {
-        Logger::warn("D3D7Interface::CreateDevice: Unsupported MMX device, falling back to RGB");
-        rgbFallback = true;
-      } else if (rclsid == IID_IDirect3DRampDevice) {
-        Logger::warn("D3D7Interface::CreateDevice: Unsupported Ramp device, falling back to RGB");
-        rgbFallback = true;
+      isHALOrTNLHALDevice = true;
+    } else if (rclsid == IID_IDirect3DRGBDevice) {
+      Logger::info("D3D7Interface::CreateDevice: Creating an IID_IDirect3DRGBDevice device");
+    } else if (rclsid == IID_IDirect3DMMXDevice) {
+      Logger::warn("D3D7Interface::CreateDevice: Unsupported MMX device, falling back to RGB");
+      rgbFallback = true;
+    } else if (rclsid == IID_IDirect3DRampDevice) {
+      Logger::warn("D3D7Interface::CreateDevice: Unsupported Ramp device, falling back to RGB");
+      rgbFallback = true;
+    } else if (unlikely(rclsid == IID_IUnknown)) {
+      Logger::warn("D3D7Interface::CreateDevice: Unsupported IID_IUnknown, falling back to RGB");
+      rgbFallback = true;
+    } else {
+      if (unlikely(rclsid != IID_WineD3DDevice)) {
+        Logger::warn("D3D7Interface::CreateDevice: Unknown device type, falling back to HAL");
+        Logger::warn(str::format(rclsid));
       } else {
-        if (unlikely(rclsid != IID_WineD3DDevice)) {
-          Logger::warn("D3D7Interface::CreateDevice: Unknown device type, falling back to HAL");
-          Logger::warn(str::format(rclsid));
-        } else {
-          Logger::info("D3D7Interface::CreateDevice: Creating an IID_WineD3DDevice HAL device");
-        }
-        halFallback = true;
-        // Don't enforce isHALOrTNLHALDevice RT validations
+        Logger::info("D3D7Interface::CreateDevice: Creating an IID_WineD3DDevice HAL device");
       }
+      halFallback = true;
+      // Don't enforce isHALOrTNLHALDevice RT validations
     }
 
     const IID rclsidOverride = halFallback ? IID_IDirect3DHALDevice :
@@ -342,7 +345,7 @@ namespace dxvk {
 
     InitReturnPtr(ppVertexBuffer);
 
-    *ppVertexBuffer = ref(new D3D7VertexBuffer(this, desc));
+    *ppVertexBuffer = ref(new D3D7VertexBuffer(nullptr, this, desc));
 
     return D3D_OK;
   }

--- a/src/ddraw/d3d_common_buffer.cpp
+++ b/src/ddraw/d3d_common_buffer.cpp
@@ -1,0 +1,61 @@
+#include "d3d_common_buffer.h"
+
+#include "d3d_common_device.h"
+
+namespace dxvk {
+
+  D3DCommonBuffer::D3DCommonBuffer(
+        DDrawCommonInterface* commonIntf,
+        const D3DVERTEXBUFFERDESC* pDesc,
+        DWORD creationFlags)
+    : m_commonIntf ( commonIntf )
+    , m_desc ( *pDesc )
+    , m_creationFlags ( creationFlags )
+    , m_stride ( GetFVFSize(pDesc->dwFVF) )
+    , m_size ( m_stride * pDesc->dwNumVertices ) {
+  }
+
+  D3DCommonBuffer::~D3DCommonBuffer() {
+  }
+
+  HRESULT D3DCommonBuffer::InitializeD3D9() {
+    // Can't create anything without a valid device
+    if (unlikely(m_commonD3DDevice == nullptr)) {
+      Logger::warn("D3DCommonBuffer::InitializeD3D9: Null device, can't initialize right now");
+      return DDERR_GENERIC;
+    }
+
+    const D3DOptions* d3dOptions = m_commonIntf->GetOptions();
+
+    const d3d9::D3DPOOL pool = (m_desc.dwCaps & D3DVBCAPS_SYSTEMMEMORY) ? d3d9::D3DPOOL_SYSTEMMEM :
+                               d3dOptions->managedVertexBuffers ? d3d9::D3DPOOL_MANAGED : d3d9::D3DPOOL_DEFAULT;
+    const DWORD usage = ConvertD3DUsageFlags(m_desc.dwCaps, m_creationFlags, pool);
+
+    // Note: IDirect3DVertexBuffer (D3D6) doesn't have a DISCARD flag
+    m_legacyDiscard = d3dOptions->forceLegacyDiscard &&
+                      (usage & D3DUSAGE_DYNAMIC) && (usage & D3DUSAGE_WRITEONLY);
+
+    d3d9::IDirect3DDevice9* device9 = m_commonD3DDevice->GetD3D9Device();
+    HRESULT hr = device9->CreateVertexBuffer(m_size, usage, m_desc.dwFVF, pool, &m_vb9, nullptr);
+    if (unlikely(FAILED(hr))) {
+      Logger::err("D3DCommonBuffer::InitializeD3D9: Failed to create D3D9 vertex buffer");
+      return hr;
+    }
+
+    return D3D_OK;
+  }
+
+  void D3DCommonBuffer::RefreshD3DDevice() {
+    D3DCommonDevice* commonD3DDevice = m_commonIntf->GetCommonD3DDevice();
+
+    if (unlikely(m_commonD3DDevice != commonD3DDevice)) {
+      // Check if the device has been recreated and reset all D3D9 resources
+      if (unlikely(m_commonD3DDevice != nullptr)) {
+        Logger::debug("D3DCommonBuffer::RefreshD3DDevice: Device context has changed, clearing D3D9 buffers");
+        m_vb9 = nullptr;
+      }
+      m_commonD3DDevice = commonD3DDevice;
+    }
+  }
+
+}

--- a/src/ddraw/d3d_common_buffer.h
+++ b/src/ddraw/d3d_common_buffer.h
@@ -1,0 +1,102 @@
+#pragma once
+
+#include "ddraw_include.h"
+#include "ddraw_util.h"
+
+#include "ddraw_common_interface.h"
+
+namespace dxvk {
+
+  class DDrawCommonInterface;
+  class D3DCommonDevice;
+
+  class D3DCommonBuffer : public ComObjectClamp<IUnknown> {
+
+  public:
+
+    D3DCommonBuffer(
+          DDrawCommonInterface* commonIntf,
+          const D3DVERTEXBUFFERDESC* pDesc,
+          DWORD creationFlags
+    );
+
+    ~D3DCommonBuffer();
+
+    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject) {
+      *ppvObject = this;
+      return S_OK;
+    }
+
+    HRESULT InitializeD3D9();
+
+    void RefreshD3DDevice();
+
+    DDrawCommonInterface* GetCommonInterface() const {
+      return m_commonIntf;
+    }
+
+    D3DCommonDevice* GetCommonD3DDevice() const {
+      return m_commonD3DDevice;
+    }
+
+    bool IsInitialized() const {
+      return m_vb9 != nullptr;
+    }
+
+    d3d9::IDirect3DVertexBuffer9* GetD3D9VertexBuffer() const {
+      return m_vb9.ptr();
+    }
+
+    D3DVERTEXBUFFERDESC GetDesc() const {
+      return m_desc;
+    }
+
+    DWORD GetFVF() const {
+      return m_desc.dwFVF;
+    }
+
+    DWORD GetStride() const {
+      return m_stride;
+    }
+
+    DWORD GetSize() const {
+      return m_size;
+    }
+
+    DWORD GetNumVertices() const {
+      return m_desc.dwNumVertices;
+    }
+
+    // Cops 2170: The Power of Law relies on us not discarding on any write only lock
+    // to render geometry, and does not mark the affected buffers with D3DVBCAPS_WRITEONLY
+    bool GetLegacyDiscard(DWORD flags) const {
+      return m_legacyDiscard || (m_commonIntf->GetOptions()->forceLegacyDiscard && (flags & DDLOCK_WRITEONLY));
+    }
+
+    void MarkAsOptimized() {
+      m_desc.dwCaps |= D3DVBCAPS_OPTIMIZED;
+    }
+
+    bool IsOptimized() const {
+      return m_desc.dwCaps & D3DVBCAPS_OPTIMIZED;
+    }
+
+  private:
+
+    bool                              m_legacyDiscard   = false;
+
+    DDrawCommonInterface*             m_commonIntf      = nullptr;
+
+    D3DCommonDevice*                  m_commonD3DDevice = nullptr;
+
+    D3DVERTEXBUFFERDESC               m_desc;
+    DWORD                             m_creationFlags   = 0;
+
+    DWORD                             m_stride          = 0;
+    DWORD                             m_size            = 0;
+
+    Com<d3d9::IDirect3DVertexBuffer9> m_vb9;
+
+  };
+
+}

--- a/src/ddraw/d3d_common_device.h
+++ b/src/ddraw/d3d_common_device.h
@@ -74,8 +74,6 @@ namespace dxvk {
 
     bool IsHALOrTNLHALDevice() const {
       return m_deviceGUID == IID_IDirect3DHALDevice ||
-             // Functionally identical to a HAL device
-             m_deviceGUID == IID_WineD3DDevice ||
              m_deviceGUID == IID_IDirect3DTnLHalDevice;
     }
 
@@ -218,6 +216,7 @@ namespace dxvk {
 
     GUID                        m_deviceGUID;
     uint32_t                    m_totalMemory         = 0;
+
     D3DMATERIALHANDLE           m_materialHandle      = 0;
     D3DTEXTUREHANDLE            m_textureHandle       = 0;
 

--- a/src/ddraw/d3d_common_interface.h
+++ b/src/ddraw/d3d_common_interface.h
@@ -76,12 +76,12 @@ namespace dxvk {
 
   private:
 
-    Com<d3d9::IDirect3D9> m_d3d9Intf       = nullptr;
+    Com<d3d9::IDirect3D9> m_d3d9Intf = nullptr;
 
-    D3D7Interface*        m_d3d7Intf       = nullptr;
-    D3D6Interface*        m_d3d6Intf       = nullptr;
-    D3D5Interface*        m_d3d5Intf       = nullptr;
-    D3D3Interface*        m_d3d3Intf       = nullptr;
+    D3D7Interface*        m_d3d7Intf = nullptr;
+    D3D6Interface*        m_d3d6Intf = nullptr;
+    D3D5Interface*        m_d3d5Intf = nullptr;
+    D3D3Interface*        m_d3d3Intf = nullptr;
 
     // Tests have indicated that once created, material handles are shared across
     // all devices and D3D interfaces, regardless of their relation

--- a/src/ddraw/d3d_common_viewport.cpp
+++ b/src/ddraw/d3d_common_viewport.cpp
@@ -83,7 +83,7 @@ namespace dxvk {
     const bool clipped = (flags & D3DTRANSFORM_CLIPPED) && !(flags & D3DTRANSFORM_UNCLIPPED);
 
     if (clipped)
-      *offscreen = UINT_MAX;
+      *offscreen = std::numeric_limits<uint32_t>::max();
     else
       *offscreen = 0;
 

--- a/src/ddraw/d3d_process_vertices.h
+++ b/src/ddraw/d3d_process_vertices.h
@@ -18,7 +18,7 @@ namespace dxvk {
     bool doExtents;
     bool doNotCopyData;
     bool isLegacy;
-    uint16_t vertexCount;
+    uint32_t vertexCount;
     size_t inStride;
     size_t outStride;
     DWORD inFVF;
@@ -398,10 +398,10 @@ namespace dxvk {
     tmp[3][0] = m->_41; tmp[3][1] = m->_42; tmp[3][2] = m->_43; tmp[3][3] = m->_44;
     tmp[3][4] = 0.0f;   tmp[3][5] = 0.0f;   tmp[3][6] = 0.0f;   tmp[3][7] = 1.0f;
 
-    for (int i = 0; i < 4; ++i) {
-      int max_row = i;
+    for (uint32_t i = 0; i < 4; ++i) {
+      uint32_t max_row = i;
       float max_val = std::fabs(tmp[i][i]);
-      for (int k = i + 1; k < 4; ++k) {
+      for (uint32_t k = i + 1; k < 4; ++k) {
         const float val = std::fabs(tmp[k][i]);
         if (val > max_val) {
           max_val = val;
@@ -413,20 +413,20 @@ namespace dxvk {
         return;
 
       if (max_row != i) {
-        for (int j = 0; j < 8; ++j) {
+        for (uint32_t j = 0; j < 8; ++j) {
           std::swap(tmp[i][j], tmp[max_row][j]);
         }
       }
 
       const float pivot = tmp[i][i];
-      for (int j = i; j < 8; ++j) {
+      for (uint32_t j = i; j < 8; ++j) {
         tmp[i][j] /= pivot;
       }
 
-      for (int k = 0; k < 4; ++k) {
+      for (uint32_t k = 0; k < 4; ++k) {
         if (k != i) {
           const float factor = tmp[k][i];
-          for (int j = 0; j < 8; ++j) {
+          for (uint32_t j = 0; j < 8; ++j) {
             tmp[k][j] -= factor * tmp[i][j];
           }
         }
@@ -936,8 +936,6 @@ namespace dxvk {
     float fogStart, fogEnd, fogDensity;
     BOOL isEnabledFogRange, isEnabledLighting, isEnabledSpecular, isEnabledNormalizeNormals, isEnabledLocalViewer;
     D3DCOLOR ambientStateColor;
-    // In D3D7 it's quite possible no material is set, even though lighting is enabled
-    d3d9::D3DMATERIAL9 material9 = { };
 
     d3d9Device->GetRenderState(d3d9::D3DRS_FOGVERTEXMODE, reinterpret_cast<DWORD*>(&fogVertexMode));
     const bool isEnabledFog = fogVertexMode != D3DFOG_NONE;
@@ -958,8 +956,9 @@ namespace dxvk {
       d3d9Device->GetRenderState(d3d9::D3DRS_NORMALIZENORMALS, reinterpret_cast<DWORD*>(&isEnabledNormalizeNormals));
       d3d9Device->GetRenderState(d3d9::D3DRS_LOCALVIEWER, reinterpret_cast<DWORD*>(&isEnabledLocalViewer));
     }
-    d3d9Device->GetMaterial(&material9);
 
+    d3d9::D3DMATERIAL9 material9;
+    d3d9Device->GetMaterial(&material9);
     const float materialPower = useLighting && isEnabledSpecular ? material9.Power : 0.0f;
 
     static constexpr D3DCOLORVALUE defaultAmbientColorValue = {0.0f, 0.0f, 0.0f, 0.0f};
@@ -1007,7 +1006,7 @@ namespace dxvk {
       }
     }
 
-    for (uint16_t t = 0; t < pvData->vertexCount; t++) {
+    for (uint32_t t = 0; t < pvData->vertexCount; t++) {
       uint8_t* inPtr = pvData->inData + t * pvData->inStride;
       uint8_t* outPtr = pvData->outData + t * pvData->outStride;
 

--- a/src/ddraw/ddraw/ddraw_interface.cpp
+++ b/src/ddraw/ddraw/ddraw_interface.cpp
@@ -235,7 +235,7 @@ namespace dxvk {
       // may crash in case they find that's not the case
       if (unlikely((lpDDSurfaceDesc->ddpfPixelFormat.dwFlags == (DDPF_BUMPDUDV | DDPF_BUMPLUMINANCE))
                 && (lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_VIDEOMEMORY))) {
-        Logger::warn("DDrawInterface::CreateSurface: Video memory DDPF_BUMPLUMINANCE surface");
+        Logger::debug("DDrawInterface::CreateSurface: Video memory DDPF_BUMPLUMINANCE surface");
         lpDDSurfaceDesc->ddsCaps.dwCaps &= ~DDSCAPS_VIDEOMEMORY &
                                            ~DDSCAPS_LOCALVIDMEM &
                                            ~DDSCAPS_NONLOCALVIDMEM;
@@ -282,8 +282,8 @@ namespace dxvk {
 
         // Shadow surface creation for the primary surface
         // (it needs to be based on the same incoming desc)
-        if (unlikely(m_commonIntf->GetOptions()->forceLegacyPresent &&
-                    !surface->GetCommonSurface()->SkipD3D9Operations())) {
+        if (m_commonIntf->GetOptions()->forceLegacyPresent &&
+           !surface->GetCommonSurface()->SkipD3D9Operations()) {
           DDSURFACEDESC shadowDesc = *lpDDSurfaceDesc;
           const DDSURFACEDESC* primaryDesc = surface->GetCommonSurface()->GetDesc();
 

--- a/src/ddraw/ddraw/ddraw_surface.cpp
+++ b/src/ddraw/ddraw/ddraw_surface.cpp
@@ -190,16 +190,28 @@ namespace dxvk {
     // The standard way of creating a new D3D3 device. Outside of RAMP, MMX, RGB and HAL,
     // some applications (e.g. Dark Rift) query for Wine's advertised custom device IID.
     if (riid == IID_IDirect3DHALDevice  || riid == IID_IDirect3DRGBDevice  ||
-        riid == IID_IDirect3DMMXDevice  || riid == IID_IDirect3DRampDevice ||
-        riid == IID_WineD3DDevice) {
+        riid == IID_IDirect3DRampDevice || riid == IID_WineD3DDevice) {
       // Surfaces which have been queried from an IDirectDrawSurface7
       // object are unable to create a D3D3 device on this legacy path
       if (unlikely(m_commonSurf->GetDD7Surface() == m_commonSurf->GetOrigin()))
         return E_NOINTERFACE;
 
-      HRESULT hr = CreateDeviceInternal(riid, ppvObject);
-      if (unlikely(FAILED(hr)))
-        return E_NOINTERFACE;
+      // Tests show that a surface can't be used to create more than a device
+      // at a time, and esentially that the surface IS the device in such cases...
+      if (m_device3 == nullptr) {
+        HRESULT hr = CreateDeviceInternal(riid, ppvObject);
+        if (unlikely(FAILED(hr)))
+          return E_NOINTERFACE;
+      // TODO: What happens when a device with a different riid than the existing one
+      // is requested on the same surface? Is the old one released and a new one created?
+      // We could potentially handle such corner cases transparently, by recreating only
+      // the D3D9 device as per the new request and binding it to the same object, though
+      // I don't actually expect this to be much of a problem in practice.
+      } else if (unlikely(m_device3->GetCommonD3DDevice()->GetDeviceGUID() != riid)) {
+        Logger::warn("DDrawSurface::QueryInterface: Query with mismatched device GUID");
+      }
+
+      *ppvObject = m_device3.ref();
 
       return S_OK;
     }
@@ -337,11 +349,23 @@ namespace dxvk {
 
     attachedSurf->SetParentSurface(this);
 
+    hr = attachedSurf->GetCommonSurface()->RefreshSurfaceDescripton(false);
+    if (unlikely(FAILED(hr))) {
+      Logger::err("DDrawSurface::AddAttachedSurface: Failed to retrieve updated attachment surface desc");
+      return hr;
+    }
+
     if (likely(attachedSurf->GetCommonSurface()->IsDepthStencil())) {
       m_depthStencil = attachedSurf;
     // If a flippable surface is attached, mark it as the next flippable surface
     } else if (unlikely(attachedSurf->GetCommonSurface()->IsBackBufferOrFlippable())) {
       m_nextFlippable = attachedSurf;
+    }
+
+    hr = m_commonSurf->RefreshSurfaceDescripton(false);
+    if (unlikely(FAILED(hr))) {
+      Logger::err("DDrawSurface::AddAttachedSurface: Failed to retrieve updated target surface desc");
+      return hr;
     }
 
     return DD_OK;
@@ -404,7 +428,7 @@ namespace dxvk {
 
     m_commonSurf->DirtyDDrawSurface();
 
-    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
+    if (m_shadowSurf != nullptr && d3d9Device != nullptr) {
       const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                 !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
                                  m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
@@ -476,7 +500,7 @@ namespace dxvk {
 
     m_commonSurf->DirtyDDrawSurface();
 
-    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
+    if (m_shadowSurf != nullptr && d3d9Device != nullptr) {
       const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                 !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
                                  m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
@@ -498,9 +522,9 @@ namespace dxvk {
     }
 
     if (lpDDSAttachedSurface == nullptr) {
-      HRESULT hrProxy = m_proxy->DeleteAttachedSurface(dwFlags, lpDDSAttachedSurface);
-      if (unlikely(FAILED(hrProxy)))
-        return hrProxy;
+      HRESULT hr = m_proxy->DeleteAttachedSurface(dwFlags, lpDDSAttachedSurface);
+      if (unlikely(FAILED(hr)))
+        return hr;
 
       // If lpDDSAttachedSurface is NULL, then all surfaces are detached
       m_depthStencil = nullptr;
@@ -516,12 +540,23 @@ namespace dxvk {
 
     attachedSurf->SetParentSurface(nullptr);
 
+    hr = attachedSurf->GetCommonSurface()->RefreshSurfaceDescripton(false);
+    if (unlikely(FAILED(hr))) {
+      Logger::err("DDrawSurface::DeleteAttachedSurface: Failed to retrieve updated attachment surface desc");
+      return hr;
+    }
+
     if (likely(m_depthStencil == attachedSurf)) {
       m_depthStencil = nullptr;
     // Clear the next flippable surface or flippable surface detachment
-    } else if (unlikely(attachedSurf->GetCommonSurface()->IsBackBufferOrFlippable() &&
-                        attachedSurf == m_nextFlippable)) {
+    } else if (unlikely(m_nextFlippable == attachedSurf)) {
       m_nextFlippable = nullptr;
+    }
+
+    hr = m_commonSurf->RefreshSurfaceDescripton(false);
+    if (unlikely(FAILED(hr))) {
+      Logger::err("DDrawSurface::DeleteAttachedSurface: Failed to retrieve updated target surface desc");
+      return hr;
     }
 
     return DD_OK;
@@ -801,14 +836,17 @@ namespace dxvk {
       return hr;
 
     // For single surface locks, track the READONLY flag in order to skip dirtying
-    // on Unlock(). Reset the tracking in case of multiple simultaneous locks.
-    if (likely(!m_lockCount)) {
+    // on Unlock(). Reset flag tracking in case of multiple simultaneous locks,
+    // which are technically possible but extremely rare in practice.
+    //
+    // Note: Using lpDestRect as a key for tracking and/or matching Lock() to Unlock()
+    // calls, as the documentation suggests, isn't feasible, as there are applications
+    // which use nullptr during Lock() calls and then a non-null pointer on Unlock().
+    if (likely(!m_readOnlyLock)) {
       m_readOnlyLock = (dwFlags & DDLOCK_READONLY) && !(dwFlags & DDLOCK_WRITEONLY);
     } else {
       m_readOnlyLock = false;
     }
-
-    m_lockCount++;
 
     return DD_OK;
   }
@@ -831,15 +869,17 @@ namespace dxvk {
 
     m_commonSurf->DirtyDDrawSurface();
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
-    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
-      const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
-                                !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
-                                  m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
-                                  false : true;
-      if (shouldPresent) {
-        InitializeOrUploadD3D9();
-        d3d9Device->Present(NULL, NULL, NULL, NULL);
+    if (m_shadowSurf != nullptr) {
+      d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
+      if (likely(d3d9Device != nullptr)) {
+        const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
+                                  !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
+                                   m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
+                                   false : true;
+        if (shouldPresent) {
+          InitializeOrUploadD3D9();
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
+        }
       }
     }
 
@@ -936,6 +976,9 @@ namespace dxvk {
       m_commonSurf->SetPalette(ddrawPalette);
     }
 
+    // Note: A palette update on a primary surface would cause immediate
+    // presentation, however we don't support P8 primary surfaces
+
     return DD_OK;
   }
 
@@ -946,23 +989,22 @@ namespace dxvk {
 
     if (!m_readOnlyLock) {
       m_commonSurf->DirtyDDrawSurface();
+
+      if (m_shadowSurf != nullptr) {
+        d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
+        if (likely(d3d9Device != nullptr)) {
+          const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
+                                    !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
+                                     m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
+                                     false : true;
+          if (shouldPresent) {
+            InitializeOrUploadD3D9();
+            d3d9Device->Present(NULL, NULL, NULL, NULL);
+          }
+        }
+      }
     } else {
       m_readOnlyLock = false;
-    }
-
-    if (likely(m_lockCount))
-      m_lockCount--;
-
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
-    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
-      const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
-                                !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
-                                 m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
-                                 false : true;
-      if (shouldPresent) {
-        InitializeOrUploadD3D9();
-        d3d9Device->Present(NULL, NULL, NULL, NULL);
-      }
     }
 
     return DD_OK;
@@ -1086,7 +1128,7 @@ namespace dxvk {
 
     //Logger::debug(str::format("DDrawSurface::UploadSurfaceData: Uploading nr. [[1-", std::hex, this, "]]"));
 
-    D3D9SurfaceType d3d9SurfaceType = m_commonSurf->GetD3D9SurfaceType();
+    const D3D9SurfaceType d3d9SurfaceType = m_commonSurf->GetD3D9SurfaceType();
 
     switch (d3d9SurfaceType) {
       case D3D9SurfaceType::Texture:
@@ -1112,29 +1154,31 @@ namespace dxvk {
     bool  halFallback          = false;
     bool  rgbFallback          = false;
 
-    if (likely(!d3dOptions->forceSWVP)) {
-      if (riid == IID_IDirect3DHALDevice) {
-        Logger::info("DDrawSurface::CreateDeviceInternal: Creating an IID_IDirect3DHALDevice device");
+    if (riid == IID_IDirect3DHALDevice) {
+      Logger::info("DDrawSurface::CreateDeviceInternal: Creating an IID_IDirect3DHALDevice device");
+      if (likely(!d3dOptions->forceSWVP))
         deviceCreationFlags9 = D3DCREATE_MIXED_VERTEXPROCESSING;
-        isHALDevice = true;
-      } else if (riid == IID_IDirect3DRGBDevice) {
-        Logger::info("DDrawSurface::CreateDeviceInternal: Creating an IID_IDirect3DRGBDevice device");
-      } else if (riid == IID_IDirect3DMMXDevice) {
-        Logger::warn("DDrawSurface::CreateDeviceInternal: Unsupported MMX device, falling back to RGB");
-        rgbFallback = true;
-      } else if (riid == IID_IDirect3DRampDevice) {
-        Logger::warn("DDrawSurface::CreateDeviceInternal: Unsupported Ramp device, falling back to RGB");
-        rgbFallback = true;
+      isHALDevice = true;
+    } else if (riid == IID_IDirect3DRGBDevice) {
+      Logger::info("DDrawSurface::CreateDeviceInternal: Creating an IID_IDirect3DRGBDevice device");
+    } else if (riid == IID_IDirect3DMMXDevice) {
+      Logger::warn("DDrawSurface::CreateDeviceInternal: Unsupported MMX device, falling back to RGB");
+      rgbFallback = true;
+    } else if (riid == IID_IDirect3DRampDevice) {
+      Logger::warn("DDrawSurface::CreateDeviceInternal: Unsupported Ramp device, falling back to RGB");
+      rgbFallback = true;
+    } else if (unlikely(riid == IID_IUnknown)) {
+      Logger::warn("DDrawSurface::CreateDeviceInternal: Unsupported IID_IUnknown, falling back to RGB");
+      rgbFallback = true;
+    } else {
+      if (unlikely(riid != IID_WineD3DDevice)) {
+        Logger::warn("DDrawSurface::CreateDeviceInternal: Unknown device type, falling back to HAL");
+        Logger::warn(str::format(riid));
       } else {
-        if (unlikely(riid != IID_WineD3DDevice)) {
-          Logger::warn("DDrawSurface::CreateDeviceInternal: Unknown device type, falling back to HAL");
-          Logger::warn(str::format(riid));
-        } else {
-          Logger::info("DDrawSurface::CreateDeviceInternal: Creating an IID_WineD3DDevice HAL device");
-        }
-        halFallback = true;
-        // Don't enforce isHALDevice RT validations
+        Logger::info("DDrawSurface::CreateDeviceInternal: Creating an IID_WineD3DDevice HAL device");
       }
+      halFallback = true;
+      // Don't enforce isHALDevice RT validations
     }
 
     const IID rclsidOverride = halFallback ? IID_IDirect3DHALDevice :
@@ -1237,18 +1281,16 @@ namespace dxvk {
     }
 
     try{
-      Com<D3D3Device> device3 = new D3D3Device(nullptr, this, rclsidOverride, &params,
-                                               std::move(device9), deviceCreationFlags9);
+      m_device3 = new D3D3Device(nullptr, this, rclsidOverride, &params,
+                                 std::move(device9), deviceCreationFlags9);
 
       // Set the common device on the common interface
-      m_commonIntf->SetCommonD3DDevice(device3->GetCommonD3DDevice());
+      m_commonIntf->SetCommonD3DDevice(m_device3->GetCommonD3DDevice());
       // Now that we have a valid common D3D device on the DDraw interface,
       // we can initialize the render target and depth stencil (if any)
-      hr = device3->InitializeRTAndDS();
+      hr = m_device3->InitializeRTAndDS();
       if (unlikely(FAILED(hr)))
         return hr;
-
-      *ppvObject = device3.ref();
     } catch (const DxvkError& e) {
       Logger::err(e.message());
       return DDERR_GENERIC;

--- a/src/ddraw/ddraw/ddraw_surface.h
+++ b/src/ddraw/ddraw/ddraw_surface.h
@@ -17,6 +17,8 @@
 
 namespace dxvk {
 
+  class D3D3Device;
+
   /**
   * \brief IDirectDrawSurface interface implementation
   */
@@ -146,16 +148,8 @@ namespace dxvk {
       return m_texture3.ptr();
     }
 
-    void SetD3D3Texture(D3D3Texture* texture3) {
-      m_texture3 = texture3;
-    }
-
     D3D5Texture* GetD3D5Texture() const {
       return m_texture5.ptr();
-    }
-
-    void SetD3D5Texture(D3D5Texture* texture5) {
-      m_texture5 = texture5;
     }
 
     void SetAttachedDepthStencil(Com<DDrawSurface>&& depthStencil) {
@@ -203,14 +197,14 @@ namespace dxvk {
     inline HRESULT CreateDeviceInternal(REFIID riid, void** ppvObject);
 
     bool                      m_isChildObject = false;
-
-    bool                      m_readOnlyLock  = false;
-    std::atomic<uint8_t>      m_lockCount     = 0u;
+    std::atomic<bool>         m_readOnlyLock  = false;
 
     Com<DDrawCommonSurface>   m_commonSurf;
     DDrawCommonInterface*     m_commonIntf    = nullptr;
 
     DDrawSurface*             m_parentSurf    = nullptr;
+
+    Com<D3D3Device, false>    m_device3;
 
     Com<D3D3Texture, false>   m_texture3;
     Com<D3D5Texture, false>   m_texture5;

--- a/src/ddraw/ddraw2/ddraw2_interface.cpp
+++ b/src/ddraw/ddraw2/ddraw2_interface.cpp
@@ -232,7 +232,7 @@ namespace dxvk {
       // may crash in case they find that's not the case
       if (unlikely((lpDDSurfaceDesc->ddpfPixelFormat.dwFlags == (DDPF_BUMPDUDV | DDPF_BUMPLUMINANCE))
                 && (lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_VIDEOMEMORY))) {
-        Logger::warn("DDraw2Interface::CreateSurface: Video memory DDPF_BUMPLUMINANCE surface");
+        Logger::debug("DDraw2Interface::CreateSurface: Video memory DDPF_BUMPLUMINANCE surface");
         lpDDSurfaceDesc->ddsCaps.dwCaps &= ~DDSCAPS_VIDEOMEMORY &
                                            ~DDSCAPS_LOCALVIDMEM &
                                            ~DDSCAPS_NONLOCALVIDMEM;
@@ -280,8 +280,8 @@ namespace dxvk {
 
         // Shadow surface creation for the primary surface
         // (it needs to be based on the same incoming desc)
-        if (unlikely(m_commonIntf->GetOptions()->forceLegacyPresent &&
-                    !surface->GetCommonSurface()->SkipD3D9Operations())) {
+        if (m_commonIntf->GetOptions()->forceLegacyPresent &&
+           !surface->GetCommonSurface()->SkipD3D9Operations()) {
           DDSURFACEDESC shadowDesc = *lpDDSurfaceDesc;
           const DDSURFACEDESC* primaryDesc = surface->GetCommonSurface()->GetDesc();
 

--- a/src/ddraw/ddraw2/ddraw2_surface.cpp
+++ b/src/ddraw/ddraw2/ddraw2_surface.cpp
@@ -158,6 +158,20 @@ namespace dxvk {
     if (unlikely(riid == __uuidof(IDirectDrawColorControl))) {
       return E_NOINTERFACE;
     }
+    // The standard way of creating a new D3D3 device. Forward the call
+    // onto the base IDirectDrawSurface object, which we keep a reference to.
+    if (unlikely(riid == IID_IDirect3DHALDevice  || riid == IID_IDirect3DRGBDevice  ||
+                 riid == IID_IDirect3DRampDevice || riid == IID_WineD3DDevice)) {
+      // Surfaces which have been queried from an IDirectDrawSurface7
+      // object are unable to create a D3D3 device on this legacy path
+      if (unlikely(m_commonSurf->GetDD7Surface() == m_commonSurf->GetOrigin()))
+        return E_NOINTERFACE;
+
+      if (likely(m_commonSurf->GetDDSurface() != nullptr))
+        return m_commonSurf->GetDDSurface()->QueryInterface(riid, ppvObject);
+
+      return E_NOINTERFACE;
+    }
     if (unlikely(riid == __uuidof(IUnknown)
               || riid == __uuidof(IDirectDrawSurface))) {
       if (m_commonSurf->GetDDSurface() != nullptr)
@@ -267,12 +281,24 @@ namespace dxvk {
 
     attachedSurf->SetParentSurface(this);
 
+    hr = attachedSurf->GetCommonSurface()->RefreshSurfaceDescripton(false);
+    if (unlikely(FAILED(hr))) {
+      Logger::err("DDrawSurface2::AddAttachedSurface: Failed to retrieve updated attachment surface desc");
+      return hr;
+    }
+
     if (likely(attachedSurf->GetCommonSurface()->IsDepthStencil())) {
       m_depthStencil = attachedSurf;
     // If a flippable surface is attached, mark it as the next flippable surface
     } else if (unlikely(attachedSurf->GetCommonSurface()->IsBackBufferOrFlippable())) {
       DDrawSurface* attachedSurfParent = attachedSurf->GetCommonSurface()->GetDDSurface();
       m_parent->SetNextFlippable(attachedSurfParent);
+    }
+
+    hr = m_commonSurf->RefreshSurfaceDescripton(false);
+    if (unlikely(FAILED(hr))) {
+      Logger::err("DDrawSurface2::AddAttachedSurface: Failed to retrieve updated target surface desc");
+      return hr;
     }
 
     return DD_OK;
@@ -339,7 +365,7 @@ namespace dxvk {
 
     m_commonSurf->DirtyDDrawSurface();
 
-    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
+    if (m_shadowSurf != nullptr && d3d9Device != nullptr) {
       const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                 !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
                                  m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
@@ -415,7 +441,7 @@ namespace dxvk {
 
     m_commonSurf->DirtyDDrawSurface();
 
-    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
+    if (m_shadowSurf != nullptr && d3d9Device != nullptr) {
       const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                 !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
                                  m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
@@ -441,9 +467,9 @@ namespace dxvk {
     }
 
     if (lpDDSAttachedSurface == nullptr) {
-      HRESULT hrProxy = m_proxy->DeleteAttachedSurface(dwFlags, lpDDSAttachedSurface);
-      if (unlikely(FAILED(hrProxy)))
-        return hrProxy;
+      HRESULT hr = m_proxy->DeleteAttachedSurface(dwFlags, lpDDSAttachedSurface);
+      if (unlikely(FAILED(hr)))
+        return hr;
 
       // If lpDDSAttachedSurface is NULL, then all surfaces are detached
       m_depthStencil = nullptr;
@@ -459,12 +485,23 @@ namespace dxvk {
 
     attachedSurf->SetParentSurface(nullptr);
 
+    hr = attachedSurf->GetCommonSurface()->RefreshSurfaceDescripton(false);
+    if (unlikely(FAILED(hr))) {
+      Logger::err("DDrawSurface2::DeleteAttachedSurface: Failed to retrieve updated attachment surface desc");
+      return hr;
+    }
+
     if (likely(m_depthStencil == attachedSurf)) {
       m_depthStencil = nullptr;
     // Clear the next flippable surface or flippable surface detachment
-    } else if (unlikely(attachedSurf->GetCommonSurface()->IsBackBufferOrFlippable() &&
-                        attachedSurf->GetCommonSurface()->GetDDSurface() == m_parent->GetNextFlippable())) {
+    } else if (unlikely(m_parent->GetNextFlippable() == attachedSurf->GetCommonSurface()->GetDDSurface())) {
       m_parent->SetNextFlippable(nullptr);
+    }
+
+    hr = m_commonSurf->RefreshSurfaceDescripton(false);
+    if (unlikely(FAILED(hr))) {
+      Logger::err("DDrawSurface2::DeleteAttachedSurface: Failed to retrieve updated target surface desc");
+      return hr;
     }
 
     return DD_OK;
@@ -707,14 +744,17 @@ namespace dxvk {
       return hr;
 
     // For single surface locks, track the READONLY flag in order to skip dirtying
-    // on Unlock(). Reset the tracking in case of multiple simultaneous locks.
-    if (likely(!m_lockCount)) {
+    // on Unlock(). Reset flag tracking in case of multiple simultaneous locks,
+    // which are technically possible but extremely rare in practice.
+    //
+    // Note: Using lpDestRect as a key for tracking and/or matching Lock() to Unlock()
+    // calls, as the documentation suggests, isn't feasible, as there are applications
+    // which use nullptr during Lock() calls and then a non-null pointer on Unlock().
+    if (likely(!m_readOnlyLock)) {
       m_readOnlyLock = (dwFlags & DDLOCK_READONLY) && !(dwFlags & DDLOCK_WRITEONLY);
     } else {
       m_readOnlyLock = false;
     }
-
-    m_lockCount++;
 
     return DD_OK;
   }
@@ -737,15 +777,17 @@ namespace dxvk {
 
     m_commonSurf->DirtyDDrawSurface();
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
-    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
-      const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
-                                !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
-                                 m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
-                                 false : true;
-      if (shouldPresent) {
-        InitializeOrUploadD3D9();
-        d3d9Device->Present(NULL, NULL, NULL, NULL);
+    if (m_shadowSurf != nullptr) {
+      d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
+      if (likely(d3d9Device != nullptr)) {
+        const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
+                                  !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
+                                   m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
+                                   false : true;
+        if (shouldPresent) {
+          InitializeOrUploadD3D9();
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
+        }
       }
     }
 
@@ -842,6 +884,9 @@ namespace dxvk {
       m_commonSurf->SetPalette(ddrawPalette);
     }
 
+    // Note: A palette update on a primary surface would cause immediate
+    // presentation, however we don't support P8 primary surfaces
+
     return DD_OK;
   }
 
@@ -852,23 +897,22 @@ namespace dxvk {
 
     if (!m_readOnlyLock) {
       m_commonSurf->DirtyDDrawSurface();
+
+      if (m_shadowSurf != nullptr) {
+        d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
+        if (likely(d3d9Device != nullptr)) {
+          const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
+                                    !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
+                                     m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
+                                     false : true;
+          if (shouldPresent) {
+            InitializeOrUploadD3D9();
+            d3d9Device->Present(NULL, NULL, NULL, NULL);
+          }
+        }
+      }
     } else {
       m_readOnlyLock = false;
-    }
-
-    if (likely(m_lockCount))
-      m_lockCount--;
-
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
-    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
-      const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
-                                !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
-                                 m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
-                                 false : true;
-      if (shouldPresent) {
-        InitializeOrUploadD3D9();
-        d3d9Device->Present(NULL, NULL, NULL, NULL);
-      }
     }
 
     return DD_OK;
@@ -980,7 +1024,7 @@ namespace dxvk {
 
     //Logger::debug(str::format("DDraw2Surface::UploadSurfaceData: Uploading nr. [[2-", std::hex, this, "]]"));
 
-    D3D9SurfaceType d3d9SurfaceType = m_commonSurf->GetD3D9SurfaceType();
+    const D3D9SurfaceType d3d9SurfaceType = m_commonSurf->GetD3D9SurfaceType();
 
     switch (d3d9SurfaceType) {
       case D3D9SurfaceType::Texture:

--- a/src/ddraw/ddraw2/ddraw2_surface.h
+++ b/src/ddraw/ddraw2/ddraw2_surface.h
@@ -171,8 +171,7 @@ namespace dxvk {
 
     inline HRESULT UploadSurfaceData();
 
-    bool                     m_readOnlyLock = false;
-    std::atomic<uint8_t>     m_lockCount    = 0u;
+    std::atomic<bool>        m_readOnlyLock = false;
 
     Com<DDrawCommonSurface>  m_commonSurf;
 

--- a/src/ddraw/ddraw2/ddraw3_surface.cpp
+++ b/src/ddraw/ddraw2/ddraw3_surface.cpp
@@ -158,6 +158,20 @@ namespace dxvk {
     if (unlikely(riid == __uuidof(IDirectDrawColorControl))) {
       return E_NOINTERFACE;
     }
+    // The standard way of creating a new D3D3 device. Forward the call
+    // onto the base IDirectDrawSurface object, which we keep a reference to.
+    if (unlikely(riid == IID_IDirect3DHALDevice  || riid == IID_IDirect3DRGBDevice  ||
+                 riid == IID_IDirect3DRampDevice || riid == IID_WineD3DDevice)) {
+      // Surfaces which have been queried from an IDirectDrawSurface7
+      // object are unable to create a D3D3 device on this legacy path
+      if (unlikely(m_commonSurf->GetDD7Surface() == m_commonSurf->GetOrigin()))
+        return E_NOINTERFACE;
+
+      if (likely(m_commonSurf->GetDDSurface() != nullptr))
+        return m_commonSurf->GetDDSurface()->QueryInterface(riid, ppvObject);
+
+      return E_NOINTERFACE;
+    }
     if (unlikely(riid == __uuidof(IUnknown)
               || riid == __uuidof(IDirectDrawSurface))) {
       if (m_commonSurf->GetDDSurface() != nullptr)
@@ -267,12 +281,24 @@ namespace dxvk {
 
     attachedSurf->SetParentSurface(this);
 
+    hr = attachedSurf->GetCommonSurface()->RefreshSurfaceDescripton(false);
+    if (unlikely(FAILED(hr))) {
+      Logger::err("DDrawSurface3::AddAttachedSurface: Failed to retrieve updated attachment surface desc");
+      return hr;
+    }
+
     if (likely(attachedSurf->GetCommonSurface()->IsDepthStencil())) {
       m_depthStencil = attachedSurf;
     // If a flippable surface is attached, mark it as the next flippable surface
     } else if (unlikely(attachedSurf->GetCommonSurface()->IsBackBufferOrFlippable())) {
       DDrawSurface* attachedSurfParent = attachedSurf->GetCommonSurface()->GetDDSurface();
       m_parent->SetNextFlippable(attachedSurfParent);
+    }
+
+    hr = m_commonSurf->RefreshSurfaceDescripton(false);
+    if (unlikely(FAILED(hr))) {
+      Logger::err("DDrawSurface3::AddAttachedSurface: Failed to retrieve updated target surface desc");
+      return hr;
     }
 
     return DD_OK;
@@ -340,7 +366,7 @@ namespace dxvk {
 
     m_commonSurf->DirtyDDrawSurface();
 
-    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
+    if (m_shadowSurf != nullptr && d3d9Device != nullptr) {
       const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                 !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
                                  m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
@@ -417,7 +443,7 @@ namespace dxvk {
 
     m_commonSurf->DirtyDDrawSurface();
 
-    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
+    if (m_shadowSurf != nullptr && d3d9Device != nullptr) {
       const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                 !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
                                  m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
@@ -443,9 +469,9 @@ namespace dxvk {
     }
 
     if (lpDDSAttachedSurface == nullptr) {
-      HRESULT hrProxy = m_proxy->DeleteAttachedSurface(dwFlags, lpDDSAttachedSurface);
-      if (unlikely(FAILED(hrProxy)))
-        return hrProxy;
+      HRESULT hr = m_proxy->DeleteAttachedSurface(dwFlags, lpDDSAttachedSurface);
+      if (unlikely(FAILED(hr)))
+        return hr;
 
       // If lpDDSAttachedSurface is NULL, then all surfaces are detached
       m_depthStencil = nullptr;
@@ -461,12 +487,23 @@ namespace dxvk {
 
     attachedSurf->SetParentSurface(nullptr);
 
+    hr = attachedSurf->GetCommonSurface()->RefreshSurfaceDescripton(false);
+    if (unlikely(FAILED(hr))) {
+      Logger::err("DDrawSurface3::DeleteAttachedSurface: Failed to retrieve updated attachment surface desc");
+      return hr;
+    }
+
     if (likely(m_depthStencil == attachedSurf)) {
       m_depthStencil = nullptr;
     // Clear the next flippable surface or flippable surface detachment
-    } else if (unlikely(attachedSurf->GetCommonSurface()->IsBackBufferOrFlippable() &&
-                        attachedSurf->GetCommonSurface()->GetDDSurface() == m_parent->GetNextFlippable())) {
+    } else if (unlikely(m_parent->GetNextFlippable() == attachedSurf->GetCommonSurface()->GetDDSurface())) {
       m_parent->SetNextFlippable(nullptr);
+    }
+
+    hr = m_commonSurf->RefreshSurfaceDescripton(false);
+    if (unlikely(FAILED(hr))) {
+      Logger::err("DDrawSurface3::DeleteAttachedSurface: Failed to retrieve updated target surface desc");
+      return hr;
     }
 
     return DD_OK;
@@ -709,14 +746,17 @@ namespace dxvk {
       return hr;
 
     // For single surface locks, track the READONLY flag in order to skip dirtying
-    // on Unlock(). Reset the tracking in case of multiple simultaneous locks.
-    if (likely(!m_lockCount)) {
+    // on Unlock(). Reset flag tracking in case of multiple simultaneous locks,
+    // which are technically possible but extremely rare in practice.
+    //
+    // Note: Using lpDestRect as a key for tracking and/or matching Lock() to Unlock()
+    // calls, as the documentation suggests, isn't feasible, as there are applications
+    // which use nullptr during Lock() calls and then a non-null pointer on Unlock().
+    if (likely(!m_readOnlyLock)) {
       m_readOnlyLock = (dwFlags & DDLOCK_READONLY) && !(dwFlags & DDLOCK_WRITEONLY);
     } else {
       m_readOnlyLock = false;
     }
-
-    m_lockCount++;
 
     return DD_OK;
   }
@@ -739,15 +779,17 @@ namespace dxvk {
 
     m_commonSurf->DirtyDDrawSurface();
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
-    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
-      const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
-                                !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
-                                 m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
-                                 false : true;
-      if (shouldPresent) {
-        InitializeOrUploadD3D9();
-        d3d9Device->Present(NULL, NULL, NULL, NULL);
+    if (m_shadowSurf != nullptr) {
+      d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
+      if (likely(d3d9Device != nullptr)) {
+        const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
+                                  !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
+                                   m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
+                                   false : true;
+        if (shouldPresent) {
+          InitializeOrUploadD3D9();
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
+        }
       }
     }
 
@@ -844,6 +886,9 @@ namespace dxvk {
       m_commonSurf->SetPalette(ddrawPalette);
     }
 
+    // Note: A palette update on a primary surface would cause immediate
+    // presentation, however we don't support P8 primary surfaces
+
     return DD_OK;
   }
 
@@ -854,23 +899,22 @@ namespace dxvk {
 
     if (!m_readOnlyLock) {
       m_commonSurf->DirtyDDrawSurface();
+
+      if (m_shadowSurf != nullptr) {
+        d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
+        if (likely(d3d9Device != nullptr)) {
+          const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
+                                    !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
+                                     m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
+                                     false : true;
+          if (shouldPresent) {
+            InitializeOrUploadD3D9();
+            d3d9Device->Present(NULL, NULL, NULL, NULL);
+          }
+        }
+      }
     } else {
       m_readOnlyLock = false;
-    }
-
-    if (likely(m_lockCount))
-      m_lockCount--;
-
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
-    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
-      const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
-                                !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
-                                 m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
-                                 false : true;
-      if (shouldPresent) {
-        InitializeOrUploadD3D9();
-        d3d9Device->Present(NULL, NULL, NULL, NULL);
-      }
     }
 
     return DD_OK;
@@ -1001,7 +1045,7 @@ namespace dxvk {
 
     //Logger::debug(str::format("DDraw3Surface::UploadSurfaceData: Uploading nr. [[3-", std::hex, this, "]]"));
 
-    D3D9SurfaceType d3d9SurfaceType = m_commonSurf->GetD3D9SurfaceType();
+    const D3D9SurfaceType d3d9SurfaceType = m_commonSurf->GetD3D9SurfaceType();
 
     switch (d3d9SurfaceType) {
       case D3D9SurfaceType::Texture:

--- a/src/ddraw/ddraw2/ddraw3_surface.h
+++ b/src/ddraw/ddraw2/ddraw3_surface.h
@@ -173,8 +173,7 @@ namespace dxvk {
 
     inline HRESULT UploadSurfaceData();
 
-    bool                     m_readOnlyLock = false;
-    std::atomic<uint8_t>     m_lockCount    = 0u;
+    std::atomic<bool>        m_readOnlyLock = false;
 
     Com<DDrawCommonSurface>  m_commonSurf;
 

--- a/src/ddraw/ddraw4/ddraw4_interface.cpp
+++ b/src/ddraw/ddraw4/ddraw4_interface.cpp
@@ -228,7 +228,7 @@ namespace dxvk {
       // may crash in case they find that's not the case
       if (unlikely((lpDDSurfaceDesc->ddpfPixelFormat.dwFlags == (DDPF_BUMPDUDV | DDPF_BUMPLUMINANCE))
                 && (lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_VIDEOMEMORY))) {
-        Logger::warn("DDraw4Interface::CreateSurface: Video memory DDPF_BUMPLUMINANCE surface");
+        Logger::debug("DDraw4Interface::CreateSurface: Video memory DDPF_BUMPLUMINANCE surface");
         lpDDSurfaceDesc->ddsCaps.dwCaps &= ~DDSCAPS_VIDEOMEMORY &
                                            ~DDSCAPS_LOCALVIDMEM &
                                            ~DDSCAPS_NONLOCALVIDMEM;
@@ -274,8 +274,8 @@ namespace dxvk {
 
         // Shadow surface creation for the primary surface
         // (it needs to be based on the same incoming desc)
-        if (unlikely(m_commonIntf->GetOptions()->forceLegacyPresent &&
-                    !surface4->GetCommonSurface()->SkipD3D9Operations())) {
+        if (m_commonIntf->GetOptions()->forceLegacyPresent &&
+           !surface4->GetCommonSurface()->SkipD3D9Operations()) {
           DDSURFACEDESC2 shadowDesc = *lpDDSurfaceDesc;
           const DDSURFACEDESC2* primaryDesc = surface4->GetCommonSurface()->GetDesc2();
 

--- a/src/ddraw/ddraw4/ddraw4_surface.cpp
+++ b/src/ddraw/ddraw4/ddraw4_surface.cpp
@@ -126,7 +126,7 @@ namespace dxvk {
         if (unlikely(FAILED(hr)))
           return hr;
 
-        m_texture3 = new D3D3Texture(m_texture6 != nullptr ? m_texture6->GetCommonTexture() : nullptr,
+        m_texture3 = new D3D3Texture(m_texture5 != nullptr ? m_texture5->GetCommonTexture() : nullptr,
                                      m_commonSurf.ptr(), std::move(ppvProxyObject), this);
       }
 
@@ -135,18 +135,18 @@ namespace dxvk {
       return S_OK;
     }
     if (unlikely(riid == __uuidof(IDirect3DTexture2))) {
-      if (unlikely(m_texture6 == nullptr)) {
+      if (unlikely(m_texture5 == nullptr)) {
         Com<IDirect3DTexture2> ppvProxyObject;
         HRESULT hr = m_proxy->QueryInterface(riid, reinterpret_cast<void**>(&ppvProxyObject));
         if (unlikely(FAILED(hr)))
           return hr;
 
         // D3D5Texture (aka IDirect3DTexture2) is shared between D3D5 and D3D6
-        m_texture6 = new D3D5Texture(m_texture3 != nullptr ? m_texture3->GetCommonTexture() : nullptr,
+        m_texture5 = new D3D5Texture(m_texture3 != nullptr ? m_texture3->GetCommonTexture() : nullptr,
                                      m_commonSurf.ptr(), std::move(ppvProxyObject), this, true);
       }
 
-      *ppvObject = m_texture6.ref();
+      *ppvObject = m_texture5.ref();
 
       return S_OK;
     }
@@ -277,11 +277,23 @@ namespace dxvk {
 
     attachedSurf->SetParentSurface(this);
 
+    hr = attachedSurf->GetCommonSurface()->RefreshSurfaceDescripton(false);
+    if (unlikely(FAILED(hr))) {
+      Logger::err("DDrawSurface4::AddAttachedSurface: Failed to retrieve updated attachment surface desc");
+      return hr;
+    }
+
     if (likely(attachedSurf->GetCommonSurface()->IsDepthStencil())) {
       m_depthStencil = attachedSurf;
     // If a flippable surface is attached, mark it as the next flippable surface
     } else if (unlikely(attachedSurf->GetCommonSurface()->IsBackBufferOrFlippable())) {
       m_nextFlippable = attachedSurf;
+    }
+
+    hr = m_commonSurf->RefreshSurfaceDescripton(false);
+    if (unlikely(FAILED(hr))) {
+      Logger::err("DDrawSurface4::AddAttachedSurface: Failed to retrieve updated target surface desc");
+      return hr;
     }
 
     return DD_OK;
@@ -343,7 +355,7 @@ namespace dxvk {
 
     m_commonSurf->DirtyDDrawSurface();
 
-    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
+    if (m_shadowSurf != nullptr && d3d9Device != nullptr) {
       const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                 !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
                                  m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
@@ -415,7 +427,7 @@ namespace dxvk {
 
     m_commonSurf->DirtyDDrawSurface();
 
-    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
+    if (m_shadowSurf != nullptr && d3d9Device != nullptr) {
       const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                 !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
                                  m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
@@ -438,9 +450,9 @@ namespace dxvk {
     }
 
     if (lpDDSAttachedSurface == nullptr) {
-      HRESULT hrProxy = m_proxy->DeleteAttachedSurface(dwFlags, lpDDSAttachedSurface);
-      if (unlikely(FAILED(hrProxy)))
-        return hrProxy;
+      HRESULT hr = m_proxy->DeleteAttachedSurface(dwFlags, lpDDSAttachedSurface);
+      if (unlikely(FAILED(hr)))
+        return hr;
 
       // If lpDDSAttachedSurface is NULL, then all surfaces are detached
       m_depthStencil = nullptr;
@@ -456,12 +468,23 @@ namespace dxvk {
 
     attachedSurf->SetParentSurface(nullptr);
 
+    hr = attachedSurf->GetCommonSurface()->RefreshSurfaceDescripton(false);
+    if (unlikely(FAILED(hr))) {
+      Logger::err("DDrawSurface4::DeleteAttachedSurface: Failed to retrieve updated attachment surface desc");
+      return hr;
+    }
+
     if (likely(m_depthStencil == attachedSurf)) {
       m_depthStencil = nullptr;
     // Clear the next flippable surface or flippable surface detachment
-    } else if (unlikely(attachedSurf->GetCommonSurface()->IsBackBufferOrFlippable() &&
-                        attachedSurf == m_nextFlippable)) {
+    } else if (unlikely(m_nextFlippable == attachedSurf)) {
       m_nextFlippable = nullptr;
+    }
+
+    hr = m_commonSurf->RefreshSurfaceDescripton(false);
+    if (unlikely(FAILED(hr))) {
+      Logger::err("DDrawSurface4::DeleteAttachedSurface: Failed to retrieve updated target surface desc");
+      return hr;
     }
 
     return DD_OK;
@@ -776,14 +799,17 @@ namespace dxvk {
       return hr;
 
     // For single surface locks, track the READONLY flag in order to skip dirtying
-    // on Unlock(). Reset the tracking in case of multiple simultaneous locks.
-    if (likely(!m_lockCount)) {
+    // on Unlock(). Reset flag tracking in case of multiple simultaneous locks,
+    // which are technically possible but extremely rare in practice.
+    //
+    // Note: Using lpDestRect as a key for tracking and/or matching Lock() to Unlock()
+    // calls, as the documentation suggests, isn't feasible, as there are applications
+    // which use nullptr during Lock() calls and then a non-null pointer on Unlock().
+    if (likely(!m_readOnlyLock)) {
       m_readOnlyLock = (dwFlags & DDLOCK_READONLY) && !(dwFlags & DDLOCK_WRITEONLY);
     } else {
       m_readOnlyLock = false;
     }
-
-    m_lockCount++;
 
     return DD_OK;
   }
@@ -806,15 +832,17 @@ namespace dxvk {
 
     m_commonSurf->DirtyDDrawSurface();
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
-    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
-      const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
-                                !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
-                                 m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
-                                 false : true;
-      if (shouldPresent) {
-        InitializeOrUploadD3D9();
-        d3d9Device->Present(NULL, NULL, NULL, NULL);
+    if (m_shadowSurf != nullptr) {
+      d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
+      if (likely(d3d9Device != nullptr)) {
+        const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
+                                  !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
+                                   m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
+                                   false : true;
+        if (shouldPresent) {
+          InitializeOrUploadD3D9();
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
+        }
       }
     }
 
@@ -911,6 +939,9 @@ namespace dxvk {
       m_commonSurf->SetPalette(ddrawPalette);
     }
 
+    // Note: A palette update on a primary surface would cause immediate
+    // presentation, however we don't support P8 primary surfaces
+
     return DD_OK;
   }
 
@@ -921,23 +952,22 @@ namespace dxvk {
 
     if (!m_readOnlyLock) {
       m_commonSurf->DirtyDDrawSurface();
+
+      if (m_shadowSurf != nullptr) {
+        d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
+        if (likely(d3d9Device != nullptr)) {
+          const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
+                                    !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
+                                     m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
+                                     false : true;
+          if (shouldPresent) {
+            InitializeOrUploadD3D9();
+            d3d9Device->Present(NULL, NULL, NULL, NULL);
+          }
+        }
+      }
     } else {
       m_readOnlyLock = false;
-    }
-
-    if (likely(m_lockCount))
-      m_lockCount--;
-
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
-    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
-      const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
-                                !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
-                                 m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
-                                 false : true;
-      if (shouldPresent) {
-        InitializeOrUploadD3D9();
-        d3d9Device->Present(NULL, NULL, NULL, NULL);
-      }
     }
 
     return DD_OK;
@@ -1131,7 +1161,7 @@ namespace dxvk {
 
     //Logger::debug(str::format("DDraw4Surface::UploadSurfaceData: Uploading nr. [[4-", std::hex, this, "]]"));
 
-    D3D9SurfaceType d3d9SurfaceType = m_commonSurf->GetD3D9SurfaceType();
+    const D3D9SurfaceType d3d9SurfaceType = m_commonSurf->GetD3D9SurfaceType();
 
     switch (d3d9SurfaceType) {
       case D3D9SurfaceType::Texture:

--- a/src/ddraw/ddraw4/ddraw4_surface.h
+++ b/src/ddraw/ddraw4/ddraw4_surface.h
@@ -193,9 +193,7 @@ namespace dxvk {
     inline HRESULT UploadSurfaceData();
 
     bool                    m_isChildObject = false;
-
-    bool                    m_readOnlyLock  = false;
-    std::atomic<uint8_t>    m_lockCount     = 0u;
+    std::atomic<bool>       m_readOnlyLock  = false;
 
     Com<DDrawCommonSurface> m_commonSurf;
     DDrawCommonInterface*   m_commonIntf    = nullptr;
@@ -204,7 +202,7 @@ namespace dxvk {
 
     Com<D3D3Texture, false> m_texture3;
     // D3D5Texture (aka IDirect3DTexture2) is shared between D3D5 and D3D6
-    Com<D3D5Texture, false> m_texture6;
+    Com<D3D5Texture, false> m_texture5;
 
     DDraw4Surface*          m_nextFlippable = nullptr;
 

--- a/src/ddraw/ddraw7/ddraw7_interface.cpp
+++ b/src/ddraw/ddraw7/ddraw7_interface.cpp
@@ -219,7 +219,7 @@ namespace dxvk {
       // may crash in case they find that's not the case
       if (unlikely((lpDDSurfaceDesc->ddpfPixelFormat.dwFlags == (DDPF_BUMPDUDV | DDPF_BUMPLUMINANCE))
                 && (lpDDSurfaceDesc->ddsCaps.dwCaps & DDSCAPS_VIDEOMEMORY))) {
-        Logger::warn("DDraw7Interface::CreateSurface: Video memory DDPF_BUMPLUMINANCE surface");
+        Logger::debug("DDraw7Interface::CreateSurface: Video memory DDPF_BUMPLUMINANCE surface");
         lpDDSurfaceDesc->ddsCaps.dwCaps &= ~DDSCAPS_VIDEOMEMORY &
                                            ~DDSCAPS_LOCALVIDMEM &
                                            ~DDSCAPS_NONLOCALVIDMEM;
@@ -265,8 +265,8 @@ namespace dxvk {
 
         // Shadow surface creation for the primary surface
         // (it needs to be based on the same incoming desc)
-        if (unlikely(m_commonIntf->GetOptions()->forceLegacyPresent &&
-                    !surface7->GetCommonSurface()->SkipD3D9Operations())) {
+        if (m_commonIntf->GetOptions()->forceLegacyPresent &&
+           !surface7->GetCommonSurface()->SkipD3D9Operations()) {
           DDSURFACEDESC2 shadowDesc = *lpDDSurfaceDesc;
           const DDSURFACEDESC2* primaryDesc = surface7->GetCommonSurface()->GetDesc2();
 

--- a/src/ddraw/ddraw7/ddraw7_surface.cpp
+++ b/src/ddraw/ddraw7/ddraw7_surface.cpp
@@ -309,7 +309,7 @@ namespace dxvk {
 
     m_commonSurf->DirtyDDrawSurface();
 
-    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
+    if (m_shadowSurf != nullptr && d3d9Device != nullptr) {
       const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                 !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
                                  m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
@@ -381,7 +381,7 @@ namespace dxvk {
 
     m_commonSurf->DirtyDDrawSurface();
 
-    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
+    if (m_shadowSurf != nullptr && d3d9Device != nullptr) {
       const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
                                 !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
                                  m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
@@ -404,9 +404,9 @@ namespace dxvk {
     }
 
     if (lpDDSAttachedSurface == nullptr) {
-      HRESULT hrProxy = m_proxy->DeleteAttachedSurface(dwFlags, lpDDSAttachedSurface);
-      if (unlikely(FAILED(hrProxy)))
-        return hrProxy;
+      HRESULT hr = m_proxy->DeleteAttachedSurface(dwFlags, lpDDSAttachedSurface);
+      if (unlikely(FAILED(hr)))
+        return hr;
 
       // If lpDDSAttachedSurface is NULL, then all surfaces are detached
       m_depthStencil = nullptr;
@@ -737,14 +737,17 @@ namespace dxvk {
       return hr;
 
     // For single surface locks, track the READONLY flag in order to skip dirtying
-    // on Unlock(). Reset the tracking in case of multiple simultaneous locks.
-    if (likely(!m_lockCount)) {
+    // on Unlock(). Reset flag tracking in case of multiple simultaneous locks,
+    // which are technically possible but extremely rare in practice.
+    //
+    // Note: Using lpDestRect as a key for tracking and/or matching Lock() to Unlock()
+    // calls, as the documentation suggests, isn't feasible, as there are applications
+    // which use nullptr during Lock() calls and then a non-null pointer on Unlock().
+    if (likely(!m_readOnlyLock)) {
       m_readOnlyLock = (dwFlags & DDLOCK_READONLY) && !(dwFlags & DDLOCK_WRITEONLY);
     } else {
       m_readOnlyLock = false;
     }
-
-    m_lockCount++;
 
     return DD_OK;
   }
@@ -767,15 +770,17 @@ namespace dxvk {
 
     m_commonSurf->DirtyDDrawSurface();
 
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
-    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
-      const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
-                                !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
-                                 m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
-                                 false : true;
-      if (shouldPresent) {
-        InitializeOrUploadD3D9();
-        d3d9Device->Present(NULL, NULL, NULL, NULL);
+    if (m_shadowSurf != nullptr) {
+      d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
+      if (likely(d3d9Device != nullptr)) {
+        const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
+                                  !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
+                                   m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
+                                   false : true;
+        if (shouldPresent) {
+          InitializeOrUploadD3D9();
+          d3d9Device->Present(NULL, NULL, NULL, NULL);
+        }
       }
     }
 
@@ -872,6 +877,9 @@ namespace dxvk {
       m_commonSurf->SetPalette(ddrawPalette);
     }
 
+    // Note: A palette update on a primary surface would cause immediate
+    // presentation, however we don't support P8 primary surfaces
+
     return DD_OK;
   }
 
@@ -882,23 +890,22 @@ namespace dxvk {
 
     if (!m_readOnlyLock) {
       m_commonSurf->DirtyDDrawSurface();
+
+      if (m_shadowSurf != nullptr) {
+        d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
+        if (likely(d3d9Device != nullptr)) {
+          const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
+                                    !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
+                                     m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
+                                     false : true;
+          if (shouldPresent) {
+            InitializeOrUploadD3D9();
+            d3d9Device->Present(NULL, NULL, NULL, NULL);
+          }
+        }
+      }
     } else {
       m_readOnlyLock = false;
-    }
-
-    if (likely(m_lockCount))
-      m_lockCount--;
-
-    d3d9::IDirect3DDevice9* d3d9Device = m_commonSurf->GetRefreshedD3D9Device();
-    if (unlikely(m_shadowSurf != nullptr && d3d9Device != nullptr)) {
-      const bool shouldPresent = m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Auto ?
-                                !m_commonSurf->GetCommonD3DDevice()->IsInScene() :
-                                 m_commonIntf->GetOptions()->legacyPresentGuard == D3DLegacyPresentGuard::Strict ?
-                                 false : true;
-      if (shouldPresent) {
-        InitializeOrUploadD3D9();
-        d3d9Device->Present(NULL, NULL, NULL, NULL);
-      }
     }
 
     return DD_OK;
@@ -1247,13 +1254,13 @@ namespace dxvk {
 
     //Logger::debug(str::format("DDraw7Surface::UploadSurfaceData: Uploading nr. [[7-", std::hex, this, "]]"));
 
-    D3D9SurfaceType d3d9SurfaceType = m_commonSurf->GetD3D9SurfaceType();
+    const D3D9SurfaceType d3d9SurfaceType = m_commonSurf->GetD3D9SurfaceType();
 
     switch (d3d9SurfaceType) {
       case D3D9SurfaceType::CubeTexture: {
         // In theory we won't know which faces have been generated,
         // so check them one by one, and upload as needed
-        const uint16_t mipCount    = m_commonSurf->GetMipCount();
+        const uint32_t mipCount    = m_commonSurf->GetMipCount();
         const bool     isDXTFormat = m_commonSurf->IsDXTFormat();
         if (likely(m_cubeMapSurfaces[0] != nullptr)) {
           BlitToD3D9CubeMap(m_commonSurf->GetD3D9CubeTexture(), m_cubeMapSurfaces[0], mipCount, isDXTFormat);

--- a/src/ddraw/ddraw7/ddraw7_surface.h
+++ b/src/ddraw/ddraw7/ddraw7_surface.h
@@ -208,19 +208,17 @@ namespace dxvk {
 
     inline HRESULT UploadSurfaceData();
 
-    bool                                m_isChildObject   = false;
-
-    bool                                m_readOnlyLock    = false;
-    std::atomic<uint8_t>                m_lockCount       = 0u;
+    bool                                m_isChildObject = false;
+    std::atomic<bool>                   m_readOnlyLock  = false;
 
     Com<DDrawCommonSurface>             m_commonSurf;
-    DDrawCommonInterface*               m_commonIntf      = nullptr;
+    DDrawCommonInterface*               m_commonIntf    = nullptr;
 
-    DDraw7Surface*                      m_parentSurf      = nullptr;
+    DDraw7Surface*                      m_parentSurf    = nullptr;
 
     std::array<IDirectDrawSurface7*, 6> m_cubeMapSurfaces;
 
-    DDraw7Surface*                      m_nextFlippable   = nullptr;
+    DDraw7Surface*                      m_nextFlippable = nullptr;
 
     // Offscreen plain surface we use to mask unwanted DDraw interactions, such
     // as forced swapchain presents caused by blits/locks on primary surfaces

--- a/src/ddraw/ddraw_caps.h
+++ b/src/ddraw/ddraw_caps.h
@@ -15,13 +15,13 @@ namespace dxvk::ddrawCaps {
 
   static constexpr uint32_t MaxEnabledLights        = 8;
 
-  static constexpr uint8_t  IndexBufferCount        = 10;
+  static constexpr uint32_t IndexBufferCount        = 10;
   // Actual index buffer sizes are 2x, so 0.25 kb, 0.5 kb, 1kb, 2 kb, 4kb, 8 kb, 16kb, 32 kb, 64 kb and 128 kb
   // Note: The DXVK backend gives us 256 byte chunks anyway as a minimum, so there's no point going below that
-  static constexpr UINT     IndexCount[IndexBufferCount] = {128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, D3DMAXNUMVERTICES};
-  static constexpr UINT     MaxIndexCount           = IndexCount[IndexBufferCount - 1];
+  static constexpr uint32_t IndexCount[IndexBufferCount] = {128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, D3DMAXNUMVERTICES};
+  static constexpr uint32_t MaxIndexCount           = IndexCount[IndexBufferCount - 1];
 
-  static constexpr uint8_t  NumberOfFOURCCCodes     = 6;
+  static constexpr uint32_t NumberOfFOURCCCodes     = 6;
   static constexpr DWORD    SupportedFourCCs[]      =
   {
     MAKEFOURCC('D', 'X', 'T', '1'),

--- a/src/ddraw/ddraw_common_surface.cpp
+++ b/src/ddraw/ddraw_common_surface.cpp
@@ -1,7 +1,5 @@
 #include "ddraw_common_surface.h"
 
-#include "d3d_common_device.h"
-
 #include "ddraw7/ddraw7_surface.h"
 #include "ddraw4/ddraw4_surface.h"
 #include "ddraw2/ddraw3_surface.h"
@@ -169,7 +167,7 @@ namespace dxvk {
       // We can't know beforehand if a texture is or isn't going to be
       // used in SetTexture() calls, and textures placed in D3DPOOL_SYSTEMMEM
       // will not work in that context, so revert to D3DPOOL_MANAGED
-      pool = IsTextureOrCubeMap() ? d3d9::D3DPOOL_MANAGED : d3d9::D3DPOOL_SYSTEMMEM;
+      pool = IsBindableAsTexture() || IsCubeMap() ? d3d9::D3DPOOL_MANAGED : d3d9::D3DPOOL_SYSTEMMEM;
     } else {
       pool = d3d9::D3DPOOL_DEFAULT;
     }
@@ -194,7 +192,7 @@ namespace dxvk {
     }
 
     // General usage flags and mip map count
-    if (IsTextureOrCubeMap()) {
+    if (IsBindableAsTexture() || IsCubeMap()) {
       // Needed to ensure D3DPOOL_DEFAULT textures/cubemaps are lockable
       if (pool == d3d9::D3DPOOL_DEFAULT) {
         //Logger::debug("DDrawCommonSurface::InitializeD3D9: Usage: D3DUSAGE_DYNAMIC");
@@ -233,7 +231,7 @@ namespace dxvk {
       }
       case D3D9SurfaceType::CubeTexture: {
         // Properly handle cube textures with auto-generated mip maps
-        const UINT mipCount = usage & D3DUSAGE_AUTOGENMIPMAP ? 0 : m_mipCount;
+        const uint32_t mipCount = usage & D3DUSAGE_AUTOGENMIPMAP ? 0 : m_mipCount;
 
         HRESULT hr = d3d9Device->CreateCubeTexture(dwWidth, mipCount, usage,
                                                    m_format9, pool, &m_cubeMap9, nullptr);
@@ -247,7 +245,7 @@ namespace dxvk {
       }
       case D3D9SurfaceType::Texture: {
         // Properly handle textures with auto-generated mip maps
-        const UINT mipCount = usage & D3DUSAGE_AUTOGENMIPMAP ? 0 : m_mipCount;
+        const uint32_t mipCount = usage & D3DUSAGE_AUTOGENMIPMAP ? 0 : m_mipCount;
 
         HRESULT hr = d3d9Device->CreateTexture(dwWidth, dwHeight, mipCount, usage,
                                                m_format9, pool, &m_texture9, nullptr);

--- a/src/ddraw/ddraw_common_surface.h
+++ b/src/ddraw/ddraw_common_surface.h
@@ -4,6 +4,7 @@
 #include "ddraw_format.h"
 
 #include "ddraw_common_interface.h"
+#include "d3d_common_device.h"
 
 #include "ddraw_clipper.h"
 #include "ddraw_palette.h"
@@ -154,14 +155,8 @@ namespace dxvk {
       return (m_desc2.dwFlags & DDSD_CKSRCBLT) || (m_desc.dwFlags & DDSD_CKSRCBLT);
     }
 
-    DDCOLORKEY GetColorKeyNormalized() const {
-      const DDPIXELFORMAT* pixelFormat = (m_desc2.dwFlags & DDSD_PIXELFORMAT) ? &m_desc2.ddpfPixelFormat :
-                                         (m_desc.dwFlags & DDSD_PIXELFORMAT)  ? &m_desc.ddpfPixelFormat : nullptr;
-      const DDCOLORKEY*    colorKey    = (m_desc2.dwFlags & DDSD_CKSRCBLT) ? &m_desc2.ddckCKSrcBlt :
-                                         (m_desc.dwFlags & DDSD_CKSRCBLT)  ? &m_desc.ddckCKSrcBlt : nullptr;
-
-      // Empire of the Ants relies on us using the "Low" color space DWORD
-      return ColorKeyToARGB(pixelFormat, colorKey != nullptr ? colorKey->dwColorSpaceLowValue : 0u);
+    const DDCOLORKEY* GetColorKeyNormalized() const {
+      return &m_ckNormalized;
     }
 
     bool IsFullSurfaceLock(const RECT* lockRect, const RECT* fullSurfaceRect) const {
@@ -186,7 +181,7 @@ namespace dxvk {
       return static_cast<float>(input) / static_cast<float>(max);
     }
 
-    uint16_t GetMipCount() const {
+    uint32_t GetMipCount() const {
       return m_mipCount;
     }
 
@@ -343,8 +338,16 @@ namespace dxvk {
 
     bool IsTexture() const {
       return m_desc2.ddsCaps.dwCaps & DDSCAPS_TEXTURE
+          || m_desc.ddsCaps.dwCaps  & DDSCAPS_TEXTURE;
+    }
+
+    bool IsBindableAsTexture() const {
+      // Surfaces which aren't explicitly marked as textures are only bindable on software devices
+      const bool isBindableSurface = !m_commonD3DDevice->IsHALOrTNLHALDevice() && m_hasTextureHandle;
+
+      return m_desc2.ddsCaps.dwCaps & DDSCAPS_TEXTURE
           || m_desc.ddsCaps.dwCaps  & DDSCAPS_TEXTURE
-          || m_hasTextureHandle;
+          || isBindableSurface;
     }
 
     bool IsTextureMip() const {
@@ -355,13 +358,6 @@ namespace dxvk {
 
     bool IsCubeMap() const {
       return m_desc2.ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP;
-    }
-
-    bool IsTextureOrCubeMap() const {
-      return m_desc2.ddsCaps.dwCaps  & DDSCAPS_TEXTURE
-          || m_desc2.ddsCaps.dwCaps2 & DDSCAPS2_CUBEMAP
-          || m_desc.ddsCaps.dwCaps   & DDSCAPS_TEXTURE
-          || m_hasTextureHandle;
     }
 
     bool IsOverlay() const {
@@ -530,7 +526,7 @@ namespace dxvk {
       } else if (IsCubeMap()) {
         m_d3d9SurfaceType = D3D9SurfaceType::CubeTexture;
       // Textures
-      } else if (IsTexture()) {
+      } else if (IsBindableAsTexture()) {
         m_d3d9SurfaceType = D3D9SurfaceType::Texture;
       // Depth Stencil
       } else if (IsDepthStencil()) {
@@ -570,30 +566,44 @@ namespace dxvk {
           Logger::warn("DDrawCommonSurface::RefreshStaticDescData: Surface format has changed post initialization");
         m_format9 = format9;
       }
+      // refresh normalized color key range (if present)
+      static constexpr DDCOLORKEY DefaultColorKey = { 0u, 0u };
+      // ignore normalized color key calculations on P8 surfaces
+      m_ckNormalized = HasValidColorKey() && m_format9 != d3d9::D3DFMT_P8 ? UpdateColorKeyNormalized() : DefaultColorKey;
     }
 
-    bool                             m_dirtyDDraw         = false;
-    bool                             m_dirtyD3D9          = false;
+    inline DDCOLORKEY UpdateColorKeyNormalized() const {
+      const DDPIXELFORMAT* pixelFormat = (m_desc2.dwFlags & DDSD_PIXELFORMAT) ? &m_desc2.ddpfPixelFormat :
+                                         (m_desc.dwFlags & DDSD_PIXELFORMAT)  ? &m_desc.ddpfPixelFormat : nullptr;
+      const DDCOLORKEY*    colorKey    = (m_desc2.dwFlags & DDSD_CKSRCBLT) ? &m_desc2.ddckCKSrcBlt :
+                                         (m_desc.dwFlags & DDSD_CKSRCBLT)  ? &m_desc.ddckCKSrcBlt : nullptr;
 
-    bool                             m_isDesc2Set         = false;
-    bool                             m_isDescSet          = false;
-    bool                             m_hasTextureHandle   = false;
+      // Empire of the Ants relies on us using the "Low" color space DWORD
+      return ColorKeyToARGB(pixelFormat, colorKey != nullptr ? colorKey->dwColorSpaceLowValue : 0u);
+    }
 
-    bool                             m_isAttached         = false;
-    bool                             m_isRenderTarget     = false;
+    bool                             m_dirtyDDraw       = false;
+    bool                             m_dirtyD3D9        = false;
+
+    bool                             m_isDesc2Set       = false;
+    bool                             m_isDescSet        = false;
+    bool                             m_hasTextureHandle = false;
+
+    bool                             m_isAttached       = false;
+    bool                             m_isRenderTarget   = false;
     bool                             m_isBackBufferOrFlippable = false;
 
     Com<DDrawCommonInterface>        m_commonIntf;
 
-    D3DCommonDevice*                 m_commonD3DDevice    = nullptr;
+    D3DCommonDevice*                 m_commonD3DDevice  = nullptr;
 
-    uint16_t                         m_mipCount           = 1;
-    uint32_t                         m_backBufferIndex    = 0;
+    uint32_t                         m_mipCount         = 1;
+    uint32_t                         m_backBufferIndex  = 0;
 
-    DDSURFACEDESC                    m_desc               = { };
-    DDSURFACEDESC2                   m_desc2              = { };
-    D3D9SurfaceType                  m_d3d9SurfaceType    = D3D9SurfaceType::None;
-    RECT                             m_rect               = { };
+    DDSURFACEDESC                    m_desc             = { };
+    DDSURFACEDESC2                   m_desc2            = { };
+    D3D9SurfaceType                  m_d3d9SurfaceType  = D3D9SurfaceType::None;
+    RECT                             m_rect             = { };
 
     Com<DDrawClipper>                m_clipper;
     Com<DDrawPalette>                m_palette;
@@ -602,17 +612,19 @@ namespace dxvk {
     Com<d3d9::IDirect3DTexture9>     m_texture9;
     Com<d3d9::IDirect3DCubeTexture9> m_cubeMap9;
 
-    d3d9::D3DFORMAT                  m_format9            = d3d9::D3DFMT_UNKNOWN;
+    d3d9::D3DFORMAT                  m_format9          = d3d9::D3DFMT_UNKNOWN;
 
-    DDraw7Surface*                   m_surf7              = nullptr;
-    DDraw4Surface*                   m_surf4              = nullptr;
-    DDraw3Surface*                   m_surf3              = nullptr;
-    DDraw2Surface*                   m_surf2              = nullptr;
-    DDrawSurface*                    m_surf               = nullptr;
+    DDCOLORKEY                       m_ckNormalized     = { };
+
+    DDraw7Surface*                   m_surf7            = nullptr;
+    DDraw4Surface*                   m_surf4            = nullptr;
+    DDraw3Surface*                   m_surf3            = nullptr;
+    DDraw2Surface*                   m_surf2            = nullptr;
+    DDrawSurface*                    m_surf             = nullptr;
 
     // Track the origin surface, as in the DDraw surface
     // that gets created through a CreateSurface call
-    IUnknown*                        m_origin             = nullptr;
+    IUnknown*                        m_origin           = nullptr;
 
   };
 

--- a/src/ddraw/ddraw_format.h
+++ b/src/ddraw/ddraw_format.h
@@ -690,10 +690,10 @@ namespace dxvk {
   // the mip chain, since the dwMipMapCount number may or may not be accurate. I am
   // guessing it was intended more as a hint, not necessarily a set number.
   template <typename SurfaceType, typename DescType>
-  inline uint16_t DetermineMipMapCount(SurfaceType* surface) {
+  inline uint32_t DetermineMipMapCount(SurfaceType* surface) {
     SurfaceType* mipMap = surface;
     DescType mipDesc;
-    uint16_t mipCount = 1;
+    uint32_t mipCount = 1u;
 
     while (mipMap != nullptr) {
       SurfaceType* parentSurface = mipMap;
@@ -774,7 +774,7 @@ namespace dxvk {
   inline void BlitToD3D9CubeMap(
         d3d9::IDirect3DCubeTexture9* cubeTex9,
         IDirectDrawSurface7* surface,
-        const uint16_t mipLevels,
+        const uint32_t mipLevels,
         const bool isDXTFormat) {
     DDSURFACEDESC2 desc;
     desc.dwSize = sizeof(DDSURFACEDESC2);
@@ -783,7 +783,7 @@ namespace dxvk {
     IDirectDrawSurface7* mipMap = surface;
     IDirectDrawSurface7* parentSurface;
 
-    for (uint16_t i = 0; i < mipLevels; i++) {
+    for (uint32_t i = 0; i < mipLevels; i++) {
       d3d9::D3DLOCKED_RECT rect9mip;
       // D3DLOCK_DISCARD will get ignored for MANAGED/SYSTEMMEM, but will work on DEFAULT
       HRESULT hr9 = cubeTex9->LockRect(face, i, &rect9mip, NULL, D3DLOCK_DISCARD);
@@ -836,12 +836,12 @@ namespace dxvk {
   inline void BlitToD3D9Texture(
         d3d9::IDirect3DTexture9* texture9,
         SurfaceType* surface,
-        const uint16_t mipLevels,
+        const uint32_t mipLevels,
         const bool isDXTFormat) {
     SurfaceType* mipMap = surface;
     SurfaceType* parentSurface;
 
-    for (uint16_t i = 0; i < mipLevels; i++) {
+    for (uint32_t i = 0; i < mipLevels; i++) {
       d3d9::D3DLOCKED_RECT rect9mip;
       // D3DLOCK_DISCARD will get ignored for MANAGED/SYSTEMMEM, but will work on DEFAULT
       HRESULT hr9 = texture9->LockRect(i, &rect9mip, NULL, D3DLOCK_DISCARD);
@@ -991,6 +991,12 @@ namespace dxvk {
   }
 
   inline DDCOLORKEY GetColorChannel(DWORD pixel, DWORD mask) {
+    DDCOLORKEY colorKey = { };
+
+    // Fast abort, otherwise we end up dividing by 0
+    if (unlikely(mask == 0))
+      return colorKey;
+
     uint32_t shift = 0;
     DWORD cmask = mask;
     while ((cmask & 1) == 0) {
@@ -1010,7 +1016,6 @@ namespace dxvk {
     const DWORD max = (1 << bits) - 1;
     const float cvalue = static_cast<float>(value) * 255.0f / static_cast<float>(max);
 
-    DDCOLORKEY colorKey = { };
     colorKey.dwColorSpaceLowValue  = static_cast<DWORD>(std::max(0.0f, floorf(cvalue - 0.5f)));
     colorKey.dwColorSpaceHighValue = static_cast<DWORD>(std::min(255.0f, floorf(cvalue + 0.5f)));
 
@@ -1026,8 +1031,9 @@ namespace dxvk {
     DDCOLORKEY b = GetColorChannel(colorKey, fmt->dwBBitMask);
     DDCOLORKEY g = GetColorChannel(colorKey, fmt->dwGBitMask);
     DDCOLORKEY r = GetColorChannel(colorKey, fmt->dwRBitMask);
+    static constexpr DDCOLORKEY DefaultAlphaColorKey = { 255u, 255u };
     DDCOLORKEY a = (fmt->dwFlags & DDPF_ALPHAPIXELS) ? GetColorChannel(colorKey, fmt->dwRGBAlphaBitMask)
-                                                     : DDCOLORKEY{255,255};
+                                                     : DefaultAlphaColorKey;
 
     rgbColorKey.dwColorSpaceLowValue  = b.dwColorSpaceLowValue |
                                        (g.dwColorSpaceLowValue << 8) |

--- a/src/ddraw/ddraw_main.cpp
+++ b/src/ddraw/ddraw_main.cpp
@@ -22,7 +22,7 @@ namespace dxvk {
       if (hDDraw == nullptr) {
         // Determine the system directory path
         char loadPath[MAX_PATH] = { };
-        UINT returnLength = ::GetSystemDirectoryA(loadPath, MAX_PATH);
+        const uint32_t returnLength = ::GetSystemDirectoryA(loadPath, MAX_PATH);
         if (unlikely(!returnLength))
           return nullptr;
 
@@ -44,7 +44,7 @@ namespace dxvk {
             return nullptr;
 
           void* pvData = nullptr;
-          UINT iLenData = 0u;
+          uint32_t iLenData = 0u;
           // DXVK/D7VK will use the English UK encoding, so simply skip
           // the check if nothing is returned (pvData will be nullptr)
           ::VerQueryValueA(versionInfo.data(), "\\StringFileInfo\\080904B0\\ProductName", &pvData, &iLenData);

--- a/src/ddraw/ddraw_palette.h
+++ b/src/ddraw/ddraw_palette.h
@@ -33,7 +33,7 @@ namespace dxvk {
 
   private:
 
-    DDrawCommonSurface* m_commonSurf   = nullptr;
+    DDrawCommonSurface* m_commonSurf = nullptr;
 
   };
 

--- a/src/ddraw/ddraw_util.h
+++ b/src/ddraw/ddraw_util.h
@@ -12,14 +12,107 @@
 namespace dxvk {
 
   struct PackedVertexBuffer {
-    UINT stride;
+    size_t stride;
     std::vector<uint8_t> vertexData;
   };
 
-  struct VertexStreamInfo {
-    D3DPRIMITIVETYPE d3dpt;
-    D3DVERTEXTYPE d3dvt;
-    DWORD dwFlags = 0;
+  struct VertexStream {
+  private:
+    bool          initialized = false;
+    D3DVERTEXTYPE cvt         = D3DVERTEXTYPE(0);
+
+  public:
+    D3DPRIMITIVETYPE d3dpt   = D3DPRIMITIVETYPE(0);
+    D3DVERTEXTYPE    d3dvt   = D3DVERTEXTYPE(0);
+    DWORD            dwFlags = 0;
+
+    union {
+      std::vector<D3DVERTEX>* vertex;
+      std::vector<D3DLVERTEX>* lvertex;
+      std::vector<D3DTLVERTEX>* tlvertex;
+    } stream = { nullptr };
+
+    VertexStream() = default;
+    // Don't allow copies, since they aren't handled
+    VertexStream(const VertexStream&) = delete;
+    VertexStream& operator=(const VertexStream&) = delete;
+
+    bool isInitialized() const {
+      return initialized;
+    }
+
+    void initialize() {
+      if (likely(cvt != D3DVERTEXTYPE(0))) {
+        if (likely(cvt == d3dvt)) {
+          switch (cvt) {
+            case D3DVT_VERTEX:
+              stream.vertex->clear();
+              break;
+            case D3DVT_LVERTEX:
+              stream.lvertex->clear();
+              break;
+            case D3DVT_TLVERTEX:
+              stream.tlvertex->clear();
+              break;
+            default:
+              break;
+          }
+
+          initialized = true;
+
+          return;
+        }
+
+        release();
+      }
+
+      switch (d3dvt) {
+        default:
+        case D3DVT_VERTEX:
+          stream.vertex = new std::vector<D3DVERTEX>();
+          cvt = D3DVT_VERTEX;
+          break;
+        case D3DVT_LVERTEX:
+          stream.lvertex = new std::vector<D3DLVERTEX>();
+          cvt = D3DVT_LVERTEX;
+          break;
+        case D3DVT_TLVERTEX:
+          stream.tlvertex = new std::vector<D3DTLVERTEX>();
+          cvt = D3DVT_TLVERTEX;
+          break;
+      }
+
+      initialized = true;
+    }
+
+    void reset() {
+      d3dpt   = D3DPRIMITIVETYPE(0);
+      d3dvt   = D3DVERTEXTYPE(0);
+      dwFlags = 0;
+
+      initialized = false;
+    }
+
+    void release() {
+      switch (cvt) {
+        case D3DVT_VERTEX:
+          delete stream.vertex;
+          break;
+        case D3DVT_LVERTEX:
+          delete stream.lvertex;
+          break;
+        case D3DVT_TLVERTEX:
+          delete stream.tlvertex;
+          break;
+        default:
+          break;
+      }
+      cvt = D3DVERTEXTYPE(0);
+    }
+
+    ~VertexStream() {
+      release();
+    }
   };
 
   inline bool IsValidDDrawCapsSize(DWORD size) {
@@ -85,14 +178,14 @@ namespace dxvk {
     }
   }
 
-  inline DWORD ConvertD3D6LockFlags(DWORD lockFlags, bool isSurface) {
+  inline DWORD ConvertD3DLockFlags(DWORD lockFlags, bool legacyDiscard, bool useExtendedFlags) {
     DWORD lockFlagsD3D9 = 0;
 
-    // DDLOCK_WAIT is default for DDraw surfaces, so ignore it
-    // and only factor in DDLOCK_DONOTWAIT. Buffers locks have
-    // a flipped logic compared to D3D9.
-    if ((!isSurface && !(lockFlags & DDLOCK_WAIT))
-     || (isSurface  &&  (lockFlags & DDLOCK_DONOTWAIT))) {
+    // Note: D3DLOCK_DONOTWAIT is ignored on D3D9 DYNAMIC buffers,
+    // and we mark nearly all buffers as DYNAMIC, but convert it anyway,
+    // for MANAGED buffers. Keep in mind the vertex buffer lock flag
+    // logic is flipped vs DDraw surfaces, which implicitly wait on locks.
+    if (!(lockFlags & DDLOCK_WAIT)) {
       lockFlagsD3D9 |= (DWORD)D3DLOCK_DONOTWAIT;
     }
     if (lockFlags & DDLOCK_NOSYSLOCK) {
@@ -102,74 +195,36 @@ namespace dxvk {
     if ((lockFlags & DDLOCK_READONLY) && !(lockFlags & DDLOCK_WRITEONLY)) {
       lockFlagsD3D9 |= (DWORD)D3DLOCK_READONLY;
     }
-
-    return lockFlagsD3D9;
-  }
-
-  inline DWORD ConvertD3D7LockFlags(DWORD lockFlags, bool legacyDiscard, bool isSurface) {
-    DWORD lockFlagsD3D9 = 0;
-
-    // DDLOCK_WAIT is default for DDraw7 surfaces, so ignore it
-    // and only factor in DDLOCK_DONOTWAIT. Buffers locks have
-    // a flipped logic compared to D3D9.
-    if ((!isSurface && !(lockFlags & DDLOCK_WAIT))
-     || (isSurface  &&  (lockFlags & DDLOCK_DONOTWAIT))) {
-      lockFlagsD3D9 |= (DWORD)D3DLOCK_DONOTWAIT;
-    }
-    if (lockFlags & DDLOCK_NOSYSLOCK) {
-      lockFlagsD3D9 |= (DWORD)D3DLOCK_NOSYSLOCK;
-    }
-    // Not sure if both can happen at the same time, but play it safe
-    if ((lockFlags & DDLOCK_READONLY) && !(lockFlags & DDLOCK_WRITEONLY)) {
-      lockFlagsD3D9 |= (DWORD)D3DLOCK_READONLY;
-    }
-    // This is called "legacy DISCARD" in D8VK, which apparently
-    // is expected to be enforced implicitly in D3D7. Earlier versions
-    // of D3D do not feature a DISCARD (or NOOVERWRITE) lock flag.
-    if ((lockFlags & DDLOCK_DISCARDCONTENTS) && !legacyDiscard) {
-      lockFlagsD3D9 |= (DWORD)D3DLOCK_DISCARD;
-    }
-    if (lockFlags & DDLOCK_NOOVERWRITE) {
-      lockFlagsD3D9 |= (DWORD)D3DLOCK_NOOVERWRITE;
+    if (useExtendedFlags) {
+      // This is called "legacy DISCARD" in D8VK, which apparently
+      // is expected to be enforced implicitly in D3D7. D3D6 vertex
+      // buffers do not use a DISCARD or NOOVERWRITE lock flag.
+      if ((lockFlags & DDLOCK_DISCARDCONTENTS) && !legacyDiscard) {
+        lockFlagsD3D9 |= (DWORD)D3DLOCK_DISCARD;
+      }
+      if (lockFlags & DDLOCK_NOOVERWRITE) {
+        lockFlagsD3D9 |= (DWORD)D3DLOCK_NOOVERWRITE;
+      }
     }
 
     return lockFlagsD3D9;
   }
 
-  inline DWORD ConvertD3D6UsageFlags(DWORD usageFlags, DWORD creationFlags, d3d9::D3DPOOL pool) {
+  inline DWORD ConvertD3DUsageFlags(DWORD usageFlags, DWORD creationFlags, d3d9::D3DPOOL pool) {
     DWORD usageFlagsD3D9 = 0;
 
     // The D3D6 docs do not mention the presence of a D3DVBCAPS_DONOTCLIP flag,
     // and only the creation flag D3DDP_DONOTCLIP is touted as being usable
-    if ((creationFlags & D3DDP_DONOTCLIP) || (usageFlags & D3DVBCAPS_DONOTCLIP)) {
+    if ((usageFlags & D3DVBCAPS_DONOTCLIP) || (creationFlags & D3DDP_DONOTCLIP)) {
       usageFlagsD3D9 |= (DWORD)D3DUSAGE_DONOTCLIP;
     }
     if (usageFlags & D3DVBCAPS_WRITEONLY) {
       usageFlagsD3D9 |= (DWORD)D3DUSAGE_WRITEONLY;
     }
     if (pool != d3d9::D3DPOOL_MANAGED) {
-      // D3D6 does not use DDLOCK_DISCARDCONTENTS or
-      // DDLOCK_NOOVERWRITE, however, still mark all non-MANAGED
+      // IDirect3DVertexBuffer (D3D6) does not use DDLOCK_DISCARDCONTENTS
+      // or DDLOCK_NOOVERWRITE, however, still mark all non-MANAGED
       // buffers as DYNAMIC to handle any potential CPU read-backs
-      usageFlagsD3D9 |= D3DUSAGE_DYNAMIC;
-    }
-
-    return usageFlagsD3D9;
-  }
-
-  inline DWORD ConvertD3D7UsageFlags(DWORD usageFlags, d3d9::D3DPOOL pool) {
-    DWORD usageFlagsD3D9 = 0;
-
-    if (usageFlags & D3DVBCAPS_DONOTCLIP) {
-      usageFlagsD3D9 |= (DWORD)D3DUSAGE_DONOTCLIP;
-    }
-    if (usageFlags & D3DVBCAPS_WRITEONLY) {
-      usageFlagsD3D9 |= (DWORD)D3DUSAGE_WRITEONLY;
-    }
-    if (pool != d3d9::D3DPOOL_MANAGED) {
-      // Though D3D7 does not specify it, all non-MANAGED buffers
-      // need to be DYNAMIC, either due to some lock flags not
-      // working properly otherwise, or for performance reasons
       usageFlagsD3D9 |= D3DUSAGE_DYNAMIC;
     }
 
@@ -257,15 +312,15 @@ namespace dxvk {
     return size;
   }
 
-  inline UINT GetPrimitiveCount(D3DPRIMITIVETYPE PrimitiveType, DWORD VertexCount) {
+  inline uint32_t GetPrimitiveCount(D3DPRIMITIVETYPE PrimitiveType, DWORD VertexCount) {
     switch (PrimitiveType) {
-      case D3DPT_POINTLIST:     return static_cast<UINT>(VertexCount);
-      case D3DPT_LINELIST:      return static_cast<UINT>(VertexCount / 2);
-      case D3DPT_LINESTRIP:     return static_cast<UINT>(VertexCount - 1);
+      case D3DPT_POINTLIST:     return static_cast<uint32_t>(VertexCount);
+      case D3DPT_LINELIST:      return static_cast<uint32_t>(VertexCount / 2);
+      case D3DPT_LINESTRIP:     return static_cast<uint32_t>(VertexCount - 1);
       default:
-      case D3DPT_TRIANGLELIST:  return static_cast<UINT>(VertexCount / 3);
-      case D3DPT_TRIANGLESTRIP: return static_cast<UINT>(VertexCount - 2);
-      case D3DPT_TRIANGLEFAN:   return static_cast<UINT>(VertexCount - 2);
+      case D3DPT_TRIANGLELIST:  return static_cast<uint32_t>(VertexCount / 3);
+      case D3DPT_TRIANGLESTRIP: return static_cast<uint32_t>(VertexCount - 2);
+      case D3DPT_TRIANGLEFAN:   return static_cast<uint32_t>(VertexCount - 2);
     }
   }
 
@@ -693,7 +748,7 @@ namespace dxvk {
                               | D3DPMISCCAPS_MASKZ;
 
     prim.dwRasterCaps         = D3DPRASTERCAPS_ANISOTROPY
-                              | D3DPRASTERCAPS_ANTIALIASEDGES // Technically not implemented in D3D9
+                           // | D3DPRASTERCAPS_ANTIALIASEDGES // Not implemented in D3D9
                            // | D3DPRASTERCAPS_ANTIALIASSORTDEPENDENT
                            // | D3DPRASTERCAPS_ANTIALIASSORTINDEPENDENT
                               | D3DPRASTERCAPS_DITHER
@@ -904,7 +959,7 @@ namespace dxvk {
                               | D3DPMISCCAPS_MASKZ;
 
     prim.dwRasterCaps         = D3DPRASTERCAPS_ANISOTROPY
-                              | D3DPRASTERCAPS_ANTIALIASEDGES // Technically not implemented in D3D9
+                           // | D3DPRASTERCAPS_ANTIALIASEDGES // Not implemented in D3D9
                            // | D3DPRASTERCAPS_ANTIALIASSORTDEPENDENT
                            // | D3DPRASTERCAPS_ANTIALIASSORTINDEPENDENT
                               | D3DPRASTERCAPS_DITHER
@@ -1145,7 +1200,7 @@ namespace dxvk {
                               | D3DPMISCCAPS_MASKZ;
 
     prim.dwRasterCaps         = D3DPRASTERCAPS_ANISOTROPY
-                              | D3DPRASTERCAPS_ANTIALIASEDGES // Technically not implemented in D3D9
+                           // | D3DPRASTERCAPS_ANTIALIASEDGES // Not implemented in D3D9
                            // | D3DPRASTERCAPS_ANTIALIASSORTDEPENDENT
                            // | D3DPRASTERCAPS_ANTIALIASSORTINDEPENDENT
                               | D3DPRASTERCAPS_DITHER

--- a/src/ddraw/meson.build
+++ b/src/ddraw/meson.build
@@ -18,6 +18,7 @@ ddraw_src = [
   'ddraw4/ddraw4_surface.cpp',
   'ddraw7/ddraw7_interface.cpp',
   'ddraw7/ddraw7_surface.cpp',
+  'd3d_common_buffer.cpp',
   'd3d_common_device.cpp',
   'd3d_common_interface.cpp',
   'd3d_common_material.cpp',

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1805,9 +1805,11 @@ namespace dxvk {
     { R"(\\(KISS.*|Psycho.*)\\client\.exe$)", {{
       { "d3d9.maxFrameRate",                 "-60" },
     }} },
-    /* Enemy Engaged: Apache vs Havoc             */
+    /* Enemy Engaged: Apache vs Havoc             *
+     * Works around slow buffer access patterns   */
     { R"(\\aphavoc\.exe$)", {{
       { "ddraw.forceLegacyPresent",         "True" },
+      { "ddraw.forceSWVP",                  "True" },
     }} },
     /* Star Trek: Starfleet Command               *
      * Works around in-game flickering            */
@@ -1962,6 +1964,12 @@ namespace dxvk {
     { R"(\\CRIMSON\.(EXE|ICD)$)", {{
       { "ddraw.forceLegacyPresent",         "True" },
     }} },
+    /* F/A-18E Super Hornet - Works around        *
+     * main menu flickers on return from gameplay */
+    { R"(\\F18\.exe$)", {{
+      { "ddraw.forceLegacyPresent",         "True" },
+      { "ddraw.emulateFrontBuffer",         "True" },
+    }} },
 
     /**********************************************/
     /* D3D5 GAMES                                 */
@@ -2054,6 +2062,13 @@ namespace dxvk {
     { R"(\\(ClaireU|LeonU)\.exe$)", {{
       { "ddraw.forceLegacyPresent",         "True" },
       { "ddraw.alternatePixelCenter",       "True" },
+    }} },
+    /* Frogger: He's Back!                        *
+     * Typically capped to 25 FPS, however it     *
+     * runs without a frame limit and exhibits    *
+     * accelerated animations on some menus       */
+    { R"(\\frogger\.exe$)", {{
+      { "d3d9.maxFrameRate",                 "-25" },
     }} },
 
     /**********************************************/


### PR DESCRIPTION
This PR backports the D7VK v2.2 release onto DXVK-Sarek and enables per-texture-stage color key transparency support, so that @CkNoSFeRaTU can finally sleep well at night :wink:.